### PR TITLE
feat(dashboard): Phase UI-3a — dashboard を primitives で再スタイル

### DIFF
--- a/apps/web/src/app/(app)/dashboard/page.tsx
+++ b/apps/web/src/app/(app)/dashboard/page.tsx
@@ -1,16 +1,35 @@
 import { auth } from '@/auth'
+import { Card, Pill, SectionLabel } from '@/components/ui'
+import { roleLabel } from '@/lib/role-label'
 
 export default async function DashboardPage() {
   const session = await auth()
+  const name = session?.user?.name ?? 'ゲスト'
+  const { label, tone } = roleLabel(session?.user?.role)
 
   return (
-    <div className="space-y-4">
-      <h2 className="text-xl font-bold">ダッシュボード</h2>
-      <div className="rounded-lg bg-white p-6 shadow-sm">
-        <p>ようこそ、{session?.user?.name}さん</p>
-        <p className="mt-2 text-sm text-gray-500">
-          ロール: {session?.user?.role}
-        </p>
+    <div className="flex flex-col gap-4">
+      <h1 className="font-display text-xl font-bold text-ink">
+        ようこそ、{name}さん
+      </h1>
+
+      <div>
+        <SectionLabel>プロフィール</SectionLabel>
+        <Card>
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-ink-meta">権限</span>
+            <Pill tone={tone}>{label}</Pill>
+          </div>
+        </Card>
+      </div>
+
+      <div>
+        <SectionLabel>今後の予定</SectionLabel>
+        <Card>
+          <p className="text-sm text-ink-meta">
+            今後の予定はまもなく表示されます
+          </p>
+        </Card>
       </div>
     </div>
   )

--- a/apps/web/src/components/layout/app-bar-main.tsx
+++ b/apps/web/src/components/layout/app-bar-main.tsx
@@ -22,7 +22,7 @@ export interface AppBarMainProps {
 export function AppBarMain({ user, signOutAction }: AppBarMainProps) {
   return (
     <div className="h-11 flex-shrink-0 flex items-center justify-between bg-surface border-b border-border px-4">
-      <div className="font-serif font-bold text-base text-brand tracking-[0.02em]">
+      <div className="font-display font-bold text-base text-brand tracking-[0.02em]">
         かげとら
       </div>
       <div className="flex items-center gap-3">

--- a/apps/web/src/lib/role-label.test.ts
+++ b/apps/web/src/lib/role-label.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { roleLabel } from './role-label'
+
+describe('roleLabel', () => {
+  it("returns '管理者' + brand tone for 'admin'", () => {
+    expect(roleLabel('admin')).toEqual({ label: '管理者', tone: 'brand' })
+  })
+
+  it("returns '副管理者' + brand tone for 'vice_admin'", () => {
+    expect(roleLabel('vice_admin')).toEqual({
+      label: '副管理者',
+      tone: 'brand',
+    })
+  })
+
+  it("returns '会員' + neutral tone for 'member'", () => {
+    expect(roleLabel('member')).toEqual({ label: '会員', tone: 'neutral' })
+  })
+
+  it("returns '会員' + neutral tone for undefined", () => {
+    expect(roleLabel(undefined)).toEqual({
+      label: '会員',
+      tone: 'neutral',
+    })
+  })
+
+  it("returns '会員' + neutral tone for null", () => {
+    expect(roleLabel(null)).toEqual({ label: '会員', tone: 'neutral' })
+  })
+
+  it("returns '会員' + neutral tone for an unknown role string", () => {
+    expect(roleLabel('unknown_role')).toEqual({
+      label: '会員',
+      tone: 'neutral',
+    })
+  })
+})

--- a/apps/web/src/lib/role-label.ts
+++ b/apps/web/src/lib/role-label.ts
@@ -1,0 +1,26 @@
+import type { PillTone } from '@/components/ui'
+
+export interface RoleLabelResult {
+  label: string
+  tone: PillTone
+}
+
+/**
+ * Map a user role string to a display label + Pill tone.
+ *
+ * Admin/vice-admin use the brand tone; everything else (including
+ * null/undefined and any unknown string) falls back to the neutral
+ * 会員 label so missing data never surfaces a broken UI.
+ */
+export function roleLabel(
+  role: string | null | undefined,
+): RoleLabelResult {
+  switch (role) {
+    case 'admin':
+      return { label: '管理者', tone: 'brand' }
+    case 'vice_admin':
+      return { label: '副管理者', tone: 'brand' }
+    default:
+      return { label: '会員', tone: 'neutral' }
+  }
+}


### PR DESCRIPTION
## 何を

Phase UI-3a として `/dashboard` を新しい primitives (Card / Pill / SectionLabel) と MobileShell の上で再構築。

- `apps/web/src/app/(app)/dashboard/page.tsx` を Card + Pill + SectionLabel で再構築
- `apps/web/src/lib/role-label.ts` に role → ラベル変換ピュア関数を抽出（6 unit test 同梱）
- `apps/web/src/components/layout/app-bar-main.tsx` の `font-serif` → `font-display` 命名統一（PR #7 のレビュー carryover nit）
- 直書きユーティリティ (`bg-white` / `bg-gray-*` / `text-gray-*` / `shadow-sm` / `rounded-lg`) を除去

## なぜ

Phase UI-2 で確立した primitives + MobileShell を 15 画面に展開していくフェーズの最初の一画面。dashboard を見本ケースとして、以降の events / members / wiki などにも同じ pattern を適用する。

`role-label.ts` の抽出は dashboard と (将来の) member 一覧で同じ変換が必要になる前提で、テスト可能な単位に切り出している。

## スコープ外

- `/dashboard` 以外の画面の再スタイル → Phase UI-3b 以降
- LINE auth のバグ修正 → PR #8 (`be9c04e`) で main にマージ済み、本 PR は rebase 済みなので依存記述不要

## テスト方法

- [x] `pnpm --filter web test` — 75/75 PASS（`role-label.test.ts` 6/6 含む）
- [x] `pnpm --filter web lint` — 0 warning
- [x] `pnpm --filter web check-types` — PASS
- [x] 手動: dev server 起動 → LINE login → `/dashboard` 新スタイル実機確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)