### PR TITLE
fix(auth): LINE user ID は account.providerAccountId から取る

### DIFF
--- a/apps/web/src/auth.config.ts
+++ b/apps/web/src/auth.config.ts
@@ -35,11 +35,14 @@ export const authConfig = {
       return !!auth
     },
     async jwt({ token, user, account, trigger, session }) {
-      // First sign-in via LINE: user.id = profile.sub (the stable LINE user ID).
-      // We stash it as token.lineUserId; auth.ts wrapper then resolves it to our
-      // internal users.id on Node side.
-      if (user && account?.provider === 'line') {
-        token.lineUserId = user.id
+      // First sign-in via LINE: account.providerAccountId = profile.sub (the
+      // stable LINE user ID). Under Auth.js v5 with the JWT strategy and no DB
+      // adapter, `user.id` is a random UUID minted per sign-in, so it cannot be
+      // used as the LINE identifier. We stash providerAccountId as
+      // token.lineUserId; auth.ts wrapper then resolves it to our internal
+      // users.id on the Node side.
+      if (user && account?.provider === 'line' && account.providerAccountId) {
+        token.lineUserId = account.providerAccountId
       }
       // session.update({...}) path: account switch completion, admin unlink, etc.
       // Auth.js passes the update payload through as `session`; callers may pass

--- a/apps/web/src/auth.ts
+++ b/apps/web/src/auth.ts
@@ -24,9 +24,9 @@ export const { handlers, auth, signIn, signOut, unstable_update } = NextAuth({
   ...authConfig,
   callbacks: {
     ...baseCallbacks,
-    async signIn({ user, account }) {
+    async signIn({ account }) {
       if (account?.provider !== 'line') return true
-      const lineUserId = user.id
+      const lineUserId = account.providerAccountId
       if (!lineUserId) return false
       const existing = await db.query.users.findFirst({
         where: eq(users.lineUserId, lineUserId),

--- a/apps/web/src/lib/node-jwt-callback.test.ts
+++ b/apps/web/src/lib/node-jwt-callback.test.ts
@@ -5,12 +5,14 @@ import { createUser } from '@/test-utils/seed'
 import { nodeJwtCallback } from './node-jwt-callback'
 
 // Stand-in for the edge-safe jwt callback from auth.config.ts. On first LINE
-// sign-in the real base stashes `user.id` (= profile.sub) into
-// `token.lineUserId`; we replicate that minimal behavior here so the Node
-// wrapper can exercise its resolution step.
-const edgeStyleBase = vi.fn(async ({ token, user, account }: { token: JWT; user?: { id: string }; account?: { provider: string } | null }): Promise<JWT> => {
-  if (user && account?.provider === 'line') {
-    ;(token as Record<string, unknown>).lineUserId = user.id
+// sign-in the real base stashes `account.providerAccountId` (= profile.sub)
+// into `token.lineUserId` — under Auth.js v5 JWT strategy without a DB adapter,
+// `user.id` is a random UUID, so providerAccountId is the stable LINE id. We
+// replicate that minimal behavior here so the Node wrapper can exercise its
+// resolution step.
+const edgeStyleBase = vi.fn(async ({ token, account }: { token: JWT; user?: { id: string }; account?: { provider: string; providerAccountId?: string } | null }): Promise<JWT> => {
+  if (account?.provider === 'line' && account.providerAccountId) {
+    ;(token as Record<string, unknown>).lineUserId = account.providerAccountId
   }
   return token
 })
@@ -35,8 +37,8 @@ describe('nodeJwtCallback — Node-side DB revalidation', () => {
     const result = await nodeJwtCallback(
       {
         token: {} as JWT,
-        user: { id: 'Uabc123' } as { id: string },
-        account: { provider: 'line', providerAccountId: 'p', type: 'oidc' } as unknown as import('next-auth').Account,
+        user: { id: 'uuid-random' } as { id: string },
+        account: { provider: 'line', providerAccountId: 'Uabc123', type: 'oidc' } as unknown as import('next-auth').Account,
         trigger: 'signIn',
       },
       edgeStyleBase as unknown as Parameters<typeof nodeJwtCallback>[1],
@@ -55,8 +57,8 @@ describe('nodeJwtCallback — Node-side DB revalidation', () => {
     const result = await nodeJwtCallback(
       {
         token: {} as JWT,
-        user: { id: 'Uunknown' } as { id: string },
-        account: { provider: 'line', providerAccountId: 'p', type: 'oidc' } as unknown as import('next-auth').Account,
+        user: { id: 'uuid-random' } as { id: string },
+        account: { provider: 'line', providerAccountId: 'Uunknown', type: 'oidc' } as unknown as import('next-auth').Account,
         trigger: 'signIn',
       },
       edgeStyleBase as unknown as Parameters<typeof nodeJwtCallback>[1],
@@ -75,8 +77,8 @@ describe('nodeJwtCallback — Node-side DB revalidation', () => {
     const result = await nodeJwtCallback(
       {
         token: {} as JWT,
-        user: { id: 'Uretired' } as { id: string },
-        account: { provider: 'line', providerAccountId: 'p', type: 'oidc' } as unknown as import('next-auth').Account,
+        user: { id: 'uuid-random' } as { id: string },
+        account: { provider: 'line', providerAccountId: 'Uretired', type: 'oidc' } as unknown as import('next-auth').Account,
         trigger: 'signIn',
       },
       edgeStyleBase as unknown as Parameters<typeof nodeJwtCallback>[1],


### PR DESCRIPTION
## 何を

Auth.js v5 の LINE sign-in コールバック 2 箇所で、LINE ユーザー識別子を `user.id` から `account.providerAccountId` に変更。

- \`apps/web/src/auth.config.ts\` (jwt callback) — \`token.lineUserId\` のソース
- \`apps/web/src/auth.ts\` (signIn callback) — deactivation check の lookup key
- \`apps/web/src/lib/node-jwt-callback.test.ts\` — edge mock と fixture を同方針で更新

## なぜ

Auth.js v5 の JWT strategy（DB adapter なし）では \`user.id\` はサインイン毎に**ランダム UUID として新規採番**される。LINE の安定 \`sub\` は \`account.providerAccountId\` （= \`id_token.sub\`）のみ。

### 観測された症状

実機検証で以下を確認:
- \`id_token.sub\` = \`Ufcb14b319d87d2d44611beca524c138d\`（正しい LINE ID）
- \`account.providerAccountId\` = 同上 ✅
- \`user.id\` = \`fe7cbc03-e2ab-4f82-aa56-9ce8b6341492\`（サインインごとに異なるランダム UUID） ❌

旧実装では毎回異なる UUID が \`token.lineUserId\` に入るため \`users.line_user_id\` との lookup が常に失敗し、ユーザーは毎回 \`/self-identify\` にループしていた。Fix 後は \`/dashboard\` まで正常到達を dev で確認済み。

## 影響

- 既存 session を保持中のユーザーは JWT が古い UUID を持つため、再ログインするまで lookup が失敗したまま。**再ログインで自動修復**
- DB 側の \`users.line_user_id\` 値は変更不要（既に正しい LINE sub 形式のため）
- self-identify や account-switch 経路は \`session.user.lineUserId\` 経由で値を受け取るため、JWT が正しくなれば自動的に正しい値が流れる

## テスト方法

- [x] \`pnpm --filter web test\` — 69/69 PASS（\`node-jwt-callback.test.ts\` 10/10 含む）
- [x] \`pnpm --filter web lint\` — 0 warning
- [x] \`pnpm --filter web check-types\` — PASS
- [x] 手動: dev server 起動 → incognito で LINE login → \`GET /dashboard 200\` 到達確認（旧スタイル UI で）

## スコープ外

- \`/self-identify\` ページや関連 actions は変更不要（session 経由で正しい値が流れる）
- UI-3a (dashboard restyle) は別 PR (\`feat/ui-3a-dashboard-restyle\`、この fix merge 後に rebase 予定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)