### PR TITLE
feat(auth): profile fields + LINE link flow (PR-B of Phase 1-5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,19 @@
 DATABASE_URL=postgresql://kagetra:kagetra_dev@localhost:5433/kagetra
 FRONTEND_URL=http://localhost:3000
+
+# Auth.js — sign JWT + cookie names
+# Generate with: openssl rand -base64 32
+AUTH_SECRET=
+
+# LINE Login (Phase 1-5 PR-B): raw OAuth2 for lineUserId linking.
+# Create a "LINE Login" channel in https://developers.line.biz/console/
+# and register the callback URL below in the channel's Callback URL field.
+# Do NOT commit real values; LINE access_token is never persisted.
+LINE_LOGIN_CHANNEL_ID=
+LINE_LOGIN_CHANNEL_SECRET=
+LINE_LOGIN_CALLBACK_URL=http://localhost:3000/api/line-link/callback
+
+# Testing switch (Vitest / Playwright only). When 'true' AND NODE_ENV !== 'production',
+# the callback handler skips real HTTP calls to LINE and returns a deterministic
+# profile. Keep this UNSET in production.
+# LINE_OAUTH_TEST_MODE=true

--- a/apps/web/e2e/line-link-flow.spec.ts
+++ b/apps/web/e2e/line-link-flow.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test } from '@playwright/test'
+import bcrypt from 'bcrypt'
+import { eq } from 'drizzle-orm'
+import { users } from '@kagetra/shared/schema'
+import { testDb, truncateAll } from '../src/test-utils/db'
+import { createUser } from '../src/test-utils/seed'
+
+/**
+ * LINE-link E2E.
+ *
+ * The LINE authorize endpoint is intercepted with `page.route` so we never
+ * hit access.line.me. The callback handler itself honors
+ * LINE_OAUTH_TEST_MODE=true (set in playwright.config.ts) and returns a
+ * deterministic profile, so we can simulate a real OAuth round-trip without
+ * any outbound HTTPS.
+ */
+test.describe('LINE link required after password change', () => {
+  test.beforeEach(async () => {
+    await truncateAll()
+  })
+
+  test('パス変更後 lineUserId=NULL → /settings/line-link にリダイレクトされ、連携すると / に到達', async ({
+    page,
+    context,
+  }) => {
+    const passwordHash = await bcrypt.hash('newpassword123', 4)
+    const user = await createUser({
+      name: 'alice',
+      passwordHash,
+      isInvited: true,
+      mustChangePassword: false,
+      role: 'member',
+      grade: 'A',
+      lineUserId: null, // must explicitly override the test seed default
+    })
+
+    // 1. Log in with already-changed password → middleware pushes us to
+    //    /settings/line-link because lineUserId is null.
+    await page.goto('/login')
+    await page.getByLabel('ユーザー名').fill('alice')
+    await page.getByLabel('パスワード', { exact: true }).fill('newpassword123')
+    await page.getByRole('button', { name: /ログイン/ }).click()
+
+    await expect(page).toHaveURL(/\/settings\/line-link/)
+    await expect(page.getByRole('heading', { name: 'LINE 連携' })).toBeVisible()
+
+    // 2. Intercept the LINE authorize URL and redirect back to our callback
+    //    with the same state (cookie → query).
+    await context.route('**access.line.me/**', async (route) => {
+      const url = new URL(route.request().url())
+      const state = url.searchParams.get('state') ?? ''
+      const callbackBase = url.searchParams.get('redirect_uri')
+      if (!callbackBase) {
+        await route.fulfill({ status: 400, body: 'missing redirect_uri' })
+        return
+      }
+      const callbackUrl = new URL(callbackBase)
+      callbackUrl.searchParams.set('code', 'fake-code')
+      callbackUrl.searchParams.set('state', state)
+      await route.fulfill({
+        status: 302,
+        headers: { location: callbackUrl.toString() },
+      })
+    })
+
+    // 3. Click "LINE で連携する" → callback runs in LINE_OAUTH_TEST_MODE,
+    //    persists lineUserId, refreshes JWT, redirects to /.
+    await page.getByRole('button', { name: 'LINE で連携する' }).click()
+
+    // 4. Final: we should land at dashboard root.
+    await expect(page).toHaveURL(/\/(dashboard)?$/, { timeout: 10_000 })
+
+    // 5. DB must now have a non-null lineUserId for this user.
+    const updated = await testDb.query.users.findFirst({
+      where: eq(users.id, user.id),
+    })
+    expect(updated?.lineUserId).toBeTruthy()
+    expect(updated?.lineUserId).toMatch(/^Utest-/)
+  })
+})

--- a/apps/web/src/app/(app)/admin/members/[id]/edit/actions.test.ts
+++ b/apps/web/src/app/(app)/admin/members/[id]/edit/actions.test.ts
@@ -157,6 +157,56 @@ describe('Admin member profile edit actions', () => {
       )
       expect(result.error).toBeDefined()
     })
+
+    it('dan に非整数 (3abc) を入れると入力エラー、DBは変更されない', async () => {
+      const admin = await createAdmin({ name: 'admin-dan-nonint' })
+      const target = await createUser({ name: 'target-dan-nonint', dan: 5 })
+      await setAuthSession({ id: admin.id, role: 'admin' })
+
+      const result = await updateMemberProfile(
+        {},
+        formOf({
+          userId: target.id,
+          grade: '',
+          gender: '',
+          affiliation: '',
+          dan: '3abc',
+          zenNichikyo: '',
+        }),
+      )
+      expect(result.error).toBeDefined()
+
+      // DB は未変更（5 のまま）
+      const unchanged = await testDb.query.users.findFirst({
+        where: eq(users.id, target.id),
+      })
+      expect(unchanged?.dan).toBe(5)
+    })
+
+    it('未知の grade (Z) は silent null にせず入力エラーとして拒否する', async () => {
+      const admin = await createAdmin({ name: 'admin-grade-unk' })
+      const target = await createUser({ name: 'target-grade-unk', grade: 'A' })
+      await setAuthSession({ id: admin.id, role: 'admin' })
+
+      const result = await updateMemberProfile(
+        {},
+        formOf({
+          userId: target.id,
+          grade: 'Z',
+          gender: '',
+          affiliation: '',
+          dan: '',
+          zenNichikyo: '',
+        }),
+      )
+      expect(result.error).toBeDefined()
+
+      // DB は未変更（A のまま）。旧実装は silent に null を入れていた。
+      const unchanged = await testDb.query.users.findFirst({
+        where: eq(users.id, target.id),
+      })
+      expect(unchanged?.grade).toBe('A')
+    })
   })
 
   describe('toggleMemberDeactivation', () => {

--- a/apps/web/src/app/(app)/admin/members/[id]/edit/actions.test.ts
+++ b/apps/web/src/app/(app)/admin/members/[id]/edit/actions.test.ts
@@ -1,0 +1,210 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { users } from '@kagetra/shared/schema'
+import { closeTestDb, testDb, truncateAll } from '@/test-utils/db'
+import { createAdmin, createUser } from '@/test-utils/seed'
+import { mockAuthModule, setAuthSession } from '@/test-utils/auth-mock'
+
+vi.mock('@/auth', () => mockAuthModule())
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+vi.mock('next/navigation', () => ({ redirect: vi.fn() }))
+
+const { updateMemberProfile, toggleMemberDeactivation } = await import('./actions')
+
+function formOf(data: Record<string, string>) {
+  const fd = new FormData()
+  for (const [k, v] of Object.entries(data)) fd.append(k, v)
+  return fd
+}
+
+describe('Admin member profile edit actions', () => {
+  beforeEach(async () => {
+    await truncateAll()
+  })
+  afterAll(async () => {
+    await closeTestDb()
+  })
+
+  describe('updateMemberProfile', () => {
+    it('管理者が gender/affiliation/dan/zenNichikyo/grade を更新できる', async () => {
+      const admin = await createAdmin({ name: 'admin-1' })
+      const target = await createUser({ name: 'target-1', grade: null })
+      await setAuthSession({ id: admin.id, role: 'admin' })
+
+      const result = await updateMemberProfile(
+        {},
+        formOf({
+          userId: target.id,
+          grade: 'B',
+          gender: 'female',
+          affiliation: '社会人',
+          dan: '3',
+          zenNichikyo: 'on',
+        }),
+      )
+      expect(result.error).toBeUndefined()
+      expect(result.success).toBe(true)
+
+      const updated = await testDb.query.users.findFirst({
+        where: eq(users.id, target.id),
+      })
+      expect(updated?.grade).toBe('B')
+      expect(updated?.gender).toBe('female')
+      expect(updated?.affiliation).toBe('社会人')
+      expect(updated?.dan).toBe(3)
+      expect(updated?.zenNichikyo).toBe(true)
+    })
+
+    it('空欄の affiliation は null で保存される', async () => {
+      const admin = await createAdmin({ name: 'admin-2' })
+      const target = await createUser({ name: 'target-2', affiliation: '既存' })
+      await setAuthSession({ id: admin.id, role: 'admin' })
+
+      await updateMemberProfile(
+        {},
+        formOf({
+          userId: target.id,
+          grade: '',
+          gender: '',
+          affiliation: '   ',
+          dan: '',
+          zenNichikyo: '',
+        }),
+      )
+
+      const updated = await testDb.query.users.findFirst({
+        where: eq(users.id, target.id),
+      })
+      expect(updated?.affiliation).toBeNull()
+      expect(updated?.grade).toBeNull()
+      expect(updated?.gender).toBeNull()
+      expect(updated?.dan).toBeNull()
+      expect(updated?.zenNichikyo).toBe(false)
+    })
+
+    it('vice_admin も更新できる', async () => {
+      const viceAdmin = await createUser({ name: 'vice-1', role: 'vice_admin' })
+      const target = await createUser({ name: 'target-3' })
+      await setAuthSession({ id: viceAdmin.id, role: 'vice_admin' })
+
+      const result = await updateMemberProfile(
+        {},
+        formOf({
+          userId: target.id,
+          grade: 'A',
+          gender: 'male',
+          affiliation: '',
+          dan: '5',
+          zenNichikyo: '',
+        }),
+      )
+      expect(result.success).toBe(true)
+    })
+
+    it('一般会員が呼ぶと拒否される (throws Unauthorized)', async () => {
+      const member = await createUser({ name: 'member-1', role: 'member' })
+      const target = await createUser({ name: 'target-4' })
+      await setAuthSession({ id: member.id, role: 'member' })
+
+      await expect(
+        updateMemberProfile(
+          {},
+          formOf({
+            userId: target.id,
+            grade: 'B',
+            gender: '',
+            affiliation: '',
+            dan: '',
+            zenNichikyo: '',
+          }),
+        ),
+      ).rejects.toThrow(/Unauthorized/)
+    })
+
+    it('未認証なら拒否される', async () => {
+      await setAuthSession(null)
+      const target = await createUser({ name: 'target-5' })
+      await expect(
+        updateMemberProfile(
+          {},
+          formOf({
+            userId: target.id,
+            grade: 'B',
+            gender: '',
+            affiliation: '',
+            dan: '',
+            zenNichikyo: '',
+          }),
+        ),
+      ).rejects.toThrow(/Unauthorized/)
+    })
+
+    it('dan が範囲外 (10) なら入力エラー', async () => {
+      const admin = await createAdmin({ name: 'admin-3' })
+      const target = await createUser({ name: 'target-6' })
+      await setAuthSession({ id: admin.id, role: 'admin' })
+
+      const result = await updateMemberProfile(
+        {},
+        formOf({
+          userId: target.id,
+          grade: '',
+          gender: '',
+          affiliation: '',
+          dan: '10',
+          zenNichikyo: '',
+        }),
+      )
+      expect(result.error).toBeDefined()
+    })
+  })
+
+  describe('toggleMemberDeactivation', () => {
+    it('deactivatedAt が NULL のユーザーを退会処理にすると now() がセットされる', async () => {
+      const admin = await createAdmin({ name: 'admin-4' })
+      const target = await createUser({ name: 'target-7', deactivatedAt: null })
+      await setAuthSession({ id: admin.id, role: 'admin' })
+
+      try {
+        await toggleMemberDeactivation(formOf({ userId: target.id }))
+      } catch {
+        // redirect() throws NEXT_REDIRECT in tests; ignore.
+      }
+
+      const updated = await testDb.query.users.findFirst({
+        where: eq(users.id, target.id),
+      })
+      expect(updated?.deactivatedAt).toBeInstanceOf(Date)
+    })
+
+    it('退会処理済みのユーザーで再実行すると取り消される', async () => {
+      const admin = await createAdmin({ name: 'admin-5' })
+      const target = await createUser({
+        name: 'target-8',
+        deactivatedAt: new Date('2026-01-01T00:00:00Z'),
+      })
+      await setAuthSession({ id: admin.id, role: 'admin' })
+
+      try {
+        await toggleMemberDeactivation(formOf({ userId: target.id }))
+      } catch {
+        // ignore redirect
+      }
+
+      const updated = await testDb.query.users.findFirst({
+        where: eq(users.id, target.id),
+      })
+      expect(updated?.deactivatedAt).toBeNull()
+    })
+
+    it('一般会員が呼ぶと拒否される', async () => {
+      const member = await createUser({ name: 'member-2', role: 'member' })
+      const target = await createUser({ name: 'target-9' })
+      await setAuthSession({ id: member.id, role: 'member' })
+
+      await expect(
+        toggleMemberDeactivation(formOf({ userId: target.id })),
+      ).rejects.toThrow(/Unauthorized/)
+    })
+  })
+})

--- a/apps/web/src/app/(app)/admin/members/[id]/edit/actions.ts
+++ b/apps/web/src/app/(app)/admin/members/[id]/edit/actions.ts
@@ -11,38 +11,37 @@ import { users } from '@kagetra/shared/schema'
 const GRADES = ['A', 'B', 'C', 'D', 'E'] as const
 const GENDERS = ['male', 'female'] as const
 
+// Normalize a FormData entry for strict zod validation. Returns:
+//   - null: when the field is missing or empty (→ nullable zod accepts as null)
+//   - the trimmed string: otherwise (zod enum / coerce validates strictness)
+function formEntryOrNull(raw: FormDataEntryValue | null): string | null {
+  if (typeof raw !== 'string') return null
+  const s = raw.trim()
+  return s.length === 0 ? null : s
+}
+
 const updateProfileSchema = z.object({
   userId: z.string().min(1),
+  // Unknown enum values (e.g. 'Z', 'anything') → zod rejects (not silently → null)
   grade: z.enum(GRADES).nullable(),
   gender: z.enum(GENDERS).nullable(),
-  affiliation: z.string().nullable(),
-  dan: z.number().int().min(0).max(9).nullable(),
+  affiliation: z.string().max(255).nullable(),
+  // Strictly integer 0-9. Rejects '3abc', '3.5', negatives, etc.
+  // Preprocess: empty/null → null; otherwise require /^\d+$/ and parse to int.
+  dan: z.preprocess((v) => {
+    if (v === null) return null
+    if (typeof v !== 'string') return v
+    const s = v.trim()
+    if (s.length === 0) return null
+    if (!/^\d+$/.test(s)) return Number.NaN // force zod int() to reject
+    return Number.parseInt(s, 10)
+  }, z.union([z.number().int().min(0).max(9), z.null()])),
   zenNichikyo: z.boolean(),
 })
 
 export type UpdateProfileState = {
   error?: string
   success?: boolean
-}
-
-function parseNullableString(raw: FormDataEntryValue | null): string | null {
-  if (raw === null) return null
-  const s = typeof raw === 'string' ? raw.trim() : ''
-  return s.length === 0 ? null : s
-}
-
-function parseNullableEnum<T extends readonly string[]>(
-  raw: FormDataEntryValue | null,
-  values: T,
-): T[number] | null {
-  if (typeof raw !== 'string' || raw.length === 0) return null
-  return (values as readonly string[]).includes(raw) ? (raw as T[number]) : null
-}
-
-function parseNullableInt(raw: FormDataEntryValue | null): number | null {
-  if (typeof raw !== 'string' || raw.trim().length === 0) return null
-  const n = Number.parseInt(raw, 10)
-  return Number.isFinite(n) ? n : null
 }
 
 async function assertAdminSession() {
@@ -64,10 +63,10 @@ export async function updateMemberProfile(
 
   const parsed = updateProfileSchema.safeParse({
     userId: formData.get('userId'),
-    grade: parseNullableEnum(formData.get('grade'), GRADES),
-    gender: parseNullableEnum(formData.get('gender'), GENDERS),
-    affiliation: parseNullableString(formData.get('affiliation')),
-    dan: parseNullableInt(formData.get('dan')),
+    grade: formEntryOrNull(formData.get('grade')),
+    gender: formEntryOrNull(formData.get('gender')),
+    affiliation: formEntryOrNull(formData.get('affiliation')),
+    dan: formData.get('dan'),
     zenNichikyo: formData.get('zenNichikyo') === 'on',
   })
   if (!parsed.success) {

--- a/apps/web/src/app/(app)/admin/members/[id]/edit/actions.ts
+++ b/apps/web/src/app/(app)/admin/members/[id]/edit/actions.ts
@@ -1,0 +1,124 @@
+'use server'
+
+import { eq } from 'drizzle-orm'
+import { redirect } from 'next/navigation'
+import { revalidatePath } from 'next/cache'
+import { z } from 'zod'
+import { auth } from '@/auth'
+import { db } from '@/lib/db'
+import { users } from '@kagetra/shared/schema'
+
+const GRADES = ['A', 'B', 'C', 'D', 'E'] as const
+const GENDERS = ['male', 'female'] as const
+
+const updateProfileSchema = z.object({
+  userId: z.string().min(1),
+  grade: z.enum(GRADES).nullable(),
+  gender: z.enum(GENDERS).nullable(),
+  affiliation: z.string().nullable(),
+  dan: z.number().int().min(0).max(9).nullable(),
+  zenNichikyo: z.boolean(),
+})
+
+export type UpdateProfileState = {
+  error?: string
+  success?: boolean
+}
+
+function parseNullableString(raw: FormDataEntryValue | null): string | null {
+  if (raw === null) return null
+  const s = typeof raw === 'string' ? raw.trim() : ''
+  return s.length === 0 ? null : s
+}
+
+function parseNullableEnum<T extends readonly string[]>(
+  raw: FormDataEntryValue | null,
+  values: T,
+): T[number] | null {
+  if (typeof raw !== 'string' || raw.length === 0) return null
+  return (values as readonly string[]).includes(raw) ? (raw as T[number]) : null
+}
+
+function parseNullableInt(raw: FormDataEntryValue | null): number | null {
+  if (typeof raw !== 'string' || raw.trim().length === 0) return null
+  const n = Number.parseInt(raw, 10)
+  return Number.isFinite(n) ? n : null
+}
+
+async function assertAdminSession() {
+  const session = await auth()
+  if (
+    !session ||
+    (session.user?.role !== 'admin' && session.user?.role !== 'vice_admin')
+  ) {
+    throw new Error('Unauthorized')
+  }
+  return session
+}
+
+export async function updateMemberProfile(
+  _prev: UpdateProfileState,
+  formData: FormData,
+): Promise<UpdateProfileState> {
+  await assertAdminSession()
+
+  const parsed = updateProfileSchema.safeParse({
+    userId: formData.get('userId'),
+    grade: parseNullableEnum(formData.get('grade'), GRADES),
+    gender: parseNullableEnum(formData.get('gender'), GENDERS),
+    affiliation: parseNullableString(formData.get('affiliation')),
+    dan: parseNullableInt(formData.get('dan')),
+    zenNichikyo: formData.get('zenNichikyo') === 'on',
+  })
+  if (!parsed.success) {
+    return { error: parsed.error.issues[0]?.message ?? '入力が不正です' }
+  }
+  const data = parsed.data
+
+  await db
+    .update(users)
+    .set({
+      grade: data.grade,
+      gender: data.gender,
+      affiliation: data.affiliation,
+      dan: data.dan,
+      zenNichikyo: data.zenNichikyo,
+      updatedAt: new Date(),
+    })
+    .where(eq(users.id, data.userId))
+
+  revalidatePath('/admin/members')
+  revalidatePath(`/admin/members/${data.userId}/edit`)
+  return { success: true }
+}
+
+/**
+ * Toggle deactivation: if deactivated_at is NULL, set it to now(); otherwise
+ * clear it. Admin-only.
+ */
+export async function toggleMemberDeactivation(formData: FormData) {
+  await assertAdminSession()
+
+  const userId = formData.get('userId')
+  if (typeof userId !== 'string' || userId.length === 0) {
+    throw new Error('userId が不正です')
+  }
+
+  const current = await db.query.users.findFirst({
+    where: eq(users.id, userId),
+    columns: { id: true, deactivatedAt: true },
+  })
+  if (!current) {
+    throw new Error('対象会員が見つかりません')
+  }
+
+  const nextValue = current.deactivatedAt == null ? new Date() : null
+  await db
+    .update(users)
+    .set({ deactivatedAt: nextValue, updatedAt: new Date() })
+    .where(eq(users.id, userId))
+
+  revalidatePath('/admin/members')
+  revalidatePath(`/admin/members/${userId}/edit`)
+  redirect(`/admin/members/${userId}/edit`)
+}

--- a/apps/web/src/app/(app)/admin/members/[id]/edit/edit-member-form.tsx
+++ b/apps/web/src/app/(app)/admin/members/[id]/edit/edit-member-form.tsx
@@ -1,0 +1,168 @@
+'use client'
+
+import { useActionState } from 'react'
+import type { Grade, Gender } from '@kagetra/shared/types'
+import { updateMemberProfile, type UpdateProfileState } from './actions'
+
+const initialState: UpdateProfileState = {}
+
+const GENDER_LABEL: Record<Gender, string> = {
+  male: '男',
+  female: '女',
+}
+
+export function EditMemberForm({
+  userId,
+  name,
+  grade,
+  gender,
+  affiliation,
+  dan,
+  zenNichikyo,
+  grades,
+  genders,
+}: {
+  userId: string
+  name: string
+  grade: Grade | null
+  gender: Gender | null
+  affiliation: string
+  dan: number | null
+  zenNichikyo: boolean
+  grades: readonly Grade[]
+  genders: readonly Gender[]
+}) {
+  const [state, formAction, pending] = useActionState(
+    updateMemberProfile,
+    initialState,
+  )
+
+  return (
+    <form action={formAction} className="space-y-4 rounded-lg bg-white p-4 shadow-sm">
+      <input type="hidden" name="userId" value={userId} />
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700">名前</label>
+        <input
+          type="text"
+          value={name}
+          readOnly
+          className="mt-1 w-full rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-500"
+        />
+        <p className="mt-1 text-xs text-gray-500">
+          ユーザー名はログインに使われるため、この画面からは変更できません。
+        </p>
+      </div>
+
+      <div>
+        <label
+          htmlFor="grade"
+          className="block text-sm font-medium text-gray-700"
+        >
+          級
+        </label>
+        <select
+          id="grade"
+          name="grade"
+          defaultValue={grade ?? ''}
+          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+        >
+          <option value="">未設定</option>
+          {grades.map((g) => (
+            <option key={g} value={g}>
+              {g}級
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label
+          htmlFor="gender"
+          className="block text-sm font-medium text-gray-700"
+        >
+          性別
+        </label>
+        <select
+          id="gender"
+          name="gender"
+          defaultValue={gender ?? ''}
+          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+        >
+          <option value="">未設定</option>
+          {genders.map((g) => (
+            <option key={g} value={g}>
+              {GENDER_LABEL[g]}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label
+          htmlFor="affiliation"
+          className="block text-sm font-medium text-gray-700"
+        >
+          所属（学校名 / 社会人 など）
+        </label>
+        <input
+          id="affiliation"
+          name="affiliation"
+          type="text"
+          defaultValue={affiliation}
+          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="dan"
+          className="block text-sm font-medium text-gray-700"
+        >
+          段位（0〜9）
+        </label>
+        <input
+          id="dan"
+          name="dan"
+          type="number"
+          min={0}
+          max={9}
+          defaultValue={dan ?? ''}
+          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <input
+          id="zenNichikyo"
+          name="zenNichikyo"
+          type="checkbox"
+          defaultChecked={zenNichikyo}
+          className="h-4 w-4"
+        />
+        <label htmlFor="zenNichikyo" className="text-sm font-medium text-gray-700">
+          全日協会員
+        </label>
+      </div>
+
+      {state.error && (
+        <p role="alert" className="text-sm text-red-600">
+          {state.error}
+        </p>
+      )}
+      {state.success && (
+        <p role="status" className="text-sm text-green-600">
+          更新しました。
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={pending}
+        className="rounded-md bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand/90 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {pending ? '更新中…' : '保存'}
+      </button>
+    </form>
+  )
+}

--- a/apps/web/src/app/(app)/admin/members/[id]/edit/page.tsx
+++ b/apps/web/src/app/(app)/admin/members/[id]/edit/page.tsx
@@ -1,0 +1,98 @@
+import { auth } from '@/auth'
+import { notFound, redirect } from 'next/navigation'
+import Link from 'next/link'
+import { db } from '@/lib/db'
+import { users } from '@kagetra/shared/schema'
+import { eq } from 'drizzle-orm'
+import type { Grade, Gender } from '@kagetra/shared/types'
+import { EditMemberForm } from './edit-member-form'
+import { toggleMemberDeactivation } from './actions'
+
+const GRADES: readonly Grade[] = ['A', 'B', 'C', 'D', 'E'] as const
+const GENDERS: readonly Gender[] = ['male', 'female'] as const
+
+export default async function EditMemberPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const session = await auth()
+  if (
+    !session ||
+    (session.user?.role !== 'admin' && session.user?.role !== 'vice_admin')
+  ) {
+    redirect('/403')
+  }
+
+  const { id } = await params
+  const member = await db.query.users.findFirst({
+    where: eq(users.id, id),
+    columns: {
+      id: true,
+      name: true,
+      role: true,
+      grade: true,
+      gender: true,
+      affiliation: true,
+      dan: true,
+      zenNichikyo: true,
+      deactivatedAt: true,
+      isInvited: true,
+      lineUserId: true,
+    },
+  })
+  if (!member) notFound()
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          href="/admin/members"
+          className="text-sm text-gray-500 hover:text-gray-700"
+        >
+          ← 会員一覧へ戻る
+        </Link>
+        <h2 className="mt-2 text-xl font-bold">
+          会員編集: {member.name ?? '未設定'}
+        </h2>
+        {member.deactivatedAt && (
+          <p className="mt-1 inline-block rounded bg-gray-200 px-2 py-0.5 text-xs font-medium text-gray-700">
+            退会済み（{member.deactivatedAt.toLocaleDateString('ja-JP')}）
+          </p>
+        )}
+      </div>
+
+      <EditMemberForm
+        userId={member.id}
+        name={member.name ?? ''}
+        grade={member.grade ?? null}
+        gender={member.gender ?? null}
+        affiliation={member.affiliation ?? ''}
+        dan={member.dan ?? null}
+        zenNichikyo={member.zenNichikyo}
+        grades={GRADES}
+        genders={GENDERS}
+      />
+
+      <section className="rounded-lg bg-white p-4 shadow-sm">
+        <h3 className="text-sm font-semibold">退会処理</h3>
+        <p className="mt-1 text-xs text-gray-600">
+          退会処理するとログインできなくなります。取り消しで復帰できます。
+        </p>
+        <form action={toggleMemberDeactivation} className="mt-3">
+          <input type="hidden" name="userId" value={member.id} />
+          <button
+            type="submit"
+            className={
+              member.deactivatedAt
+                ? 'rounded-md bg-green-600 px-4 py-2 text-sm text-white hover:bg-green-700'
+                : 'rounded-md bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700'
+            }
+          >
+            {member.deactivatedAt ? '退会を取り消す' : '退会処理する'}
+          </button>
+        </form>
+      </section>
+    </div>
+  )
+}

--- a/apps/web/src/app/(app)/admin/members/page.tsx
+++ b/apps/web/src/app/(app)/admin/members/page.tsx
@@ -21,10 +21,16 @@ async function updateMemberGrade(formData: FormData) {
   if (typeof userId !== 'string' || userId.length === 0) {
     throw new Error('userId が不正です')
   }
-  const grade: Grade | null =
-    typeof gradeRaw === 'string' && (GRADES as readonly string[]).includes(gradeRaw)
-      ? (gradeRaw as Grade)
-      : null
+  // Match updateMemberProfile: reject unknown grade values rather than
+  // silently coercing to null. Empty string is the explicit "未設定" choice.
+  let grade: Grade | null
+  if (typeof gradeRaw !== 'string' || gradeRaw === '') {
+    grade = null
+  } else if ((GRADES as readonly string[]).includes(gradeRaw)) {
+    grade = gradeRaw as Grade
+  } else {
+    throw new Error('grade が不正です')
+  }
 
   await db
     .update(users)

--- a/apps/web/src/app/(app)/admin/members/page.tsx
+++ b/apps/web/src/app/(app)/admin/members/page.tsx
@@ -1,5 +1,6 @@
 import { auth } from '@/auth'
 import { redirect } from 'next/navigation'
+import Link from 'next/link'
 import { db } from '@/lib/db'
 import { users } from '@kagetra/shared/schema'
 import type { Grade } from '@kagetra/shared/types'
@@ -40,7 +41,15 @@ export default async function MembersPage() {
   }
 
   const memberList = await db.query.users.findMany({
-    columns: { id: true, name: true, role: true, grade: true, isInvited: true, createdAt: true },
+    columns: {
+      id: true,
+      name: true,
+      role: true,
+      grade: true,
+      isInvited: true,
+      createdAt: true,
+      deactivatedAt: true,
+    },
     orderBy: (users, { asc }) => [asc(users.createdAt)],
   })
 
@@ -56,43 +65,65 @@ export default async function MembersPage() {
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500">級</th>
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500">招待状態</th>
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500">登録日</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500">操作</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-200">
-            {memberList.map((member) => (
-              <tr key={member.id}>
-                <td className="whitespace-nowrap px-4 py-3 text-sm">{member.name ?? '未設定'}</td>
-                <td className="whitespace-nowrap px-4 py-3 text-sm">{member.role}</td>
-                <td className="whitespace-nowrap px-4 py-3 text-sm">
-                  <form action={updateMemberGrade} className="flex items-center gap-2">
-                    <input type="hidden" name="userId" value={member.id} />
-                    <select
-                      name="grade"
-                      defaultValue={member.grade ?? ''}
-                      className="rounded-md border border-gray-300 px-2 py-1 text-sm"
-                      aria-label={`${member.name ?? member.id} の級`}
+            {memberList.map((member) => {
+              const deactivated = member.deactivatedAt != null
+              const rowClass = deactivated
+                ? 'text-gray-400'
+                : 'text-gray-900'
+              return (
+                <tr key={member.id} className={rowClass}>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm">
+                    {member.name ?? '未設定'}
+                    {deactivated && (
+                      <span className="ml-2 inline-block rounded bg-gray-200 px-1.5 py-0.5 text-[10px] font-medium text-gray-700">
+                        退会
+                      </span>
+                    )}
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm">{member.role}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm">
+                    <form action={updateMemberGrade} className="flex items-center gap-2">
+                      <input type="hidden" name="userId" value={member.id} />
+                      <select
+                        name="grade"
+                        defaultValue={member.grade ?? ''}
+                        className="rounded-md border border-gray-300 px-2 py-1 text-sm"
+                        aria-label={`${member.name ?? member.id} の級`}
+                      >
+                        <option value="">未設定</option>
+                        {GRADES.map((g) => (
+                          <option key={g} value={g}>{g}級</option>
+                        ))}
+                      </select>
+                      <button
+                        type="submit"
+                        className="rounded-md bg-gray-100 px-3 py-1 text-xs hover:bg-gray-200"
+                      >
+                        保存
+                      </button>
+                    </form>
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm">
+                    {member.isInvited ? '招待済み' : '未招待'}
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm">
+                    {member.createdAt.toLocaleDateString('ja-JP')}
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm">
+                    <Link
+                      href={`/admin/members/${member.id}/edit`}
+                      className="text-brand hover:underline"
                     >
-                      <option value="">未設定</option>
-                      {GRADES.map((g) => (
-                        <option key={g} value={g}>{g}級</option>
-                      ))}
-                    </select>
-                    <button
-                      type="submit"
-                      className="rounded-md bg-gray-100 px-3 py-1 text-xs hover:bg-gray-200"
-                    >
-                      保存
-                    </button>
-                  </form>
-                </td>
-                <td className="whitespace-nowrap px-4 py-3 text-sm">
-                  {member.isInvited ? '招待済み' : '未招待'}
-                </td>
-                <td className="whitespace-nowrap px-4 py-3 text-sm">
-                  {member.createdAt.toLocaleDateString('ja-JP')}
-                </td>
-              </tr>
-            ))}
+                      編集
+                    </Link>
+                  </td>
+                </tr>
+              )
+            })}
           </tbody>
         </table>
       </div>

--- a/apps/web/src/app/api/line-link/callback/route.test.ts
+++ b/apps/web/src/app/api/line-link/callback/route.test.ts
@@ -1,0 +1,148 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { users } from '@kagetra/shared/schema'
+import { closeTestDb, testDb, truncateAll } from '@/test-utils/db'
+import { createUser } from '@/test-utils/seed'
+import { mockAuthModule, setAuthSession } from '@/test-utils/auth-mock'
+
+// We must mock '@/auth' before importing the route, and we also need
+// unstable_update to be a vi.fn so the route's call to it is a no-op.
+vi.mock('@/auth', () => {
+  const mod = mockAuthModule() as unknown as Record<string, unknown>
+  mod.unstable_update = vi.fn().mockResolvedValue(null)
+  return mod
+})
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+// next/headers `cookies()` shim: stateful per-test cookie jar. The route
+// reads `line_link_state` and deletes it; we back it with a Map here.
+const cookieJar = new Map<string, string>()
+vi.mock('next/headers', () => ({
+  cookies: async () => ({
+    get: (name: string) => {
+      const value = cookieJar.get(name)
+      return value ? { name, value } : undefined
+    },
+    set: (name: string, value: string) => {
+      cookieJar.set(name, value)
+    },
+    delete: (name: string) => {
+      cookieJar.delete(name)
+    },
+  }),
+}))
+
+const { GET } = await import('./route')
+const { LINE_STATE_COOKIE } = await import('@/lib/line-oauth')
+
+function makeRequest(search: Record<string, string>) {
+  const url = new URL('http://localhost:3000/api/line-link/callback')
+  for (const [k, v] of Object.entries(search)) {
+    url.searchParams.set(k, v)
+  }
+  // The route only reads `req.url` — a plain Request is enough.
+  return new Request(url.toString()) as unknown as import('next/server').NextRequest
+}
+
+describe('GET /api/line-link/callback', () => {
+  beforeEach(async () => {
+    await truncateAll()
+    cookieJar.clear()
+    process.env.LINE_OAUTH_TEST_MODE = 'true'
+  })
+  afterEach(() => {
+    delete process.env.LINE_OAUTH_TEST_MODE
+    vi.restoreAllMocks()
+  })
+  afterAll(async () => {
+    await closeTestDb()
+  })
+
+  it('正常系: state 一致 + code 有効 → lineUserId 保存 + / へリダイレクト', async () => {
+    const user = await createUser({ name: 'alice', lineUserId: null })
+    await setAuthSession({ id: user.id, role: 'member', lineUserId: null })
+    cookieJar.set(LINE_STATE_COOKIE, 'state-abc')
+
+    const res = await GET(makeRequest({ code: 'code-xyz', state: 'state-abc' }))
+
+    expect(res.status).toBeGreaterThanOrEqual(300)
+    expect(res.status).toBeLessThan(400)
+    const location = res.headers.get('location') ?? ''
+    // Redirects to root (dashboard); may include trailing slash only.
+    expect(location).toMatch(/\/$|\/\?/)
+
+    const updated = await testDb.query.users.findFirst({
+      where: eq(users.id, user.id),
+    })
+    expect(updated?.lineUserId).toMatch(/^Utest-/)
+    // Cookie must be cleared
+    expect(cookieJar.has(LINE_STATE_COOKIE)).toBe(false)
+  })
+
+  it('state 不一致: DB を書き換えず /settings/line-link?error=state_mismatch に戻る', async () => {
+    const user = await createUser({ name: 'bob', lineUserId: null })
+    await setAuthSession({ id: user.id, role: 'member', lineUserId: null })
+    cookieJar.set(LINE_STATE_COOKIE, 'state-abc')
+
+    const res = await GET(
+      makeRequest({ code: 'code-xyz', state: 'different' }),
+    )
+    const location = res.headers.get('location') ?? ''
+    expect(location).toContain('/settings/line-link')
+    expect(location).toContain('error=state_mismatch')
+
+    const unchanged = await testDb.query.users.findFirst({
+      where: eq(users.id, user.id),
+    })
+    expect(unchanged?.lineUserId).toBeNull()
+  })
+
+  it('error パラメータあり: DB を書き換えずエラー画面へ', async () => {
+    const user = await createUser({ name: 'carol', lineUserId: null })
+    await setAuthSession({ id: user.id, role: 'member', lineUserId: null })
+    cookieJar.set(LINE_STATE_COOKIE, 'state-abc')
+
+    const res = await GET(
+      makeRequest({ error: 'access_denied', state: 'state-abc' }),
+    )
+    const location = res.headers.get('location') ?? ''
+    expect(location).toContain('error=denied')
+
+    const unchanged = await testDb.query.users.findFirst({
+      where: eq(users.id, user.id),
+    })
+    expect(unchanged?.lineUserId).toBeNull()
+  })
+
+  it('別会員の lineUserId と衝突: error=conflict を返す', async () => {
+    // Pre-existing user already owns the Utest-xxxx ID that test-mode will produce.
+    const callbackUser = await createUser({ name: 'me', lineUserId: null })
+    const conflictId = `Utest-${callbackUser.id.slice(0, 8)}`
+    await createUser({ name: 'other', lineUserId: conflictId })
+
+    await setAuthSession({ id: callbackUser.id, role: 'member', lineUserId: null })
+    cookieJar.set(LINE_STATE_COOKIE, 'state-abc')
+
+    const res = await GET(
+      makeRequest({ code: 'code-xyz', state: 'state-abc' }),
+    )
+    const location = res.headers.get('location') ?? ''
+    expect(location).toContain('error=conflict')
+
+    const unchanged = await testDb.query.users.findFirst({
+      where: eq(users.id, callbackUser.id),
+    })
+    expect(unchanged?.lineUserId).toBeNull()
+  })
+
+  it('state cookie なし: error=state_mismatch', async () => {
+    const user = await createUser({ name: 'dan', lineUserId: null })
+    await setAuthSession({ id: user.id, role: 'member', lineUserId: null })
+
+    const res = await GET(
+      makeRequest({ code: 'code-xyz', state: 'state-abc' }),
+    )
+    const location = res.headers.get('location') ?? ''
+    expect(location).toContain('error=state_mismatch')
+  })
+})

--- a/apps/web/src/app/api/line-link/callback/route.test.ts
+++ b/apps/web/src/app/api/line-link/callback/route.test.ts
@@ -97,7 +97,7 @@ describe('GET /api/line-link/callback', () => {
     expect(unchanged?.lineUserId).toBeNull()
   })
 
-  it('error パラメータあり: DB を書き換えずエラー画面へ', async () => {
+  it('error パラメータあり: DB を書き換えずエラー画面へ、かつ state cookie が削除される', async () => {
     const user = await createUser({ name: 'carol', lineUserId: null })
     await setAuthSession({ id: user.id, role: 'member', lineUserId: null })
     cookieJar.set(LINE_STATE_COOKIE, 'state-abc')
@@ -112,6 +112,30 @@ describe('GET /api/line-link/callback', () => {
       where: eq(users.id, user.id),
     })
     expect(unchanged?.lineUserId).toBeNull()
+
+    // state cookie must be dropped on every exit path (including error=) —
+    // prevents stale state from lingering for the next attempt.
+    expect(cookieJar.has(LINE_STATE_COOKIE)).toBe(false)
+  })
+
+  it('エラー時のリダイレクト先が req.url と同じ origin になる (NEXTAUTH_URL 非依存)', async () => {
+    const user = await createUser({ name: 'host-check', lineUserId: null })
+    await setAuthSession({ id: user.id, role: 'member', lineUserId: null })
+    cookieJar.set(LINE_STATE_COOKIE, 'state-abc')
+
+    // Override NEXTAUTH_URL to a bogus host; redirect must still use req.url
+    const prev = process.env.NEXTAUTH_URL
+    process.env.NEXTAUTH_URL = 'http://bogus.example.invalid'
+
+    try {
+      const res = await GET(makeRequest({ error: 'access_denied', state: 'state-abc' }))
+      const location = res.headers.get('location') ?? ''
+      expect(location).toContain('http://localhost:3000/settings/line-link')
+      expect(location).not.toContain('bogus.example.invalid')
+    } finally {
+      if (prev === undefined) delete process.env.NEXTAUTH_URL
+      else process.env.NEXTAUTH_URL = prev
+    }
   })
 
   it('別会員の lineUserId と衝突: error=conflict を返す', async () => {

--- a/apps/web/src/app/api/line-link/callback/route.test.ts
+++ b/apps/web/src/app/api/line-link/callback/route.test.ts
@@ -33,7 +33,9 @@ vi.mock('next/headers', () => ({
 }))
 
 const { GET } = await import('./route')
-const { LINE_STATE_COOKIE } = await import('@/lib/line-oauth')
+const { LINE_STATE_COOKIE, buildLineLinkStateCookie } = await import(
+  '@/lib/line-oauth'
+)
 
 function makeRequest(search: Record<string, string>) {
   const url = new URL('http://localhost:3000/api/line-link/callback')
@@ -61,7 +63,7 @@ describe('GET /api/line-link/callback', () => {
   it('正常系: state 一致 + code 有効 → lineUserId 保存 + / へリダイレクト', async () => {
     const user = await createUser({ name: 'alice', lineUserId: null })
     await setAuthSession({ id: user.id, role: 'member', lineUserId: null })
-    cookieJar.set(LINE_STATE_COOKIE, 'state-abc')
+    cookieJar.set(LINE_STATE_COOKIE, buildLineLinkStateCookie('state-abc', user.id))
 
     const res = await GET(makeRequest({ code: 'code-xyz', state: 'state-abc' }))
 
@@ -82,7 +84,7 @@ describe('GET /api/line-link/callback', () => {
   it('state 不一致: DB を書き換えず /settings/line-link?error=state_mismatch に戻る', async () => {
     const user = await createUser({ name: 'bob', lineUserId: null })
     await setAuthSession({ id: user.id, role: 'member', lineUserId: null })
-    cookieJar.set(LINE_STATE_COOKIE, 'state-abc')
+    cookieJar.set(LINE_STATE_COOKIE, buildLineLinkStateCookie('state-abc', user.id))
 
     const res = await GET(
       makeRequest({ code: 'code-xyz', state: 'different' }),
@@ -100,7 +102,7 @@ describe('GET /api/line-link/callback', () => {
   it('error パラメータあり: DB を書き換えずエラー画面へ、かつ state cookie が削除される', async () => {
     const user = await createUser({ name: 'carol', lineUserId: null })
     await setAuthSession({ id: user.id, role: 'member', lineUserId: null })
-    cookieJar.set(LINE_STATE_COOKIE, 'state-abc')
+    cookieJar.set(LINE_STATE_COOKIE, buildLineLinkStateCookie('state-abc', user.id))
 
     const res = await GET(
       makeRequest({ error: 'access_denied', state: 'state-abc' }),
@@ -121,7 +123,7 @@ describe('GET /api/line-link/callback', () => {
   it('エラー時のリダイレクト先が req.url と同じ origin になる (NEXTAUTH_URL 非依存)', async () => {
     const user = await createUser({ name: 'host-check', lineUserId: null })
     await setAuthSession({ id: user.id, role: 'member', lineUserId: null })
-    cookieJar.set(LINE_STATE_COOKIE, 'state-abc')
+    cookieJar.set(LINE_STATE_COOKIE, buildLineLinkStateCookie('state-abc', user.id))
 
     // Override NEXTAUTH_URL to a bogus host; redirect must still use req.url
     const prev = process.env.NEXTAUTH_URL
@@ -145,7 +147,10 @@ describe('GET /api/line-link/callback', () => {
     await createUser({ name: 'other', lineUserId: conflictId })
 
     await setAuthSession({ id: callbackUser.id, role: 'member', lineUserId: null })
-    cookieJar.set(LINE_STATE_COOKIE, 'state-abc')
+    cookieJar.set(
+      LINE_STATE_COOKIE,
+      buildLineLinkStateCookie('state-abc', callbackUser.id),
+    )
 
     const res = await GET(
       makeRequest({ code: 'code-xyz', state: 'state-abc' }),
@@ -168,5 +173,67 @@ describe('GET /api/line-link/callback', () => {
     )
     const location = res.headers.get('location') ?? ''
     expect(location).toContain('error=state_mismatch')
+  })
+
+  it('cookie 署名が壊れている場合: error=state_mismatch, DB 変更なし', async () => {
+    const user = await createUser({ name: 'tamper', lineUserId: null })
+    await setAuthSession({ id: user.id, role: 'member', lineUserId: null })
+    // Truncate the signature so verifyLineLinkStateCookie rejects it.
+    const tampered = buildLineLinkStateCookie('state-abc', user.id).slice(0, -4)
+    cookieJar.set(LINE_STATE_COOKIE, tampered)
+
+    const res = await GET(makeRequest({ code: 'code-xyz', state: 'state-abc' }))
+    const location = res.headers.get('location') ?? ''
+    expect(location).toContain('error=state_mismatch')
+
+    const unchanged = await testDb.query.users.findFirst({
+      where: eq(users.id, user.id),
+    })
+    expect(unchanged?.lineUserId).toBeNull()
+  })
+
+  it('cookie の userId と session の userId が不一致: error=state_mismatch で DB 変更なし', async () => {
+    // alice started the flow; bob is logged in at callback time (tab switch).
+    const alice = await createUser({ name: 'alice-start', lineUserId: null })
+    const bob = await createUser({ name: 'bob-callback', lineUserId: null })
+    await setAuthSession({ id: bob.id, role: 'member', lineUserId: null })
+    cookieJar.set(LINE_STATE_COOKIE, buildLineLinkStateCookie('state-abc', alice.id))
+
+    const res = await GET(makeRequest({ code: 'code-xyz', state: 'state-abc' }))
+    const location = res.headers.get('location') ?? ''
+    expect(location).toContain('error=state_mismatch')
+
+    // Neither alice nor bob should have been linked.
+    const [aliceAfter, bobAfter] = await Promise.all([
+      testDb.query.users.findFirst({ where: eq(users.id, alice.id) }),
+      testDb.query.users.findFirst({ where: eq(users.id, bob.id) }),
+    ])
+    expect(aliceAfter?.lineUserId).toBeNull()
+    expect(bobAfter?.lineUserId).toBeNull()
+  })
+
+  it('unstable_update が throw しても DB は更新され / にリダイレクトされる', async () => {
+    // Regression guard for the Blocker: silent unstable_update failure must
+    // not roll back the DB write. Recovery is handled by nodeJwtCallback
+    // self-healing on the next Node render.
+    const user = await createUser({ name: 'heal-on-next', lineUserId: null })
+    await setAuthSession({ id: user.id, role: 'member', lineUserId: null })
+    cookieJar.set(LINE_STATE_COOKIE, buildLineLinkStateCookie('state-abc', user.id))
+
+    const authMod = (await import('@/auth')) as unknown as {
+      unstable_update: ReturnType<typeof vi.fn>
+    }
+    authMod.unstable_update.mockRejectedValueOnce(new Error('jwt update boom'))
+
+    const res = await GET(makeRequest({ code: 'code-xyz', state: 'state-abc' }))
+    expect(res.status).toBeGreaterThanOrEqual(300)
+    expect(res.status).toBeLessThan(400)
+    const location = res.headers.get('location') ?? ''
+    expect(location).toMatch(/\/$|\/\?/)
+
+    const updated = await testDb.query.users.findFirst({
+      where: eq(users.id, user.id),
+    })
+    expect(updated?.lineUserId).toMatch(/^Utest-/)
   })
 })

--- a/apps/web/src/app/api/line-link/callback/route.ts
+++ b/apps/web/src/app/api/line-link/callback/route.ts
@@ -10,6 +10,7 @@ import {
   fetchLineProfile,
   isLineOAuthTestMode,
   readLineOAuthEnv,
+  verifyLineLinkStateCookie,
   type LineProfile,
 } from '@/lib/line-oauth'
 
@@ -19,7 +20,7 @@ export const dynamic = 'force-dynamic'
  * LINE Login OAuth2 callback handler.
  *
  * Flow:
- * 1. Verify `state` against the cookie we set in the Server Action (CSRF).
+ * 1. Verify the signed `state` cookie (CSRF + initiating userId binding).
  * 2. Exchange `code` for an access_token (HTTP POST to LINE).
  * 3. Fetch profile with the token.
  * 4. Persist `users.lineUserId` (UNIQUE; collision -> error screen).
@@ -34,13 +35,16 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   // Drop the CSRF state cookie on every path (success, error, mismatch).
   // Must happen before early returns so LINE's error redirect also clears it.
   const cookieStore = await cookies()
-  const storedState = cookieStore.get(LINE_STATE_COOKIE)?.value
+  const storedCookie = cookieStore.get(LINE_STATE_COOKIE)?.value
   cookieStore.delete(LINE_STATE_COOKIE)
 
   if (error) {
     return redirectToLinkPage(req, 'denied')
   }
-  if (!state || !storedState || state !== storedState) {
+  const verifiedCookie = storedCookie
+    ? verifyLineLinkStateCookie(storedCookie)
+    : null
+  if (!state || !verifiedCookie || state !== verifiedCookie.state) {
     return redirectToLinkPage(req, 'state_mismatch')
   }
   if (!code) {
@@ -50,6 +54,14 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const session = await auth()
   if (!session?.user?.id) {
     return NextResponse.redirect(new URL('/login', req.url))
+  }
+
+  // The session that started the flow must be the same session that returns
+  // to the callback. A logout/relogin as a different user in another tab
+  // between /start and /callback would otherwise attach LINE to whoever is
+  // authenticated at callback time.
+  if (session.user.id !== verifiedCookie.userId) {
+    return redirectToLinkPage(req, 'state_mismatch')
   }
 
   let profile: LineProfile
@@ -101,9 +113,12 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
     await unstable_update({ user: { lineUserId: profile.userId } })
   } catch {
-    // If the refresh fails, middleware will redirect to the link page once
-    // more (where the DB-backed "linked" state shows and the user can proceed
-    // on their next request).
+    // If the refresh fails, the user would otherwise be trapped: edge
+    // middleware still sees lineUserId=null in the stale JWT and bounces to
+    // /settings/line-link, where the DB says "linked" but the JWT is never
+    // rewritten. `nodeJwtCallback` self-heals the JWT against the DB on the
+    // next Node render, so the next request through the settings page (or
+    // any Server Component) will write a fresh cookie and unblock the user.
   }
 
   return NextResponse.redirect(new URL('/', req.url))

--- a/apps/web/src/app/api/line-link/callback/route.ts
+++ b/apps/web/src/app/api/line-link/callback/route.ts
@@ -1,0 +1,116 @@
+import { cookies } from 'next/headers'
+import { NextResponse, type NextRequest } from 'next/server'
+import { eq } from 'drizzle-orm'
+import { auth, unstable_update } from '@/auth'
+import { db } from '@/lib/db'
+import { users } from '@kagetra/shared/schema'
+import {
+  LINE_STATE_COOKIE,
+  exchangeCodeForAccessToken,
+  fetchLineProfile,
+  isLineOAuthTestMode,
+  readLineOAuthEnv,
+  type LineProfile,
+} from '@/lib/line-oauth'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * LINE Login OAuth2 callback handler.
+ *
+ * Flow:
+ * 1. Verify `state` against the cookie we set in the Server Action (CSRF).
+ * 2. Exchange `code` for an access_token (HTTP POST to LINE).
+ * 3. Fetch profile with the token.
+ * 4. Persist `users.lineUserId` (UNIQUE; collision -> error screen).
+ * 5. Clear the state cookie. Never persist the access_token.
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const url = new URL(req.url)
+  const code = url.searchParams.get('code')
+  const state = url.searchParams.get('state')
+  const error = url.searchParams.get('error')
+
+  if (error) {
+    return redirectToLinkPage('denied')
+  }
+
+  // State verification (CSRF). Always drop the cookie regardless of outcome.
+  const cookieStore = await cookies()
+  const storedState = cookieStore.get(LINE_STATE_COOKIE)?.value
+  cookieStore.delete(LINE_STATE_COOKIE)
+
+  if (!state || !storedState || state !== storedState) {
+    return redirectToLinkPage('state_mismatch')
+  }
+  if (!code) {
+    return redirectToLinkPage('oauth_failed')
+  }
+
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.redirect(new URL('/login', req.url))
+  }
+
+  let profile: LineProfile
+  try {
+    if (isLineOAuthTestMode()) {
+      // Deterministic fixture for Playwright / Vitest integration.
+      profile = {
+        userId: `Utest-${session.user.id.slice(0, 8)}`,
+        displayName: 'Test User',
+      }
+    } else {
+      const env = readLineOAuthEnv()
+      if (!env) return redirectToLinkPage('missing_env')
+      const accessToken = await exchangeCodeForAccessToken(env, code)
+      profile = await fetchLineProfile(accessToken)
+    }
+  } catch {
+    // Intentionally do not log the access_token or profile payload.
+    return redirectToLinkPage('oauth_failed')
+  }
+
+  // Conflict: another account already linked with this lineUserId.
+  const existing = await db.query.users.findFirst({
+    where: eq(users.lineUserId, profile.userId),
+    columns: { id: true },
+  })
+  if (existing && existing.id !== session.user.id) {
+    return redirectToLinkPage('conflict')
+  }
+
+  try {
+    await db
+      .update(users)
+      .set({ lineUserId: profile.userId, updatedAt: new Date() })
+      .where(eq(users.id, session.user.id))
+  } catch {
+    // Catch unique-violation racing with a concurrent link on the other side.
+    return redirectToLinkPage('conflict')
+  }
+
+  // Refresh the JWT so middleware sees the new lineUserId without requiring
+  // a full sign-out/sign-in. `unstable_update` re-runs the jwt() callback
+  // with the `update` trigger; our callback branches on `session.user.lineUserId`.
+  try {
+    await unstable_update({ user: { lineUserId: profile.userId } })
+  } catch {
+    // If the refresh fails, middleware will redirect to the link page once
+    // more (where the DB-backed "linked" state shows and the user can proceed
+    // on their next request).
+  }
+
+  return NextResponse.redirect(new URL('/', req.url))
+}
+
+function redirectToLinkPage(errorCode: string): NextResponse {
+  return NextResponse.redirect(
+    // Absolute base is injected by Next at runtime via request URL; we use a
+    // relative URL here and let NextResponse.redirect resolve it.
+    new URL(
+      `/settings/line-link?error=${encodeURIComponent(errorCode)}`,
+      process.env.NEXTAUTH_URL ?? 'http://localhost:3000',
+    ),
+  )
+}

--- a/apps/web/src/app/api/line-link/callback/route.ts
+++ b/apps/web/src/app/api/line-link/callback/route.ts
@@ -31,20 +31,20 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const state = url.searchParams.get('state')
   const error = url.searchParams.get('error')
 
-  if (error) {
-    return redirectToLinkPage('denied')
-  }
-
-  // State verification (CSRF). Always drop the cookie regardless of outcome.
+  // Drop the CSRF state cookie on every path (success, error, mismatch).
+  // Must happen before early returns so LINE's error redirect also clears it.
   const cookieStore = await cookies()
   const storedState = cookieStore.get(LINE_STATE_COOKIE)?.value
   cookieStore.delete(LINE_STATE_COOKIE)
 
+  if (error) {
+    return redirectToLinkPage(req, 'denied')
+  }
   if (!state || !storedState || state !== storedState) {
-    return redirectToLinkPage('state_mismatch')
+    return redirectToLinkPage(req, 'state_mismatch')
   }
   if (!code) {
-    return redirectToLinkPage('oauth_failed')
+    return redirectToLinkPage(req, 'oauth_failed')
   }
 
   const session = await auth()
@@ -62,13 +62,13 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
       }
     } else {
       const env = readLineOAuthEnv()
-      if (!env) return redirectToLinkPage('missing_env')
+      if (!env) return redirectToLinkPage(req, 'missing_env')
       const accessToken = await exchangeCodeForAccessToken(env, code)
       profile = await fetchLineProfile(accessToken)
     }
   } catch {
     // Intentionally do not log the access_token or profile payload.
-    return redirectToLinkPage('oauth_failed')
+    return redirectToLinkPage(req, 'oauth_failed')
   }
 
   // Conflict: another account already linked with this lineUserId.
@@ -77,7 +77,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     columns: { id: true },
   })
   if (existing && existing.id !== session.user.id) {
-    return redirectToLinkPage('conflict')
+    return redirectToLinkPage(req, 'conflict')
   }
 
   try {
@@ -85,9 +85,14 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
       .update(users)
       .set({ lineUserId: profile.userId, updatedAt: new Date() })
       .where(eq(users.id, session.user.id))
-  } catch {
-    // Catch unique-violation racing with a concurrent link on the other side.
-    return redirectToLinkPage('conflict')
+  } catch (err) {
+    // Only the 23505 unique_violation race is a conflict; other DB errors
+    // (connectivity, timeouts) are operational failures and deserve a
+    // different UX + separate observability category.
+    if (isUniqueViolation(err)) {
+      return redirectToLinkPage(req, 'conflict')
+    }
+    return redirectToLinkPage(req, 'oauth_failed')
   }
 
   // Refresh the JWT so middleware sees the new lineUserId without requiring
@@ -104,13 +109,31 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   return NextResponse.redirect(new URL('/', req.url))
 }
 
-function redirectToLinkPage(errorCode: string): NextResponse {
+function redirectToLinkPage(req: NextRequest, errorCode: string): NextResponse {
+  // Use the request URL as the origin so the redirect stays on the same host
+  // as the caller (works behind reverse proxies without requiring NEXTAUTH_URL).
   return NextResponse.redirect(
-    // Absolute base is injected by Next at runtime via request URL; we use a
-    // relative URL here and let NextResponse.redirect resolve it.
     new URL(
       `/settings/line-link?error=${encodeURIComponent(errorCode)}`,
-      process.env.NEXTAUTH_URL ?? 'http://localhost:3000',
+      req.url,
     ),
   )
+}
+
+function isUniqueViolation(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false
+  // node-postgres exposes the PG error code on the `code` field.
+  // 23505 = unique_violation per PostgreSQL error codes.
+  const code = (err as { code?: unknown }).code
+  if (code === '23505') return true
+  // Drizzle may nest the driver error in `.cause`.
+  const cause = (err as { cause?: unknown }).cause
+  if (
+    typeof cause === 'object' &&
+    cause !== null &&
+    (cause as { code?: unknown }).code === '23505'
+  ) {
+    return true
+  }
+  return false
 }

--- a/apps/web/src/app/login/actions.test.ts
+++ b/apps/web/src/app/login/actions.test.ts
@@ -98,4 +98,30 @@ describe('authorizeCredentials — Credentials provider predicate', () => {
     const result = await authorizeCredentials(null)
     expect(result).toBeNull()
   })
+
+  it('deactivatedAt がセットされたユーザーは null を返す', async () => {
+    await seedWithPassword('alice', 'password123', {
+      isInvited: true,
+      mustChangePassword: false,
+      deactivatedAt: new Date(),
+    })
+    const result = await authorizeCredentials({
+      username: 'alice',
+      password: 'password123',
+    })
+    expect(result).toBeNull()
+  })
+
+  it('認証成功時に lineUserId が結果に含まれる', async () => {
+    await seedWithPassword('alice', 'password123', {
+      isInvited: true,
+      mustChangePassword: false,
+      lineUserId: 'Uabc123',
+    })
+    const result = await authorizeCredentials({
+      username: 'alice',
+      password: 'password123',
+    })
+    expect(result?.lineUserId).toBe('Uabc123')
+  })
 })

--- a/apps/web/src/app/login/actions.ts
+++ b/apps/web/src/app/login/actions.ts
@@ -51,7 +51,13 @@ export async function login(
   // lagging behind the rendered content.
   const user = await db.query.users.findFirst({
     where: eq(users.name, parsed.data.username),
-    columns: { mustChangePassword: true },
+    columns: { mustChangePassword: true, lineUserId: true },
   })
-  redirect(user?.mustChangePassword ? '/change-password' : '/')
+  if (user?.mustChangePassword) {
+    redirect('/change-password')
+  }
+  if (user && !user.lineUserId) {
+    redirect('/settings/line-link')
+  }
+  redirect('/')
 }

--- a/apps/web/src/app/settings/line-link/actions.ts
+++ b/apps/web/src/app/settings/line-link/actions.ts
@@ -7,6 +7,7 @@ import {
   LINE_STATE_COOKIE,
   LINE_STATE_MAX_AGE,
   buildAuthorizeUrl,
+  buildLineLinkStateCookie,
   readLineOAuthEnv,
 } from '@/lib/line-oauth'
 
@@ -15,8 +16,9 @@ import {
  *
  * 1. Require authenticated session (otherwise middleware wouldn't even
  *    serve the page, but we double-check here).
- * 2. Generate a CSRF `state` token, store it in an httpOnly cookie.
- * 3. Redirect to LINE authorize URL.
+ * 2. Generate a CSRF `state` token bound to the initiating userId, store
+ *    the signed pair in an httpOnly cookie.
+ * 3. Redirect to LINE authorize URL (plain state, no userId leaks).
  */
 export async function startLineLink() {
   const session = await auth()
@@ -32,8 +34,9 @@ export async function startLineLink() {
   }
 
   const state = crypto.randomUUID()
+  const signedCookie = buildLineLinkStateCookie(state, session.user.id)
   const cookieStore = await cookies()
-  cookieStore.set(LINE_STATE_COOKIE, state, {
+  cookieStore.set(LINE_STATE_COOKIE, signedCookie, {
     httpOnly: true,
     sameSite: 'lax',
     secure: process.env.NODE_ENV === 'production',

--- a/apps/web/src/app/settings/line-link/actions.ts
+++ b/apps/web/src/app/settings/line-link/actions.ts
@@ -1,0 +1,45 @@
+'use server'
+
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+import { auth } from '@/auth'
+import {
+  LINE_STATE_COOKIE,
+  LINE_STATE_MAX_AGE,
+  buildAuthorizeUrl,
+  readLineOAuthEnv,
+} from '@/lib/line-oauth'
+
+/**
+ * Server Action: initiate LINE Login OAuth2 flow.
+ *
+ * 1. Require authenticated session (otherwise middleware wouldn't even
+ *    serve the page, but we double-check here).
+ * 2. Generate a CSRF `state` token, store it in an httpOnly cookie.
+ * 3. Redirect to LINE authorize URL.
+ */
+export async function startLineLink() {
+  const session = await auth()
+  if (!session?.user?.id) {
+    redirect('/login')
+  }
+
+  const env = readLineOAuthEnv()
+  if (!env) {
+    throw new Error(
+      'LINE Login 環境変数が未設定です (LINE_LOGIN_CHANNEL_ID / SECRET / CALLBACK_URL)',
+    )
+  }
+
+  const state = crypto.randomUUID()
+  const cookieStore = await cookies()
+  cookieStore.set(LINE_STATE_COOKIE, state, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: LINE_STATE_MAX_AGE,
+    path: '/',
+  })
+
+  redirect(buildAuthorizeUrl(env, state))
+}

--- a/apps/web/src/app/settings/line-link/actions.ts
+++ b/apps/web/src/app/settings/line-link/actions.ts
@@ -28,9 +28,10 @@ export async function startLineLink() {
 
   const env = readLineOAuthEnv()
   if (!env) {
-    throw new Error(
-      'LINE Login 環境変数が未設定です (LINE_LOGIN_CHANNEL_ID / SECRET / CALLBACK_URL)',
-    )
+    // The callback route surfaces the same `missing_env` code to the page,
+    // which renders an admin-facing message. Keep the two entry points
+    // symmetric so users never hit a raw 500 from a config gap.
+    redirect('/settings/line-link?error=missing_env')
   }
 
   const state = crypto.randomUUID()

--- a/apps/web/src/app/settings/line-link/page.tsx
+++ b/apps/web/src/app/settings/line-link/page.tsx
@@ -1,0 +1,100 @@
+import { redirect } from 'next/navigation'
+import Link from 'next/link'
+import { auth } from '@/auth'
+import { db } from '@/lib/db'
+import { users } from '@kagetra/shared/schema'
+import { eq } from 'drizzle-orm'
+import { startLineLink } from './actions'
+
+export default async function LineLinkPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ error?: string }>
+}) {
+  const session = await auth()
+  if (!session?.user?.id) {
+    redirect('/login')
+  }
+
+  // Pull latest lineUserId from DB (session token lags behind until refresh).
+  const user = await db.query.users.findFirst({
+    where: eq(users.id, session.user.id),
+    columns: { id: true, name: true, lineUserId: true },
+  })
+  if (!user) redirect('/login')
+
+  const resolvedParams = (await searchParams) ?? {}
+  const errorCode = resolvedParams.error
+  const errorMessage = errorCode ? describeError(errorCode) : null
+
+  const alreadyLinked = user.lineUserId != null
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
+      <div className="w-full max-w-md space-y-6 rounded-lg bg-white p-8 shadow-lg">
+        <div>
+          <h1 className="text-xl font-bold">LINE 連携</h1>
+          <p className="mt-2 text-sm text-gray-600">
+            通知を受け取るには LINE アカウントとの連携が必要です。
+          </p>
+        </div>
+
+        {errorMessage && (
+          <p role="alert" className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+            {errorMessage}
+          </p>
+        )}
+
+        {alreadyLinked ? (
+          <div className="space-y-3">
+            <p className="text-sm text-gray-700">
+              LINE 連携済みです。通知はこのアカウントに届きます。
+            </p>
+            <div className="flex gap-3">
+              <Link
+                href="/"
+                className="rounded-md bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand/90"
+              >
+                ダッシュボードへ
+              </Link>
+              <form action={startLineLink}>
+                <button
+                  type="submit"
+                  className="rounded-md bg-gray-100 px-4 py-2 text-sm text-gray-700 hover:bg-gray-200"
+                >
+                  別の LINE で再連携
+                </button>
+              </form>
+            </div>
+          </div>
+        ) : (
+          <form action={startLineLink}>
+            <button
+              type="submit"
+              className="w-full rounded-md bg-[#06c755] px-4 py-3 text-sm font-semibold text-white hover:bg-[#05a648]"
+            >
+              LINE で連携する
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function describeError(code: string): string {
+  switch (code) {
+    case 'missing_env':
+      return 'LINE Login の設定が未完了です。管理者にお問い合わせください。'
+    case 'state_mismatch':
+      return 'セッションの有効期限が切れました。もう一度お試しください。'
+    case 'denied':
+      return 'LINE 連携がキャンセルされました。'
+    case 'conflict':
+      return 'この LINE アカウントは既に別の会員に連携されています。'
+    case 'oauth_failed':
+      return 'LINE との通信に失敗しました。時間を置いて再度お試しください。'
+    default:
+      return '連携中にエラーが発生しました。'
+  }
+}

--- a/apps/web/src/auth.config.ts
+++ b/apps/web/src/auth.config.ts
@@ -20,7 +20,11 @@ export const authConfig = {
   },
   callbacks: {
     authorized({ auth }) {
-      // Let middleware handle redirects explicitly; always allow here.
+      // Gate pages on "has a session at all" only; per-route access rules
+      // (mustChangePassword, lineUserId link, role checks) are enforced in
+      // middleware.ts, which can redirect to specific destinations. Returning
+      // `true` here would bypass Auth.js's default unauthenticated redirect,
+      // so we still require `auth` to be present.
       return !!auth
     },
     async jwt({ token, user, trigger, session }) {

--- a/apps/web/src/auth.config.ts
+++ b/apps/web/src/auth.config.ts
@@ -30,12 +30,30 @@ export const authConfig = {
         token.mustChangePassword = Boolean(
           (user as { mustChangePassword?: boolean }).mustChangePassword,
         )
+        // lineUserId: null on first login (pre-link), set after LINE OAuth
+        // completes. Middleware uses this to enforce the link step without
+        // hitting the DB on every request.
+        token.lineUserId =
+          (user as { lineUserId?: string | null }).lineUserId ?? null
       }
-      // Allow session.update({ mustChangePassword: false }) post password change.
+      // Allow session.update({ mustChangePassword | lineUserId }) post flow.
+      // Auth.js passes the update payload through as `session`; callers may
+      // pass either a flat `{ ...patch }` or `{ user: { ...patch } }`.
       if (trigger === 'update' && session && typeof session === 'object') {
-        const patch = session as { mustChangePassword?: boolean }
+        type Patch = {
+          mustChangePassword?: boolean
+          lineUserId?: string | null
+        }
+        const s = session as Patch & { user?: Patch }
+        const patch: Patch = s.user ?? s
         if (typeof patch.mustChangePassword === 'boolean') {
           token.mustChangePassword = patch.mustChangePassword
+        }
+        if (
+          typeof patch.lineUserId === 'string' ||
+          patch.lineUserId === null
+        ) {
+          token.lineUserId = patch.lineUserId
         }
       }
       return token
@@ -45,6 +63,8 @@ export const authConfig = {
         session.user.id = (token.id as string) ?? (token.sub as string)
         session.user.role = token.role as 'admin' | 'vice_admin' | 'member'
         session.user.mustChangePassword = Boolean(token.mustChangePassword)
+        session.user.lineUserId =
+          (token.lineUserId as string | null | undefined) ?? null
       }
       return session
     },

--- a/apps/web/src/auth.ts
+++ b/apps/web/src/auth.ts
@@ -1,14 +1,21 @@
 import NextAuth from 'next-auth'
 import Credentials from 'next-auth/providers/credentials'
 import { authorizeCredentials } from '@/lib/credentials-authorize'
+import { nodeJwtCallback } from '@/lib/node-jwt-callback'
 import { authConfig } from './auth.config'
 
 /**
  * Full NextAuth instance for the Node runtime. Layers the Credentials
- * provider on top of the edge-safe `authConfig` (which already contains the
- * jwt/session callbacks). Middleware re-creates a NextAuth instance from
- * `authConfig` alone — no providers needed there.
+ * provider on top of the edge-safe `authConfig` and wraps its jwt callback
+ * with a Node-only DB revalidation step to invalidate deactivated users'
+ * sessions. Middleware re-creates a NextAuth instance from `authConfig`
+ * alone — it stays DB-free and so may allow one request through, but the
+ * next Node render (Server Component / Action) will reject a revoked
+ * session and redirect to /login.
  */
+const baseCallbacks = authConfig.callbacks ?? {}
+const baseJwt = baseCallbacks.jwt
+
 export const { handlers, auth, signIn, signOut, unstable_update } = NextAuth({
   ...authConfig,
   providers: [
@@ -21,4 +28,14 @@ export const { handlers, auth, signIn, signOut, unstable_update } = NextAuth({
       authorize: authorizeCredentials,
     }),
   ],
+  callbacks: {
+    ...baseCallbacks,
+    jwt: async (params) => {
+      if (!baseJwt) return params.token
+      return nodeJwtCallback(
+        params as Parameters<typeof nodeJwtCallback>[0],
+        baseJwt as Parameters<typeof nodeJwtCallback>[1],
+      )
+    },
+  },
 })

--- a/apps/web/src/auth.ts
+++ b/apps/web/src/auth.ts
@@ -9,7 +9,7 @@ import { authConfig } from './auth.config'
  * jwt/session callbacks). Middleware re-creates a NextAuth instance from
  * `authConfig` alone — no providers needed there.
  */
-export const { handlers, auth, signIn, signOut } = NextAuth({
+export const { handlers, auth, signIn, signOut, unstable_update } = NextAuth({
   ...authConfig,
   providers: [
     Credentials({

--- a/apps/web/src/lib/credentials-authorize.ts
+++ b/apps/web/src/lib/credentials-authorize.ts
@@ -14,6 +14,7 @@ export type AuthorizedUser = {
   name: string | null
   role: 'admin' | 'vice_admin' | 'member'
   mustChangePassword: boolean
+  lineUserId: string | null
 }
 
 // Generated once at module load. Comparing any input against this takes the
@@ -48,7 +49,13 @@ export async function authorizeCredentials(
   const hashToCompare = user?.passwordHash ?? (await DUMMY_HASH_PROMISE)
   const passwordOk = await bcrypt.compare(password, hashToCompare)
 
-  if (!user || !user.passwordHash || !user.isInvited || !passwordOk) {
+  if (
+    !user ||
+    !user.passwordHash ||
+    !user.isInvited ||
+    user.deactivatedAt != null ||
+    !passwordOk
+  ) {
     return null
   }
 
@@ -57,5 +64,6 @@ export async function authorizeCredentials(
     name: user.name,
     role: user.role,
     mustChangePassword: user.mustChangePassword,
+    lineUserId: user.lineUserId,
   }
 }

--- a/apps/web/src/lib/line-oauth.ts
+++ b/apps/web/src/lib/line-oauth.ts
@@ -1,0 +1,100 @@
+/**
+ * LINE Login OAuth2 helpers.
+ *
+ * We do NOT use the Auth.js LINE provider because it would create a session;
+ * here we only want to resolve a `lineUserId` and persist it on the existing
+ * user record. Everything is a plain HTTPS POST.
+ *
+ * Docs: https://developers.line.biz/ja/docs/line-login/integrate-line-login/
+ */
+
+export const LINE_AUTHORIZE_URL = 'https://access.line.me/oauth2/v2.1/authorize'
+export const LINE_TOKEN_URL = 'https://api.line.me/oauth2/v2.1/token'
+export const LINE_PROFILE_URL = 'https://api.line.me/v2/profile'
+
+export const LINE_STATE_COOKIE = 'line_link_state'
+export const LINE_STATE_MAX_AGE = 300 // 5 minutes
+
+export type LineProfile = {
+  userId: string
+  displayName: string
+  pictureUrl?: string
+}
+
+export type LineOAuthEnv = {
+  channelId: string
+  channelSecret: string
+  callbackUrl: string
+}
+
+export function readLineOAuthEnv(): LineOAuthEnv | null {
+  const channelId = process.env.LINE_LOGIN_CHANNEL_ID
+  const channelSecret = process.env.LINE_LOGIN_CHANNEL_SECRET
+  const callbackUrl = process.env.LINE_LOGIN_CALLBACK_URL
+  if (!channelId || !channelSecret || !callbackUrl) return null
+  return { channelId, channelSecret, callbackUrl }
+}
+
+/**
+ * Testing switch: when set to 'true' in non-production, the callback route
+ * skips the real HTTP round-trips and returns a deterministic profile. This
+ * is ONLY read in non-production (we double-check via NODE_ENV).
+ */
+export function isLineOAuthTestMode(): boolean {
+  if (process.env.NODE_ENV === 'production') return false
+  return process.env.LINE_OAUTH_TEST_MODE === 'true'
+}
+
+export function buildAuthorizeUrl(
+  env: LineOAuthEnv,
+  state: string,
+): string {
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: env.channelId,
+    redirect_uri: env.callbackUrl,
+    state,
+    scope: 'profile openid',
+  })
+  return `${LINE_AUTHORIZE_URL}?${params.toString()}`
+}
+
+/**
+ * Exchange an authorization code for an access token. We intentionally do
+ * not persist the token — it's used once to fetch the profile then dropped.
+ */
+export async function exchangeCodeForAccessToken(
+  env: LineOAuthEnv,
+  code: string,
+): Promise<string> {
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: env.callbackUrl,
+    client_id: env.channelId,
+    client_secret: env.channelSecret,
+  })
+  const res = await fetch(LINE_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  })
+  if (!res.ok) {
+    throw new Error(`LINE token exchange failed: ${res.status}`)
+  }
+  const json = (await res.json()) as { access_token?: string }
+  if (!json.access_token) {
+    throw new Error('LINE token response missing access_token')
+  }
+  return json.access_token
+}
+
+export async function fetchLineProfile(accessToken: string): Promise<LineProfile> {
+  const res = await fetch(LINE_PROFILE_URL, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  })
+  if (!res.ok) {
+    throw new Error(`LINE profile fetch failed: ${res.status}`)
+  }
+  return (await res.json()) as LineProfile
+}

--- a/apps/web/src/lib/line-oauth.ts
+++ b/apps/web/src/lib/line-oauth.ts
@@ -7,6 +7,7 @@
  *
  * Docs: https://developers.line.biz/ja/docs/line-login/integrate-line-login/
  */
+import { createHmac, timingSafeEqual } from 'node:crypto'
 
 export const LINE_AUTHORIZE_URL = 'https://access.line.me/oauth2/v2.1/authorize'
 export const LINE_TOKEN_URL = 'https://api.line.me/oauth2/v2.1/token'
@@ -97,4 +98,106 @@ export async function fetchLineProfile(accessToken: string): Promise<LineProfile
     throw new Error(`LINE profile fetch failed: ${res.status}`)
   }
   return (await res.json()) as LineProfile
+}
+
+// --- Signed state cookie ------------------------------------------------
+//
+// The OAuth2 `state` alone only defends against CSRF. It does NOT bind the
+// flow to the user who started it, so a logout+relogin as a different user
+// between /start and /callback could attach the linked LINE ID to the wrong
+// account. We bind `userId` into the cookie and HMAC-sign the pair with
+// AUTH_SECRET; the callback re-verifies and rejects on mismatch.
+
+const STATE_COOKIE_SEPARATOR = '.'
+
+function readAuthSecret(): string {
+  const secret = process.env.AUTH_SECRET
+  if (!secret) {
+    // Auth.js v5 refuses to start without AUTH_SECRET, so this should never
+    // fire in a real environment — but surfacing the missing config is safer
+    // than silently producing unverifiable cookies.
+    throw new Error('AUTH_SECRET is not set; LINE link flow cannot sign state cookie')
+  }
+  return secret
+}
+
+function base64UrlEncode(input: string): string {
+  return Buffer.from(input, 'utf8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+}
+
+function base64UrlDecode(input: string): string {
+  const pad = input.length % 4 === 0 ? '' : '='.repeat(4 - (input.length % 4))
+  return Buffer.from(
+    input.replace(/-/g, '+').replace(/_/g, '/') + pad,
+    'base64',
+  ).toString('utf8')
+}
+
+function hmacSign(payload: string, secret: string): string {
+  return createHmac('sha256', secret)
+    .update(payload)
+    .digest('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+}
+
+/**
+ * Build the signed state cookie: `${state}.${userIdB64}.${sig}`.
+ * Callers pass the pure OAuth state via the authorize URL; only the cookie
+ * carries the userId binding.
+ */
+export function buildLineLinkStateCookie(state: string, userId: string): string {
+  const secret = readAuthSecret()
+  const userIdB64 = base64UrlEncode(userId)
+  const payload = `${state}${STATE_COOKIE_SEPARATOR}${userIdB64}`
+  const sig = hmacSign(payload, secret)
+  return `${payload}${STATE_COOKIE_SEPARATOR}${sig}`
+}
+
+export type LineLinkStateCookieContents = {
+  state: string
+  userId: string
+}
+
+/**
+ * Verify signature + structure and return the state/userId pair. Returns
+ * null on any parse or signature failure; callers should treat null as
+ * state_mismatch.
+ */
+export function verifyLineLinkStateCookie(
+  cookieValue: string,
+): LineLinkStateCookieContents | null {
+  const parts = cookieValue.split(STATE_COOKIE_SEPARATOR)
+  if (parts.length !== 3) return null
+  const [state, userIdB64, sig] = parts
+  if (!state || !userIdB64 || !sig) return null
+
+  let secret: string
+  try {
+    secret = readAuthSecret()
+  } catch {
+    return null
+  }
+  const expected = hmacSign(
+    `${state}${STATE_COOKIE_SEPARATOR}${userIdB64}`,
+    secret,
+  )
+  const sigBuf = Buffer.from(sig)
+  const expectedBuf = Buffer.from(expected)
+  if (sigBuf.length !== expectedBuf.length) return null
+  if (!timingSafeEqual(sigBuf, expectedBuf)) return null
+
+  let userId: string
+  try {
+    userId = base64UrlDecode(userIdB64)
+  } catch {
+    return null
+  }
+  if (!userId) return null
+  return { state, userId }
 }

--- a/apps/web/src/lib/line-oauth.ts
+++ b/apps/web/src/lib/line-oauth.ts
@@ -8,6 +8,7 @@
  * Docs: https://developers.line.biz/ja/docs/line-login/integrate-line-login/
  */
 import { createHmac, timingSafeEqual } from 'node:crypto'
+import { z } from 'zod'
 
 export const LINE_AUTHORIZE_URL = 'https://access.line.me/oauth2/v2.1/authorize'
 export const LINE_TOKEN_URL = 'https://api.line.me/oauth2/v2.1/token'
@@ -16,11 +17,16 @@ export const LINE_PROFILE_URL = 'https://api.line.me/v2/profile'
 export const LINE_STATE_COOKIE = 'line_link_state'
 export const LINE_STATE_MAX_AGE = 300 // 5 minutes
 
-export type LineProfile = {
-  userId: string
-  displayName: string
-  pictureUrl?: string
-}
+// `userId` is the only field we persist; empty/missing must hard-fail so a
+// malformed upstream response can't silently overwrite users.lineUserId with
+// an empty string or leave the flow looking successful without a real link.
+const lineProfileSchema = z.object({
+  userId: z.string().min(1),
+  displayName: z.string(),
+  pictureUrl: z.string().optional(),
+})
+
+export type LineProfile = z.infer<typeof lineProfileSchema>
 
 export type LineOAuthEnv = {
   channelId: string
@@ -97,7 +103,11 @@ export async function fetchLineProfile(accessToken: string): Promise<LineProfile
   if (!res.ok) {
     throw new Error(`LINE profile fetch failed: ${res.status}`)
   }
-  return (await res.json()) as LineProfile
+  const parsed = lineProfileSchema.safeParse(await res.json())
+  if (!parsed.success) {
+    throw new Error('LINE profile response failed validation')
+  }
+  return parsed.data
 }
 
 // --- Signed state cookie ------------------------------------------------

--- a/apps/web/src/lib/node-jwt-callback.test.ts
+++ b/apps/web/src/lib/node-jwt-callback.test.ts
@@ -71,4 +71,37 @@ describe('nodeJwtCallback — Node-side DB revalidation', () => {
     )
     expect(result).toBeNull()
   })
+
+  // Self-heal behavior: the LINE-link callback's unstable_update() may fail
+  // silently. Without this, the JWT would be stuck with lineUserId=null and
+  // edge middleware would loop the user back to /settings/line-link. The
+  // Node callback refreshes the field from DB so the next Node render
+  // unblocks the user.
+  it('DB の lineUserId が token と違う場合、token を DB に合わせて更新する', async () => {
+    const user = await createUser({ name: 'heal', lineUserId: 'Ufromdb12345' })
+    const result = await nodeJwtCallback(
+      {
+        token: { id: user.id, sub: user.id, lineUserId: null },
+        user: undefined,
+        trigger: undefined,
+      },
+      passThroughBase,
+    )
+    expect(result).not.toBeNull()
+    expect(result?.lineUserId).toBe('Ufromdb12345')
+  })
+
+  it('DB で lineUserId が null の場合、token の古い値は null に戻す', async () => {
+    const user = await createUser({ name: 'unlink', lineUserId: null })
+    const result = await nodeJwtCallback(
+      {
+        token: { id: user.id, sub: user.id, lineUserId: 'Ustaletoken' },
+        user: undefined,
+        trigger: undefined,
+      },
+      passThroughBase,
+    )
+    expect(result).not.toBeNull()
+    expect(result?.lineUserId).toBeNull()
+  })
 })

--- a/apps/web/src/lib/node-jwt-callback.test.ts
+++ b/apps/web/src/lib/node-jwt-callback.test.ts
@@ -1,0 +1,74 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { closeTestDb, truncateAll } from '@/test-utils/db'
+import { createUser } from '@/test-utils/seed'
+import { nodeJwtCallback } from './node-jwt-callback'
+
+// Minimal stand-in for the edge-safe jwt callback: returns the token as-is.
+// The Node wrapper is what should add the DB revalidation.
+const passThroughBase = vi.fn(async ({ token }: { token: unknown }) => token as never)
+
+describe('nodeJwtCallback — Node-side DB revalidation', () => {
+  beforeEach(async () => {
+    await truncateAll()
+    passThroughBase.mockClear()
+  })
+  afterAll(async () => {
+    await closeTestDb()
+  })
+
+  it('アクティブな会員は token が返る', async () => {
+    const user = await createUser({ name: 'active', deactivatedAt: null })
+    const result = await nodeJwtCallback(
+      { token: { id: user.id, sub: user.id }, user: undefined, trigger: undefined },
+      passThroughBase,
+    )
+    expect(result).not.toBeNull()
+    expect(result?.id).toBe(user.id)
+  })
+
+  it('deactivatedAt セット済みの会員は null を返してセッションを即無効化する', async () => {
+    const user = await createUser({
+      name: 'retired',
+      deactivatedAt: new Date('2026-04-18T00:00:00Z'),
+    })
+    const result = await nodeJwtCallback(
+      { token: { id: user.id, sub: user.id }, user: undefined, trigger: undefined },
+      passThroughBase,
+    )
+    expect(result).toBeNull()
+  })
+
+  it('DB に存在しない id は null を返す', async () => {
+    const result = await nodeJwtCallback(
+      {
+        token: { id: '00000000-0000-0000-0000-000000000000', sub: '00000000-0000-0000-0000-000000000000' },
+        user: undefined,
+        trigger: undefined,
+      },
+      passThroughBase,
+    )
+    expect(result).toBeNull()
+  })
+
+  it('初回サインイン (user 付き) は DB 再検証をスキップして token をそのまま返す', async () => {
+    // No user in DB — but because params.user is set, we skip revalidation.
+    const result = await nodeJwtCallback(
+      {
+        token: { id: '00000000-0000-0000-0000-000000000000' },
+        user: { id: '00000000-0000-0000-0000-000000000000' } as { id: string },
+        trigger: 'signIn',
+      },
+      passThroughBase,
+    )
+    expect(result).not.toBeNull()
+  })
+
+  it('base callback が null を返した場合はそのまま null を返す', async () => {
+    const nullBase = vi.fn(async () => null as unknown as never)
+    const result = await nodeJwtCallback(
+      { token: { id: 'any' }, user: undefined, trigger: undefined },
+      nullBase,
+    )
+    expect(result).toBeNull()
+  })
+})

--- a/apps/web/src/lib/node-jwt-callback.ts
+++ b/apps/web/src/lib/node-jwt-callback.ts
@@ -15,12 +15,19 @@ type BaseJwt = (p: JwtParams) => Promise<JWT | null> | JWT | null
 
 /**
  * Node-only JWT callback that wraps the edge-safe base callback and adds
- * DB revalidation to catch user deactivation.
+ * DB revalidation. Two jobs:
+ *
+ * 1. Catch user deactivation — a revoked account returns null here so the
+ *    next Node render bounces to /login.
+ * 2. Self-heal `lineUserId` — if the LINE-link callback's `unstable_update`
+ *    failed (transient error, concurrent request), the JWT can stay stale
+ *    with `lineUserId=null` even though the DB is linked. Edge middleware
+ *    would then trap the user on /settings/line-link indefinitely. Pulling
+ *    the current `lineUserId` from the same row we're already fetching for
+ *    the deactivation check lets the JWT recover on the next Node render.
  *
  * Edge middleware uses only the base callback (via auth.config.ts) and is
- * kept DB-free. Any Node auth() call (Server Component / Server Action /
- * Route Handler) goes through this wrapper, so a deactivated user's session
- * is invalidated on the next request that reaches Node.
+ * kept DB-free.
  */
 export async function nodeJwtCallback(
   params: JwtParams,
@@ -30,7 +37,8 @@ export async function nodeJwtCallback(
   if (!token) return null
 
   // Skip the DB check on the initial sign-in path (user is set then) —
-  // authorizeCredentials already enforced deactivatedAt there.
+  // authorizeCredentials already enforced deactivatedAt and provided the
+  // authoritative lineUserId.
   if (params.user) return token
 
   const userId = (token.id ?? token.sub) as string | undefined
@@ -38,10 +46,13 @@ export async function nodeJwtCallback(
 
   const dbUser = await db.query.users.findFirst({
     where: eq(users.id, userId),
-    columns: { deactivatedAt: true },
+    columns: { deactivatedAt: true, lineUserId: true },
   })
   if (!dbUser || dbUser.deactivatedAt != null) {
     return null
+  }
+  if (token.lineUserId !== dbUser.lineUserId) {
+    token.lineUserId = dbUser.lineUserId
   }
   return token
 }

--- a/apps/web/src/lib/node-jwt-callback.ts
+++ b/apps/web/src/lib/node-jwt-callback.ts
@@ -1,0 +1,47 @@
+import { eq } from 'drizzle-orm'
+import { db } from '@/lib/db'
+import { users } from '@kagetra/shared/schema'
+import type { JWT } from 'next-auth/jwt'
+import type { User, Session } from 'next-auth'
+
+type JwtParams = {
+  token: JWT
+  user?: User
+  trigger?: 'signIn' | 'signUp' | 'update' | string
+  session?: Session | Record<string, unknown>
+}
+
+type BaseJwt = (p: JwtParams) => Promise<JWT | null> | JWT | null
+
+/**
+ * Node-only JWT callback that wraps the edge-safe base callback and adds
+ * DB revalidation to catch user deactivation.
+ *
+ * Edge middleware uses only the base callback (via auth.config.ts) and is
+ * kept DB-free. Any Node auth() call (Server Component / Server Action /
+ * Route Handler) goes through this wrapper, so a deactivated user's session
+ * is invalidated on the next request that reaches Node.
+ */
+export async function nodeJwtCallback(
+  params: JwtParams,
+  baseCallback: BaseJwt,
+): Promise<JWT | null> {
+  const token = await baseCallback(params)
+  if (!token) return null
+
+  // Skip the DB check on the initial sign-in path (user is set then) —
+  // authorizeCredentials already enforced deactivatedAt there.
+  if (params.user) return token
+
+  const userId = (token.id ?? token.sub) as string | undefined
+  if (!userId) return token
+
+  const dbUser = await db.query.users.findFirst({
+    where: eq(users.id, userId),
+    columns: { deactivatedAt: true },
+  })
+  if (!dbUser || dbUser.deactivatedAt != null) {
+    return null
+  }
+  return token
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -19,6 +19,16 @@ function isPublicPath(pathname: string): boolean {
   )
 }
 
+// LINE-link flow: user is already authenticated but has no lineUserId.
+// These paths must remain reachable so the link can be completed.
+const LINE_LINK_PATHS = ['/settings/line-link', '/api/line-link']
+
+function isLineLinkPath(pathname: string): boolean {
+  return LINE_LINK_PATHS.some(
+    (p) => pathname === p || pathname.startsWith(`${p}/`),
+  )
+}
+
 export default auth((req) => {
   const { nextUrl } = req
   const session = req.auth
@@ -39,6 +49,19 @@ export default auth((req) => {
   ) {
     const url = nextUrl.clone()
     url.pathname = '/change-password'
+    return NextResponse.redirect(url)
+  }
+
+  // Authenticated, password OK, but LINE not yet linked: force /settings/line-link.
+  // JWT-only check (token.lineUserId is set at login and on successful link),
+  // so middleware never touches the DB.
+  if (
+    !session.user?.mustChangePassword &&
+    !session.user?.lineUserId &&
+    !isLineLinkPath(pathname)
+  ) {
+    const url = nextUrl.clone()
+    url.pathname = '/settings/line-link'
     return NextResponse.redirect(url)
   }
 

--- a/apps/web/src/next-auth.d.ts
+++ b/apps/web/src/next-auth.d.ts
@@ -9,6 +9,7 @@ declare module 'next-auth' {
       id: string
       role: 'admin' | 'vice_admin' | 'member'
       mustChangePassword: boolean
+      lineUserId: string | null
       name?: string | null
       email?: string | null
       image?: string | null
@@ -19,6 +20,7 @@ declare module 'next-auth' {
     role?: 'admin' | 'vice_admin' | 'member'
     mustChangePassword?: boolean
     isInvited?: boolean
+    lineUserId?: string | null
   }
 }
 
@@ -27,6 +29,7 @@ declare module 'next-auth/jwt' {
     id?: string
     role?: 'admin' | 'vice_admin' | 'member'
     mustChangePassword?: boolean
+    lineUserId?: string | null
   }
 }
 
@@ -35,6 +38,7 @@ declare module '@auth/core/types' {
     role?: 'admin' | 'vice_admin' | 'member'
     mustChangePassword?: boolean
     isInvited?: boolean
+    lineUserId?: string | null
   }
 }
 
@@ -43,5 +47,6 @@ declare module '@auth/core/adapters' {
     role?: 'admin' | 'vice_admin' | 'member'
     mustChangePassword?: boolean
     isInvited?: boolean
+    lineUserId?: string | null
   }
 }

--- a/apps/web/src/test-utils/auth-mock.ts
+++ b/apps/web/src/test-utils/auth-mock.ts
@@ -9,24 +9,29 @@ export type MockSessionUser = {
   image?: string | null
   role: UserRole
   mustChangePassword?: boolean
+  lineUserId?: string | null
 }
 
 export type MockSession = {
   user: Required<Pick<MockSessionUser, 'id' | 'role'>> &
-    Omit<MockSessionUser, 'id' | 'role'> & { mustChangePassword: boolean }
+    Omit<MockSessionUser, 'id' | 'role'> & {
+      mustChangePassword: boolean
+      lineUserId: string | null
+    }
   expires: string
 }
 
 /**
  * Build a minimal session object compatible with auth() return shape under the
  * JWT strategy. Only fields consumed by Server Actions / layouts (id, role,
- * mustChangePassword) are required.
+ * mustChangePassword, lineUserId) are required.
  */
 export function buildMockSession(user: MockSessionUser): MockSession {
   return {
     user: {
       ...user,
       mustChangePassword: user.mustChangePassword ?? false,
+      lineUserId: user.lineUserId ?? null,
     },
     expires: new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString(),
   }

--- a/apps/web/src/test-utils/playwright-auth.ts
+++ b/apps/web/src/test-utils/playwright-auth.ts
@@ -27,6 +27,7 @@ export type SeededSession = {
 type IssueOptions = {
   role: 'admin' | 'vice_admin' | 'member'
   mustChangePassword?: boolean
+  lineUserId?: string | null
 }
 
 async function issueJwtSession(
@@ -45,6 +46,7 @@ async function issueJwtSession(
       name,
       role: opts.role,
       mustChangePassword: opts.mustChangePassword ?? false,
+      lineUserId: opts.lineUserId ?? null,
       iat: now,
       exp: now + SESSION_MAX_AGE,
       jti: crypto.randomUUID(),
@@ -60,6 +62,7 @@ export async function seedMemberSession(
   return issueJwtSession(user.id, user.name, {
     role: user.role,
     mustChangePassword: user.mustChangePassword ?? false,
+    lineUserId: user.lineUserId ?? null,
   })
 }
 
@@ -70,5 +73,6 @@ export async function seedAdminSession(
   return issueJwtSession(user.id, user.name, {
     role: user.role,
     mustChangePassword: user.mustChangePassword ?? false,
+    lineUserId: user.lineUserId ?? null,
   })
 }

--- a/apps/web/src/test-utils/seed.ts
+++ b/apps/web/src/test-utils/seed.ts
@@ -10,6 +10,10 @@ type NewEventGroup = InferInsertModel<typeof eventGroups>
 /**
  * Create a user. Defaults to a member role with a unique email.
  * All schema fields are nullable/have defaults except id (auto-generated via crypto.randomUUID()).
+ *
+ * `lineUserId` defaults to a unique value so most tests bypass the Phase 1-5
+ * LINE-link middleware redirect. Tests exercising the line-link flow should
+ * override with `lineUserId: null`.
  */
 export async function createUser(overrides: Partial<NewUser> = {}) {
   const uniqueId = crypto.randomUUID()
@@ -21,6 +25,7 @@ export async function createUser(overrides: Partial<NewUser> = {}) {
       role: 'member',
       isInvited: true,
       grade: 'A',
+      lineUserId: `Utest-${uniqueId}`,
       ...overrides,
     })
     .returning()

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -4,3 +4,8 @@
 process.env.DATABASE_URL =
   process.env.TEST_DATABASE_URL ??
   'postgresql://kagetra:kagetra_dev@localhost:5434/kagetra_test'
+
+// LINE link state cookie signing uses AUTH_SECRET. Provide a fixture value
+// so `buildLineLinkStateCookie` / `verifyLineLinkStateCookie` work under
+// Vitest without requiring the developer's local .env to leak in.
+process.env.AUTH_SECRET ??= 'vitest-line-link-state-secret'

--- a/packages/shared/drizzle/0002_furry_vance_astro.sql
+++ b/packages/shared/drizzle/0002_furry_vance_astro.sql
@@ -1,0 +1,6 @@
+CREATE TYPE "public"."gender" AS ENUM('male', 'female');--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "gender" "gender";--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "affiliation" text;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "dan" integer;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "zen_nichikyo" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "deactivated_at" timestamp with time zone;

--- a/packages/shared/drizzle/0003_dan_range_check.sql
+++ b/packages/shared/drizzle/0003_dan_range_check.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD CONSTRAINT "users_dan_range" CHECK ("users"."dan" BETWEEN 0 AND 9 OR "users"."dan" IS NULL);

--- a/packages/shared/drizzle/meta/0002_snapshot.json
+++ b/packages/shared/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,868 @@
+{
+  "id": "5577143f-5de0-4dff-8541-0f0cbb527cd3",
+  "prevId": "32c863ff-76f7-4367-b686-8d2a231a23fd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_user_id": {
+          "name": "line_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "grade": {
+          "name": "grade",
+          "type": "grade",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_invited": {
+          "name": "is_invited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affiliation": {
+          "name": "affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dan": {
+          "name": "dan",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zen_nichikyo": {
+          "name": "zen_nichikyo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_name_unique": {
+          "name": "users_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_line_user_id_unique": {
+          "name": "users_line_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "line_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_groups": {
+      "name": "event_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_groups_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_groups_name_unique": {
+          "name": "event_groups_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "events_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formal_name": {
+          "name": "formal_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official": {
+          "name": "official",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'individual'"
+        },
+        "entry_deadline": {
+          "name": "entry_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_deadline": {
+          "name": "internal_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_group_id": {
+          "name": "event_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligible_grades": {
+          "name": "eligible_grades",
+          "type": "grade[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "events_created_by_users_id_fk": {
+          "name": "events_created_by_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_event_group_id_event_groups_id_fk": {
+          "name": "events_event_group_id_event_groups_id_fk",
+          "tableFrom": "events",
+          "tableTo": "event_groups",
+          "columnsFrom": [
+            "event_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_attendances": {
+      "name": "event_attendances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_attendances_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attend": {
+          "name": "attend",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_attendances_event_id_events_id_fk": {
+          "name": "event_attendances_event_id_events_id_fk",
+          "tableFrom": "event_attendances",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_attendances_user_id_users_id_fk": {
+          "name": "event_attendances_user_id_users_id_fk",
+          "tableFrom": "event_attendances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_attendances_event_id_user_id_unique": {
+          "name": "event_attendances_event_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_items": {
+      "name": "schedule_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "schedule_items_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "schedule_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_items_owner_id_users_id_fk": {
+          "name": "schedule_items_owner_id_users_id_fk",
+          "tableFrom": "schedule_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.event_kind": {
+      "name": "event_kind",
+      "schema": "public",
+      "values": [
+        "individual",
+        "team"
+      ]
+    },
+    "public.event_status": {
+      "name": "event_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "cancelled",
+        "done"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female"
+      ]
+    },
+    "public.grade": {
+      "name": "grade",
+      "schema": "public",
+      "values": [
+        "A",
+        "B",
+        "C",
+        "D",
+        "E"
+      ]
+    },
+    "public.schedule_kind": {
+      "name": "schedule_kind",
+      "schema": "public",
+      "values": [
+        "practice",
+        "meeting",
+        "social",
+        "other"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "vice_admin",
+        "member"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/shared/drizzle/meta/0003_snapshot.json
+++ b/packages/shared/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,873 @@
+{
+  "id": "09ac7471-fc98-4b29-bd34-4957e96b4231",
+  "prevId": "5577143f-5de0-4dff-8541-0f0cbb527cd3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_user_id": {
+          "name": "line_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "grade": {
+          "name": "grade",
+          "type": "grade",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_invited": {
+          "name": "is_invited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affiliation": {
+          "name": "affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dan": {
+          "name": "dan",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zen_nichikyo": {
+          "name": "zen_nichikyo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_name_unique": {
+          "name": "users_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_line_user_id_unique": {
+          "name": "users_line_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "line_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_dan_range": {
+          "name": "users_dan_range",
+          "value": "\"users\".\"dan\" BETWEEN 0 AND 9 OR \"users\".\"dan\" IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_groups": {
+      "name": "event_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_groups_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_groups_name_unique": {
+          "name": "event_groups_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "events_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formal_name": {
+          "name": "formal_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official": {
+          "name": "official",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'individual'"
+        },
+        "entry_deadline": {
+          "name": "entry_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_deadline": {
+          "name": "internal_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_group_id": {
+          "name": "event_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligible_grades": {
+          "name": "eligible_grades",
+          "type": "grade[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "events_created_by_users_id_fk": {
+          "name": "events_created_by_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_event_group_id_event_groups_id_fk": {
+          "name": "events_event_group_id_event_groups_id_fk",
+          "tableFrom": "events",
+          "tableTo": "event_groups",
+          "columnsFrom": [
+            "event_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_attendances": {
+      "name": "event_attendances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_attendances_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attend": {
+          "name": "attend",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_attendances_event_id_events_id_fk": {
+          "name": "event_attendances_event_id_events_id_fk",
+          "tableFrom": "event_attendances",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_attendances_user_id_users_id_fk": {
+          "name": "event_attendances_user_id_users_id_fk",
+          "tableFrom": "event_attendances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_attendances_event_id_user_id_unique": {
+          "name": "event_attendances_event_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_items": {
+      "name": "schedule_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "schedule_items_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "schedule_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_items_owner_id_users_id_fk": {
+          "name": "schedule_items_owner_id_users_id_fk",
+          "tableFrom": "schedule_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.event_kind": {
+      "name": "event_kind",
+      "schema": "public",
+      "values": [
+        "individual",
+        "team"
+      ]
+    },
+    "public.event_status": {
+      "name": "event_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "cancelled",
+        "done"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female"
+      ]
+    },
+    "public.grade": {
+      "name": "grade",
+      "schema": "public",
+      "values": [
+        "A",
+        "B",
+        "C",
+        "D",
+        "E"
+      ]
+    },
+    "public.schedule_kind": {
+      "name": "schedule_kind",
+      "schema": "public",
+      "values": [
+        "practice",
+        "meeting",
+        "social",
+        "other"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "vice_admin",
+        "member"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/shared/drizzle/meta/_journal.json
+++ b/packages/shared/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1776519401832,
       "tag": "0002_furry_vance_astro",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1776696747081,
+      "tag": "0003_dan_range_check",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/drizzle/meta/_journal.json
+++ b/packages/shared/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1776513637134,
       "tag": "0001_nifty_justice",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1776519401832,
+      "tag": "0002_furry_vance_astro",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/schema/auth.ts
+++ b/packages/shared/src/schema/auth.ts
@@ -1,37 +1,47 @@
 import {
   boolean,
+  check,
   integer,
   pgTable,
   primaryKey,
   text,
   timestamp,
 } from 'drizzle-orm/pg-core'
+import { sql } from 'drizzle-orm'
 import type { AdapterAccountType } from '@auth/core/adapters'
 import { userRoleEnum, gradeEnum, genderEnum } from './enums'
 
-export const users = pgTable('users', {
-  id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
-  name: text('name').unique(),
-  email: text('email').unique(),
-  emailVerified: timestamp('email_verified', { mode: 'date' }),
-  image: text('image'),
-  // kagetra extensions
-  lineUserId: text('line_user_id').unique(),
-  role: userRoleEnum('role').notNull().default('member'),
-  grade: gradeEnum('grade'),
-  isInvited: boolean('is_invited').notNull().default(false),
-  invitedAt: timestamp('invited_at', { mode: 'date' }),
-  passwordHash: text('password_hash'),
-  mustChangePassword: boolean('must_change_password').notNull().default(false),
-  // Phase 1-5 PR-B: extended profile fields
-  gender: genderEnum('gender'),
-  affiliation: text('affiliation'),
-  dan: integer('dan'),
-  zenNichikyo: boolean('zen_nichikyo').notNull().default(false),
-  deactivatedAt: timestamp('deactivated_at', { mode: 'date', withTimezone: true }),
-  createdAt: timestamp('created_at', { mode: 'date', withTimezone: true }).notNull().defaultNow(),
-  updatedAt: timestamp('updated_at', { mode: 'date', withTimezone: true }).notNull().defaultNow(),
-})
+export const users = pgTable(
+  'users',
+  {
+    id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
+    name: text('name').unique(),
+    email: text('email').unique(),
+    emailVerified: timestamp('email_verified', { mode: 'date' }),
+    image: text('image'),
+    // kagetra extensions
+    lineUserId: text('line_user_id').unique(),
+    role: userRoleEnum('role').notNull().default('member'),
+    grade: gradeEnum('grade'),
+    isInvited: boolean('is_invited').notNull().default(false),
+    invitedAt: timestamp('invited_at', { mode: 'date' }),
+    passwordHash: text('password_hash'),
+    mustChangePassword: boolean('must_change_password').notNull().default(false),
+    // Phase 1-5 PR-B: extended profile fields
+    gender: genderEnum('gender'),
+    affiliation: text('affiliation'),
+    dan: integer('dan'),
+    zenNichikyo: boolean('zen_nichikyo').notNull().default(false),
+    deactivatedAt: timestamp('deactivated_at', { mode: 'date', withTimezone: true }),
+    createdAt: timestamp('created_at', { mode: 'date', withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { mode: 'date', withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    // dan is 段位 (kyu/dan rank). Valid range is 0–9; enforce at the DB layer
+    // so batch/SQL updates cannot bypass the application-level validation.
+    check('users_dan_range', sql`${table.dan} BETWEEN 0 AND 9 OR ${table.dan} IS NULL`),
+  ],
+)
 
 export const accounts = pgTable(
   'accounts',

--- a/packages/shared/src/schema/auth.ts
+++ b/packages/shared/src/schema/auth.ts
@@ -7,7 +7,7 @@ import {
   timestamp,
 } from 'drizzle-orm/pg-core'
 import type { AdapterAccountType } from '@auth/core/adapters'
-import { userRoleEnum, gradeEnum } from './enums'
+import { userRoleEnum, gradeEnum, genderEnum } from './enums'
 
 export const users = pgTable('users', {
   id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
@@ -23,6 +23,12 @@ export const users = pgTable('users', {
   invitedAt: timestamp('invited_at', { mode: 'date' }),
   passwordHash: text('password_hash'),
   mustChangePassword: boolean('must_change_password').notNull().default(false),
+  // Phase 1-5 PR-B: extended profile fields
+  gender: genderEnum('gender'),
+  affiliation: text('affiliation'),
+  dan: integer('dan'),
+  zenNichikyo: boolean('zen_nichikyo').notNull().default(false),
+  deactivatedAt: timestamp('deactivated_at', { mode: 'date', withTimezone: true }),
   createdAt: timestamp('created_at', { mode: 'date', withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp('updated_at', { mode: 'date', withTimezone: true }).notNull().defaultNow(),
 })

--- a/packages/shared/src/schema/enums.ts
+++ b/packages/shared/src/schema/enums.ts
@@ -3,5 +3,6 @@ import { pgEnum } from 'drizzle-orm/pg-core'
 export const userRoleEnum = pgEnum('user_role', ['admin', 'vice_admin', 'member'])
 export const eventStatusEnum = pgEnum('event_status', ['draft', 'published', 'cancelled', 'done'])
 export const gradeEnum = pgEnum('grade', ['A', 'B', 'C', 'D', 'E'])
+export const genderEnum = pgEnum('gender', ['male', 'female'])
 export const eventKindEnum = pgEnum('event_kind', ['individual', 'team'])
 export const scheduleKindEnum = pgEnum('schedule_kind', ['practice', 'meeting', 'social', 'other'])

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -2,5 +2,6 @@
 export type UserRole = 'admin' | 'vice_admin' | 'member'
 export type EventStatus = 'draft' | 'published' | 'cancelled' | 'done'
 export type Grade = 'A' | 'B' | 'C' | 'D' | 'E'
+export type Gender = 'male' | 'female'
 export type EventKind = 'individual' | 'team'
 export type ScheduleKind = 'practice' | 'meeting' | 'social' | 'other'

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,6 +36,12 @@ export default defineConfig({
       AUTH_SECRET: 'e2e-test-secret-do-not-use-in-production',
       AUTH_TRUST_HOST: 'true',
       NEXTAUTH_URL: E2E_BASE_URL,
+      // Phase 1-5 PR-B: bypass real LINE OAuth in the callback route.
+      // Only honored when NODE_ENV !== 'production' (see lib/line-oauth.ts).
+      LINE_OAUTH_TEST_MODE: 'true',
+      LINE_LOGIN_CHANNEL_ID: 'test-channel-id',
+      LINE_LOGIN_CHANNEL_SECRET: 'test-channel-secret',
+      LINE_LOGIN_CALLBACK_URL: `${E2E_BASE_URL}/api/line-link/callback`,
     },
   },
   projects: [


### PR DESCRIPTION
## Summary

Phase 1-5 データ移行の2本目（PR-B）。会員プロフィールに5カラム追加 + 必須化された LINE OAuth 連携フローを実装。Phase 2 LINE通知基盤の下準備。計画書: [docs/phase-1-5-migration-plan.md](./docs/phase-1-5-migration-plan.md) の Phase 2 セクション。

## What changed

### Schema (additive only, migration `0002_*.sql`)
- `users.gender` (enum 'male'|'female', nullable)
- `users.affiliation` (text, nullable) — 学校名 or "社会人"
- `users.dan` (integer 0-9, nullable) — 段位
- `users.zen_nichikyo` (bool, default false, not null) — 全日協
- `users.deactivated_at` (timestamp tz, nullable) — 退会日時
- `CREATE TYPE gender_enum`

### Auth
- `authorize()` が `deactivated_at != null` を拒否（退会者ログイン不可）
- JWT に `lineUserId` を含め、session/jwt callbacks で伝播
- middleware: パスワード変更完了済み + `lineUserId IS NULL` → `/settings/line-link` へリダイレクト

### Admin UI
- `/admin/members/[id]/edit`: grade/gender/affiliation/dan/zen_nichikyo 編集 + 退会トグル
- `/admin/members`: 退会済みは薄色 + 「退会」バッジ

### LINE OAuth 連携フロー（raw OAuth2、Auth.js 非使用）
- `/settings/line-link`: 連携状態表示 + 開始ボタン
- Server Action `startLineLink`: httpOnly state cookie セット + `access.line.me/oauth2/v2.1/authorize` へリダイレクト
- `/api/line-link/callback`:
  - state 検証
  - code → access_token 交換
  - profile 取得 → `users.lineUserId` UPSERT
  - UNIQUE 衝突（別会員に紐付き済）時は明示エラー
  - `unstable_update` で JWT 更新（再ログイン不要）
- `access_token` はメモリ上のみ、ログ/DB に一切残さない
- `LINE_OAUTH_TEST_MODE` フラグで E2E/unit テスト可能。**production では `NODE_ENV` ガードで絶対に発火しない**

## Tests (all green)
- Vitest: **34/34 PASS**
  - 18 prior (PR-A) + 16 new: 2 login(deactivatedAt + lineUserId), 9 admin edit, 5 LINE callback
- Playwright: **4/4 PASS**
  - 3 prior + 1 new: フル line-link-flow (`page.route` で LINE authorize intercept)
- typecheck / lint: PASS

## Out of scope (PR-C で対応)
- 各テーブルへの `legacyId` 列追加（冪等アップサート用）
- `event_attendances.gradeSnapshot`
- `scripts/migration/` データ移行スクリプト本体

## 環境変数追加 (`.env.example`)
- `LINE_LOGIN_CHANNEL_ID`
- `LINE_LOGIN_CHANNEL_SECRET`
- `LINE_LOGIN_CALLBACK_URL`
- `LINE_OAUTH_TEST_MODE` (非 production のみ有効)

## Test plan
- [x] `pnpm check-types` PASS
- [x] `pnpm lint` PASS
- [x] `pnpm --filter @kagetra/web test` 34/34 PASS
- [x] `pnpm test:e2e` 4/4 PASS
- [ ] LINE Developers で Login channel を作成し、実環境での OAuth フロー手動確認（shipping 前）
- [ ] 管理画面で新フィールドの入力・表示・退会トグルを手動確認
- [ ] Codex レビュー対応

## Follow-ups
- PR-C: データ移行スクリプト
- 退会トグルに確認ダイアログ追加（minor nit）
- dan input に step=1 付与（minor nit）

🤖 Generated with [Claude Code](https://claude.com/claude-code)