### PR TITLE
feat(events): Phase UI-3b — events restyle + archive page

### DIFF
--- a/apps/web/e2e/grade-update.spec.ts
+++ b/apps/web/e2e/grade-update.spec.ts
@@ -45,13 +45,14 @@ test.describe('Admin grade update changes member eligibility', () => {
     await addSessionCookie(memberContext, member.sessionToken)
     const memberPage = await memberContext.newPage()
 
-    // Before grade update: member has no grade → form is hidden with ガイドメッセージ
+    // Before grade update: member has no grade → sticky RSVP toggle is hidden
+    // and a guidance message replaces it.
     await memberPage.goto(`/events/${event.id}`)
     await expect(
       memberPage.getByText(/級が未設定/),
     ).toBeVisible()
     await expect(
-      memberPage.getByRole('button', { name: '参加', exact: true }),
+      memberPage.getByRole('button', { name: '参加する' }),
     ).toHaveCount(0)
 
     // Admin updates member's grade to A
@@ -67,10 +68,11 @@ test.describe('Admin grade update changes member eligibility', () => {
     // Wait for revalidation: the persisted value should reflect 'A'
     await expect(gradeSelect).toHaveValue('A')
 
-    // After grade update: member can now respond
+    // After grade update: member can now respond — the sticky RSVP toggle
+    // shows '参加する' (the un-toggled label, since myAttendance is undefined).
     await memberPage.goto(`/events/${event.id}`)
     await expect(
-      memberPage.getByRole('button', { name: '参加', exact: true }),
+      memberPage.getByRole('button', { name: '参加する' }),
     ).toBeVisible()
 
     await memberContext.close()

--- a/apps/web/src/app/(app)/events-archive/page.tsx
+++ b/apps/web/src/app/(app)/events-archive/page.tsx
@@ -1,0 +1,91 @@
+import Link from 'next/link'
+import { db } from '@/lib/db'
+import { events, eventAttendances } from '@kagetra/shared/schema'
+import { desc, eq, count, lt } from 'drizzle-orm'
+import { Card, Pill, StatusPill } from '@/components/ui'
+
+export default async function EventsArchivePage() {
+  // JST today; events.eventDate is YYYY-MM-DD so lexicographic compare is correct.
+  const todayStr = new Date().toLocaleDateString('sv-SE', {
+    timeZone: 'Asia/Tokyo',
+  })
+
+  const [eventList, attendCounts] = await Promise.all([
+    db.query.events.findMany({
+      where: lt(events.eventDate, todayStr),
+      orderBy: [desc(events.eventDate)],
+    }),
+    db
+      .select({
+        eventId: eventAttendances.eventId,
+        count: count(),
+      })
+      .from(eventAttendances)
+      .where(eq(eventAttendances.attend, true))
+      .groupBy(eventAttendances.eventId),
+  ])
+  const attendCountMap = new Map(attendCounts.map((c) => [c.eventId, c.count]))
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h1 className="font-display text-xl font-bold text-ink">
+          過去のイベント
+        </h1>
+        <Link href="/events" className="text-sm text-brand">
+          現在のイベント →
+        </Link>
+      </div>
+      {eventList.length === 0 ? (
+        <Card>
+          <div className="text-center text-ink-meta py-6">
+            過去のイベントはまだありません
+          </div>
+        </Card>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {eventList.map((event) => (
+            <Link
+              key={event.id}
+              href={`/events/${event.id}`}
+              className="block"
+            >
+              <Card>
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium text-ink truncate">
+                        {event.title}
+                      </span>
+                      {event.official && (
+                        <Pill tone="success" size="sm">
+                          公認
+                        </Pill>
+                      )}
+                    </div>
+                    <div className="mt-1 text-xs text-ink-meta">
+                      {event.eventDate}
+                      {event.startTime && ` ${event.startTime}`}
+                      {event.endTime && `〜${event.endTime}`}
+                    </div>
+                    {event.location && (
+                      <div className="mt-0.5 text-xs text-ink-meta">
+                        {event.location}
+                      </div>
+                    )}
+                  </div>
+                  <div className="flex flex-col items-end gap-1.5 shrink-0">
+                    <StatusPill status={event.status} size="sm" />
+                    <span className="text-xs text-ink-meta">
+                      参加 {attendCountMap.get(event.id) ?? 0}名
+                    </span>
+                  </div>
+                </div>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/app/(app)/events-archive/page.tsx
+++ b/apps/web/src/app/(app)/events-archive/page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import { db } from '@/lib/db'
 import { events, eventAttendances } from '@kagetra/shared/schema'
-import { desc, eq, count, lt } from 'drizzle-orm'
+import { and, desc, eq, count, inArray, lt } from 'drizzle-orm'
 import { Card, Pill, StatusPill } from '@/components/ui'
 
 export default async function EventsArchivePage() {
@@ -10,20 +10,30 @@ export default async function EventsArchivePage() {
     timeZone: 'Asia/Tokyo',
   })
 
-  const [eventList, attendCounts] = await Promise.all([
-    db.query.events.findMany({
-      where: lt(events.eventDate, todayStr),
-      orderBy: [desc(events.eventDate)],
-    }),
-    db
-      .select({
-        eventId: eventAttendances.eventId,
-        count: count(),
-      })
-      .from(eventAttendances)
-      .where(eq(eventAttendances.attend, true))
-      .groupBy(eventAttendances.eventId),
-  ])
+  // Fetch event list first so the attendance aggregate can be scoped to the
+  // visible IDs — otherwise we'd scan every row in event_attendances, including
+  // rows for current events rendered on /events.
+  const eventList = await db.query.events.findMany({
+    where: lt(events.eventDate, todayStr),
+    orderBy: [desc(events.eventDate)],
+  })
+  const visibleEventIds = eventList.map((e) => e.id)
+  const attendCounts =
+    visibleEventIds.length === 0
+      ? []
+      : await db
+          .select({
+            eventId: eventAttendances.eventId,
+            count: count(),
+          })
+          .from(eventAttendances)
+          .where(
+            and(
+              inArray(eventAttendances.eventId, visibleEventIds),
+              eq(eventAttendances.attend, true),
+            ),
+          )
+          .groupBy(eventAttendances.eventId)
   const attendCountMap = new Map(attendCounts.map((c) => [c.eventId, c.count]))
 
   return (

--- a/apps/web/src/app/(app)/events/[id]/actions.test.ts
+++ b/apps/web/src/app/(app)/events/[id]/actions.test.ts
@@ -91,4 +91,24 @@ describe('submitAttendance — permission control', () => {
     const row = await getAttendance(event.id, admin.id)
     expect(row).toMatchObject({ attend: true, comment: 'admin override' })
   })
+
+  // Regression: sticky single-toggle UI submits only `attend`, so the action
+  // must NOT wipe an existing comment when the form omits the `comment` field.
+  it('toggle-only 再送信では既存のコメントが保持される', async () => {
+    const user = await createUser({ isInvited: true, grade: 'A' })
+    const event = await createEvent({ title: 'E5' })
+    await setAuthSession({ id: user.id, role: 'member' })
+
+    await submitAttendance(event.id, formWith(true, 'keep me'))
+    expect(await getAttendance(event.id, user.id)).toMatchObject({
+      attend: true,
+      comment: 'keep me',
+    })
+
+    await submitAttendance(event.id, formWith(false))
+    expect(await getAttendance(event.id, user.id)).toMatchObject({
+      attend: false,
+      comment: 'keep me',
+    })
+  })
 })

--- a/apps/web/src/app/(app)/events/[id]/actions.ts
+++ b/apps/web/src/app/(app)/events/[id]/actions.ts
@@ -13,7 +13,12 @@ export async function submitAttendance(eventId: number, formData: FormData) {
     session.user.role === 'admin' || session.user.role === 'vice_admin'
 
   const attend = formData.get('attend') === 'true'
-  const comment = (formData.get('comment') as string) || null
+  // Comment is only updated when the form actually submits a `comment` field.
+  // The sticky single-toggle UI intentionally omits it, so we must not overwrite
+  // any existing comment with null on a toggle — read conditionally.
+  const commentRaw = formData.get('comment')
+  const hasComment = commentRaw !== null
+  const comment = hasComment ? ((commentRaw as string) || null) : null
 
   const [targetEvent, currentUser] = await Promise.all([
     db.query.events.findFirst({ where: eq(events.id, eventId) }),
@@ -43,12 +48,16 @@ export async function submitAttendance(eventId: number, formData: FormData) {
     throw new Error('対象外の級です')
   }
 
+  const updateSet: { attend: boolean; updatedAt: Date; comment?: string | null } =
+    { attend, updatedAt: new Date() }
+  if (hasComment) updateSet.comment = comment
+
   await db
     .insert(eventAttendances)
     .values({ eventId, userId: session.user.id, attend, comment })
     .onConflictDoUpdate({
       target: [eventAttendances.eventId, eventAttendances.userId],
-      set: { attend, comment, updatedAt: new Date() },
+      set: updateSet,
     })
 
   revalidatePath(`/events/${eventId}`)

--- a/apps/web/src/app/(app)/events/[id]/edit/page.tsx
+++ b/apps/web/src/app/(app)/events/[id]/edit/page.tsx
@@ -1,10 +1,10 @@
 import { auth } from '@/auth'
 import { redirect, notFound } from 'next/navigation'
-import Link from 'next/link'
 import { db } from '@/lib/db'
 import { events, eventGroups } from '@kagetra/shared/schema'
 import { eq } from 'drizzle-orm'
 import { eventFormSchema, extractEventFormData } from '@/lib/form-schemas'
+import { EventForm } from '@/components/events/event-form'
 
 export default async function EditEventPage({
   params,
@@ -67,176 +67,31 @@ export default async function EditEventPage({
   }
 
   return (
-    <div className="space-y-4">
-      <h2 className="text-xl font-bold">イベント編集</h2>
-      <form action={updateEvent} className="space-y-4 rounded-lg bg-white p-6 shadow-sm">
-        <div>
-          <label className="block text-sm font-medium text-gray-700">
-            タイトル <span className="text-red-500">*</span>
-          </label>
-          <input
-            name="title"
-            type="text"
-            required
-            defaultValue={event.title}
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700">正式名称</label>
-          <input
-            name="formalName"
-            type="text"
-            defaultValue={event.formalName ?? ''}
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-          />
-        </div>
-        <div>
-          <label className="flex items-center gap-2 text-sm font-medium text-gray-700">
-            <input
-              name="official"
-              type="checkbox"
-              defaultChecked={event.official}
-              className="rounded border-gray-300"
-            />
-            公認大会
-          </label>
-        </div>
-        <input type="hidden" name="kind" value={event.kind} />
-        <div>
-          <label className="block text-sm font-medium text-gray-700">
-            日付 <span className="text-red-500">*</span>
-          </label>
-          <input
-            name="eventDate"
-            type="date"
-            required
-            defaultValue={event.eventDate}
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-          />
-        </div>
-        <div className="grid grid-cols-2 gap-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-700">開始時間</label>
-            <input
-              name="startTime"
-              type="time"
-              defaultValue={event.startTime ?? ''}
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700">終了時間</label>
-            <input
-              name="endTime"
-              type="time"
-              defaultValue={event.endTime ?? ''}
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-            />
-          </div>
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700">場所</label>
-          <input
-            name="location"
-            type="text"
-            defaultValue={event.location ?? ''}
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700">定員</label>
-          <input
-            name="capacity"
-            type="number"
-            min="1"
-            defaultValue={event.capacity ?? ''}
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-          />
-        </div>
-        <div className="grid grid-cols-2 gap-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-700">大会申込締切</label>
-            <input
-              name="entryDeadline"
-              type="date"
-              defaultValue={event.entryDeadline ?? ''}
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700">会内締切</label>
-            <input
-              name="internalDeadline"
-              type="date"
-              defaultValue={event.internalDeadline ?? ''}
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-            />
-          </div>
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700">大会グループ</label>
-          <select
-            name="eventGroupId"
-            defaultValue={event.eventGroupId ?? ''}
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-          >
-            <option value="">なし</option>
-            {groups.map((g) => (
-              <option key={g.id} value={g.id}>{g.name}</option>
-            ))}
-          </select>
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">参加可能な級</label>
-          <div className="flex gap-4">
-            {(['A', 'B', 'C', 'D', 'E'] as const).map((grade) => (
-              <label key={grade} className="flex items-center gap-1 text-sm">
-                <input
-                  name={`grade_${grade}`}
-                  type="checkbox"
-                  defaultChecked={event.eligibleGrades?.includes(grade) ?? false}
-                  className="rounded border-gray-300"
-                />
-                {grade}級
-              </label>
-            ))}
-          </div>
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700">説明</label>
-          <textarea
-            name="description"
-            rows={3}
-            defaultValue={event.description ?? ''}
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700">ステータス</label>
-          <select
-            name="status"
-            defaultValue={event.status}
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-          >
-            <option value="draft">下書き</option>
-            <option value="published">公開</option>
-            <option value="cancelled">中止</option>
-            <option value="done">終了</option>
-          </select>
-        </div>
-        <div className="flex gap-3">
-          <button
-            type="submit"
-            className="rounded-md bg-brand px-4 py-2 text-sm text-white hover:opacity-90"
-          >
-            更新
-          </button>
-          <Link href={`/events/${event.id}`} className="rounded-md bg-gray-100 px-4 py-2 text-sm hover:bg-gray-200">
-            キャンセル
-          </Link>
-        </div>
-      </form>
+    <div className="flex flex-col gap-4">
+      <h1 className="font-display text-xl font-bold text-ink mb-4">イベント編集</h1>
+      <EventForm
+        mode="edit"
+        action={updateEvent}
+        groups={groups}
+        cancelHref={`/events/${event.id}`}
+        defaultValues={{
+          title: event.title,
+          formalName: event.formalName,
+          official: event.official,
+          kind: event.kind,
+          eventDate: event.eventDate,
+          startTime: event.startTime,
+          endTime: event.endTime,
+          location: event.location,
+          capacity: event.capacity,
+          entryDeadline: event.entryDeadline,
+          internalDeadline: event.internalDeadline,
+          eventGroupId: event.eventGroupId,
+          eligibleGrades: event.eligibleGrades,
+          description: event.description,
+          status: event.status,
+        }}
+      />
     </div>
   )
 }

--- a/apps/web/src/app/(app)/events/[id]/page.tsx
+++ b/apps/web/src/app/(app)/events/[id]/page.tsx
@@ -64,9 +64,18 @@ export default async function EventDetailPage({
   })
 
   const attendingList = event.attendances.filter((a) => a.attend)
-  const notAttendingList = event.attendances.filter((a) => !a.attend)
-  const respondedUserIds = new Set(event.attendances.map((a) => a.userId))
-  const unansweredUsers = eligibleUsers.filter((u) => !respondedUserIds.has(u.id))
+  // Domain rule (CLAUDE.md): 未回答 = 不参加扱い. Collapse "explicit not-attending"
+  // and "unanswered" into a single non-attending count (= eligibles not in attendingList).
+  // Clamp with Math.max to guard against stale attend=true rows whose user is no
+  // longer eligible (e.g. grade changed), which would otherwise drive the count negative.
+  const eligibleUserIdSet = new Set(eligibleUsers.map((u) => u.id))
+  const eligibleAttendingCount = attendingList.filter((a) =>
+    eligibleUserIdSet.has(a.userId),
+  ).length
+  const nonAttendingCount = Math.max(
+    0,
+    eligibleUsers.length - eligibleAttendingCount,
+  )
 
   // Check if current user can respond to attendance (JST-based comparison)
   const todayStr = new Date().toLocaleDateString('sv-SE', { timeZone: 'Asia/Tokyo' })
@@ -191,8 +200,7 @@ export default async function EventDetailPage({
         <AttendanceCounts
           ev={{
             attendIds: attendingList.map((a) => a.userId),
-            absentIds: notAttendingList.map((a) => a.userId),
-            unansweredCount: unansweredUsers.length,
+            nonAttendingCount,
           }}
           variant="cards"
         />

--- a/apps/web/src/app/(app)/events/[id]/page.tsx
+++ b/apps/web/src/app/(app)/events/[id]/page.tsx
@@ -63,18 +63,18 @@ export default async function EventDetailPage({
       : eq(users.isInvited, true),
   })
 
-  const attendingList = event.attendances.filter((a) => a.attend)
-  // Domain rule (CLAUDE.md): 未回答 = 不参加扱い. Collapse "explicit not-attending"
-  // and "unanswered" into a single non-attending count (= eligibles not in attendingList).
-  // Clamp with Math.max to guard against stale attend=true rows whose user is no
-  // longer eligible (e.g. grade changed), which would otherwise drive the count negative.
+  // Domain rule (CLAUDE.md): 未回答 = 不参加扱い. Both the participant chips and
+  // the count cards are scoped to currently-eligible attendees so that 参加 +
+  // (不参加 + 未回答) always equals the eligible denominator. Stale attend=true
+  // rows from non-eligible users (e.g. grade changed, or admin-override answers
+  // for a different cohort) are excluded from the displayed totals.
   const eligibleUserIdSet = new Set(eligibleUsers.map((u) => u.id))
-  const eligibleAttendingCount = attendingList.filter((a) =>
-    eligibleUserIdSet.has(a.userId),
-  ).length
+  const eligibleAttendingList = event.attendances.filter(
+    (a) => a.attend && eligibleUserIdSet.has(a.userId),
+  )
   const nonAttendingCount = Math.max(
     0,
-    eligibleUsers.length - eligibleAttendingCount,
+    eligibleUsers.length - eligibleAttendingList.length,
   )
 
   // Check if current user can respond to attendance (JST-based comparison)
@@ -108,7 +108,7 @@ export default async function EventDetailPage({
   const boundSubmitAttendance = submitAttendance.bind(null, event.id)
 
   // Sort participants by ascending grade (A < B < ... < E); unranked goes last.
-  const sortedAttending = attendingList
+  const sortedAttending = eligibleAttendingList
     .slice()
     .sort((a, b) => (a.user.grade ?? 'Z').localeCompare(b.user.grade ?? 'Z'))
 
@@ -199,16 +199,16 @@ export default async function EventDetailPage({
         <SectionLabel>出欠状況</SectionLabel>
         <AttendanceCounts
           ev={{
-            attendIds: attendingList.map((a) => a.userId),
+            attendIds: eligibleAttendingList.map((a) => a.userId),
             nonAttendingCount,
           }}
           variant="cards"
         />
       </Card>
 
-      {attendingList.length > 0 && (
+      {eligibleAttendingList.length > 0 && (
         <Card>
-          <SectionLabel>参加者 ({attendingList.length}名)</SectionLabel>
+          <SectionLabel>参加者 ({eligibleAttendingList.length}名)</SectionLabel>
           <div className="flex flex-wrap gap-2">
             {sortedAttending.map((a) => (
               <span
@@ -240,6 +240,41 @@ export default async function EventDetailPage({
               !isEligible &&
               '対象外の級です'}
           </div>
+        </Card>
+      )}
+
+      {canRespond && (
+        <Card>
+          {/* Comment editor is intentionally separated from the sticky toggle so
+              the toggle can keep submitting only `attend` (preserves an existing
+              comment via submitAttendance's omitted-field guard), while this
+              form explicitly sends `comment` when the user wants to edit it. */}
+          <details>
+            <summary className="cursor-pointer text-xs font-semibold text-ink-meta tracking-[0.02em]">
+              コメント{myAttendance?.comment ? '（記入済み）' : ''}
+            </summary>
+            <form
+              action={boundSubmitAttendance}
+              className="mt-3 flex flex-col gap-2"
+            >
+              <input
+                type="hidden"
+                name="attend"
+                value={myAttendance?.attend === true ? 'true' : 'false'}
+              />
+              <textarea
+                name="comment"
+                rows={2}
+                defaultValue={myAttendance?.comment ?? ''}
+                className="block w-full rounded-md border border-border bg-canvas px-3 py-2 text-sm text-ink focus:outline-none focus:ring-2 focus:ring-brand/30"
+              />
+              <div className="flex justify-end">
+                <Btn type="submit" kind="secondary" size="sm">
+                  コメントを保存
+                </Btn>
+              </div>
+            </form>
+          </details>
         </Card>
       )}
 

--- a/apps/web/src/app/(app)/events/[id]/page.tsx
+++ b/apps/web/src/app/(app)/events/[id]/page.tsx
@@ -5,7 +5,30 @@ import { events, users } from '@kagetra/shared/schema'
 import type { Grade } from '@kagetra/shared/types'
 import { and, eq, inArray } from 'drizzle-orm'
 import { auth } from '@/auth'
+import {
+  AttendanceCounts,
+  Btn,
+  Card,
+  DescList,
+  type DescListItem,
+  GradePill,
+  Pill,
+  SectionLabel,
+  StatusPill,
+} from '@/components/ui'
 import { submitAttendance } from './actions'
+
+// Mirrors EventForm's CANCEL_LINK_CLASS but at size sm so the edit affordance
+// matches the back link's visual weight in the in-page header bar.
+const EDIT_LINK_CLASS =
+  'inline-flex items-center justify-center gap-1.5 rounded-lg font-semibold transition-colors h-8 px-3 text-xs bg-surface text-ink-2 border border-border hover:bg-surface-alt'
+
+/** Extract the surname for the participant chip (split on ASCII or full-width space). */
+function surname(name: string | null | undefined): string {
+  if (!name) return '?'
+  const parts = name.split(/[\s　]/)
+  return parts[0] || name
+}
 
 export default async function EventDetailPage({
   params,
@@ -16,7 +39,8 @@ export default async function EventDetailPage({
   const idNum = Number(id)
   if (!Number.isInteger(idNum) || idNum <= 0) notFound()
   const session = await auth()
-  const isAdmin = session?.user.role === 'admin' || session?.user.role === 'vice_admin'
+  const isAdmin =
+    session?.user.role === 'admin' || session?.user.role === 'vice_admin'
 
   const event = await db.query.events.findFirst({
     where: eq(events.id, idNum),
@@ -39,15 +63,17 @@ export default async function EventDetailPage({
       : eq(users.isInvited, true),
   })
 
-  const attendingList = event.attendances.filter(a => a.attend)
-  const notAttendingList = event.attendances.filter(a => !a.attend)
-  const respondedUserIds = new Set(event.attendances.map(a => a.userId))
-  const unansweredUsers = eligibleUsers.filter(u => !respondedUserIds.has(u.id))
+  const attendingList = event.attendances.filter((a) => a.attend)
+  const notAttendingList = event.attendances.filter((a) => !a.attend)
+  const respondedUserIds = new Set(event.attendances.map((a) => a.userId))
+  const unansweredUsers = eligibleUsers.filter((u) => !respondedUserIds.has(u.id))
 
   // Check if current user can respond to attendance (JST-based comparison)
   const todayStr = new Date().toLocaleDateString('sv-SE', { timeZone: 'Asia/Tokyo' })
   const isBeforeDeadline = !event.internalDeadline || event.internalDeadline >= todayStr
-  const myAttendance = session ? event.attendances.find(a => a.userId === session.user.id) : null
+  const myAttendance = session
+    ? event.attendances.find((a) => a.userId === session.user.id)
+    : null
 
   // Fetch current user's grade + isInvited from DB if logged in
   let currentUserGrade: Grade | null = null
@@ -60,207 +86,174 @@ export default async function EventDetailPage({
     currentUserIsInvited = currentUser?.isInvited ?? false
   }
 
-  const isEligible = !event.eligibleGrades?.length || (currentUserGrade != null && event.eligibleGrades.includes(currentUserGrade))
+  const isEligible =
+    !event.eligibleGrades?.length ||
+    (currentUserGrade != null && event.eligibleGrades.includes(currentUserGrade))
   // Admins/vice-admins bypass deadline/grade/invite checks (administrative override).
   // For non-admins, isInvited is required because Auth.js signIn allows returning users
   // (with already-linked accounts) to skip the isInvited gate — so the app must re-check here.
   // Non-admin users with grade=null are considered ineligible when the event has eligibleGrades;
   // there is no self-service grade UI in this PR, so such users must ask an admin to set it.
-  const canRespond = session && (isAdmin || (currentUserIsInvited && isBeforeDeadline && isEligible))
+  const canRespond =
+    session && (isAdmin || (currentUserIsInvited && isBeforeDeadline && isEligible))
   const boundSubmitAttendance = submitAttendance.bind(null, event.id)
 
+  // Sort participants by ascending grade (A < B < ... < E); unranked goes last.
+  const sortedAttending = attendingList
+    .slice()
+    .sort((a, b) => (a.user.grade ?? 'Z').localeCompare(b.user.grade ?? 'Z'))
+
+  const detailItems: DescListItem[] = [
+    ...(event.formalName
+      ? [{ label: '正式名称', value: event.formalName }]
+      : []),
+    {
+      label: '日付',
+      value: (
+        <>
+          {event.eventDate}
+          {event.startTime && ` ${event.startTime}`}
+          {event.endTime && `〜${event.endTime}`}
+        </>
+      ),
+    },
+    ...(event.location ? [{ label: '会場', value: event.location }] : []),
+    ...(event.eligibleGrades?.length
+      ? [
+          {
+            label: '対象級',
+            value: (
+              <div className="flex flex-wrap gap-1.5">
+                {event.eligibleGrades.map((g) => (
+                  <GradePill key={g} grade={g} size="sm" />
+                ))}
+              </div>
+            ),
+          },
+        ]
+      : []),
+    ...(event.capacity != null
+      ? [{ label: '定員', value: `${event.capacity}名` }]
+      : []),
+    ...(event.eventGroup?.name
+      ? [{ label: '大会グループ', value: event.eventGroup.name }]
+      : []),
+    ...(event.entryDeadline
+      ? [{ label: '大会申込締切', value: event.entryDeadline }]
+      : []),
+    ...(event.internalDeadline
+      ? [{ label: '会内締切', value: event.internalDeadline }]
+      : []),
+    { label: 'ステータス', value: <StatusPill status={event.status} size="sm" /> },
+  ]
+
   return (
-    <div className="space-y-6">
+    <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <h2 className="text-xl font-bold">{event.title}</h2>
-          <span className={`rounded-full px-2 py-1 text-xs ${
-            event.official ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-600'
-          }`}>
-            {event.official ? '公認' : '非公認'}
-          </span>
-        </div>
+        <Link href="/events" className="text-sm text-brand">
+          ← イベント一覧
+        </Link>
         {isAdmin && (
-          <Link
-            href={`/events/${event.id}/edit`}
-            className="rounded-md bg-gray-100 px-4 py-2 text-sm hover:bg-gray-200"
-          >
+          <Link href={`/events/${event.id}/edit`} className={EDIT_LINK_CLASS}>
             編集
           </Link>
         )}
       </div>
-      <div className="rounded-lg bg-white p-6 shadow-sm space-y-4">
-        {event.formalName && (
-          <div>
-            <dt className="text-sm text-gray-500">正式名称</dt>
-            <dd>{event.formalName}</dd>
-          </div>
-        )}
-        <div>
-          <dt className="text-sm text-gray-500">日付</dt>
-          <dd>{event.eventDate}</dd>
-        </div>
-        {(event.startTime || event.endTime) && (
-          <div>
-            <dt className="text-sm text-gray-500">時間</dt>
-            <dd>
-              {event.startTime ?? ''}
-              {event.endTime ? `〜${event.endTime}` : ''}
-            </dd>
-          </div>
-        )}
-        {event.location && (
-          <div>
-            <dt className="text-sm text-gray-500">場所</dt>
-            <dd>{event.location}</dd>
-          </div>
-        )}
-        {event.capacity && (
-          <div>
-            <dt className="text-sm text-gray-500">定員</dt>
-            <dd>{event.capacity}名</dd>
-          </div>
-        )}
-        {event.eventGroup && (
-          <div>
-            <dt className="text-sm text-gray-500">大会グループ</dt>
-            <dd>{event.eventGroup.name}</dd>
-          </div>
-        )}
-        {event.entryDeadline && (
-          <div>
-            <dt className="text-sm text-gray-500">大会申込締切</dt>
-            <dd>{event.entryDeadline}</dd>
-          </div>
-        )}
-        {event.internalDeadline && (
-          <div>
-            <dt className="text-sm text-gray-500">会内締切</dt>
-            <dd>{event.internalDeadline}</dd>
-          </div>
-        )}
-        {event.eligibleGrades && event.eligibleGrades.length > 0 && (
-          <div>
-            <dt className="text-sm text-gray-500">参加可能な級</dt>
-            <dd className="flex gap-1 mt-1">
-              {event.eligibleGrades.map((g) => (
-                <span key={g} className="rounded-full bg-blue-100 px-2 py-0.5 text-xs text-blue-700">
-                  {g}級
-                </span>
-              ))}
-            </dd>
-          </div>
-        )}
-        {event.description && (
-          <div>
-            <dt className="text-sm text-gray-500">説明</dt>
-            <dd className="whitespace-pre-wrap">{event.description}</dd>
-          </div>
-        )}
-        <div>
-          <dt className="text-sm text-gray-500">ステータス</dt>
-          <dd>
-            <span className={`rounded-full px-2 py-1 text-xs ${
-              event.status === 'published' ? 'bg-green-100 text-green-700' :
-              event.status === 'cancelled' ? 'bg-red-100 text-red-700' :
-              event.status === 'done' ? 'bg-blue-100 text-blue-700' :
-              'bg-gray-100 text-gray-600'
-            }`}>
-              {event.status === 'published' ? '公開' : event.status === 'cancelled' ? '中止' : event.status === 'done' ? '終了' : '下書き'}
-            </span>
-          </dd>
-        </div>
-      </div>
 
-      {/* Attendance section */}
-      <div className="rounded-lg bg-white p-6 shadow-sm space-y-4">
-        <h3 className="text-lg font-bold">出欠状況</h3>
-
-        <div className="space-y-3">
-          <div>
-            <span className="text-sm font-medium text-green-700">参加 ({attendingList.length}名)</span>
-            {attendingList.length > 0 && (
-              <p className="mt-1 text-sm text-gray-700">
-                {attendingList.map(a => a.user.name ?? '名前未設定').join(', ')}
-              </p>
-            )}
-          </div>
-          <div>
-            <span className="text-sm font-medium text-red-700">不参加 ({notAttendingList.length}名)</span>
-            {notAttendingList.length > 0 && (
-              <p className="mt-1 text-sm text-gray-700">
-                {notAttendingList.map(a => a.user.name ?? '名前未設定').join(', ')}
-              </p>
-            )}
-          </div>
-          <div>
-            <span className="text-sm font-medium text-gray-500">未回答 ({unansweredUsers.length}名)</span>
-            {unansweredUsers.length > 0 && (
-              <p className="mt-1 text-sm text-gray-700">
-                {unansweredUsers.map(u => u.name ?? '名前未設定').join(', ')}
-              </p>
-            )}
-          </div>
-        </div>
-
-        {/* Attendance form for current user */}
-        {session && (
-          <div className="border-t pt-4">
-            {canRespond ? (
-              <form action={boundSubmitAttendance} className="space-y-3">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">コメント（任意）</label>
-                  <textarea
-                    name="comment"
-                    defaultValue={myAttendance?.comment ?? ''}
-                    placeholder="コメント（任意）"
-                    rows={2}
-                    className="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-                  />
-                </div>
-                <div className="flex gap-2">
-                  <button
-                    type="submit"
-                    name="attend"
-                    value="true"
-                    className={`rounded-md px-4 py-2 text-sm font-medium ${
-                      myAttendance?.attend === true
-                        ? 'bg-green-600 text-white'
-                        : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                    }`}
-                  >
-                    参加
-                  </button>
-                  <button
-                    type="submit"
-                    name="attend"
-                    value="false"
-                    className={`rounded-md px-4 py-2 text-sm font-medium ${
-                      myAttendance?.attend === false
-                        ? 'bg-red-600 text-white'
-                        : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                    }`}
-                  >
-                    不参加
-                  </button>
-                </div>
-              </form>
-            ) : !currentUserIsInvited ? (
-              <p className="text-sm text-gray-500">出欠回答の対象外です</p>
-            ) : !isBeforeDeadline ? (
-              <p className="text-sm text-gray-500">締切済み</p>
-            ) : event.eligibleGrades?.length && currentUserGrade == null ? (
-              <p className="text-sm text-gray-500">級が未設定のため回答できません。管理者に級の設定を依頼してください。</p>
-            ) : !isEligible ? (
-              <p className="text-sm text-gray-500">対象外の級です</p>
-            ) : null}
+      <div>
+        <h1 className="font-display text-[28px] font-bold text-ink leading-tight">
+          {event.title}
+        </h1>
+        {event.official && (
+          <div className="mt-1.5">
+            <Pill tone="success" size="sm">
+              公認
+            </Pill>
           </div>
         )}
       </div>
 
-      <Link href="/events" className="text-sm text-gray-500 hover:text-gray-700">
-        ← イベント一覧に戻る
-      </Link>
+      <Card>
+        <DescList items={detailItems} />
+      </Card>
+
+      {event.description && (
+        <Card>
+          <SectionLabel>詳細</SectionLabel>
+          <div className="whitespace-pre-wrap text-sm text-ink">
+            {event.description}
+          </div>
+        </Card>
+      )}
+
+      <Card>
+        <SectionLabel>出欠状況</SectionLabel>
+        <AttendanceCounts
+          ev={{
+            attendIds: attendingList.map((a) => a.userId),
+            absentIds: notAttendingList.map((a) => a.userId),
+            unansweredCount: unansweredUsers.length,
+          }}
+          variant="cards"
+        />
+      </Card>
+
+      {attendingList.length > 0 && (
+        <Card>
+          <SectionLabel>参加者 ({attendingList.length}名)</SectionLabel>
+          <div className="flex flex-wrap gap-2">
+            {sortedAttending.map((a) => (
+              <span
+                key={a.userId}
+                className="inline-flex items-center gap-1.5 rounded-full bg-neutral-bg px-2 py-0.5 text-xs text-neutral-fg"
+              >
+                {surname(a.user.name)}
+                {a.user.grade && <GradePill grade={a.user.grade} size="sm" />}
+              </span>
+            ))}
+          </div>
+        </Card>
+      )}
+
+      {!canRespond && session && (
+        <Card>
+          <div className="text-sm text-ink-meta">
+            {!currentUserIsInvited && '出欠回答の対象外です'}
+            {currentUserIsInvited &&
+              !isBeforeDeadline &&
+              '会内締切を過ぎています'}
+            {currentUserIsInvited &&
+              isBeforeDeadline &&
+              currentUserGrade == null &&
+              '級が未設定のため回答できません'}
+            {currentUserIsInvited &&
+              isBeforeDeadline &&
+              currentUserGrade != null &&
+              !isEligible &&
+              '対象外の級です'}
+          </div>
+        </Card>
+      )}
+
+      {canRespond && (
+        <div className="sticky bottom-0 bg-canvas/95 backdrop-blur border-t border-border-soft p-3">
+          <form action={boundSubmitAttendance}>
+            <input
+              type="hidden"
+              name="attend"
+              value={myAttendance?.attend === true ? 'false' : 'true'}
+            />
+            <Btn
+              type="submit"
+              kind={myAttendance?.attend === true ? 'secondary' : 'primary'}
+              size="lg"
+              block
+            >
+              {myAttendance?.attend === true ? '参加をキャンセル' : '参加する'}
+            </Btn>
+          </form>
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/web/src/app/(app)/events/new/page.tsx
+++ b/apps/web/src/app/(app)/events/new/page.tsx
@@ -1,10 +1,10 @@
 import { auth } from '@/auth'
 import { redirect } from 'next/navigation'
-import Link from 'next/link'
 import { db } from '@/lib/db'
 import { events, eventGroups } from '@kagetra/shared/schema'
 import { eq } from 'drizzle-orm'
 import { eventFormSchema, extractEventFormData } from '@/lib/form-schemas'
+import { EventForm } from '@/components/events/event-form'
 
 export default async function NewEventPage() {
   const session = await auth()
@@ -53,161 +53,14 @@ export default async function NewEventPage() {
   }
 
   return (
-    <div className="space-y-4">
-      <h2 className="text-xl font-bold">イベント作成</h2>
-      <form action={createEvent} className="space-y-4 rounded-lg bg-white p-6 shadow-sm">
-        <div>
-          <label className="block text-sm font-medium text-gray-700">
-            タイトル <span className="text-red-500">*</span>
-          </label>
-          <input
-            name="title"
-            type="text"
-            required
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700">正式名称</label>
-          <input
-            name="formalName"
-            type="text"
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-          />
-        </div>
-        <div>
-          <label className="flex items-center gap-2 text-sm font-medium text-gray-700">
-            <input
-              name="official"
-              type="checkbox"
-              defaultChecked
-              className="rounded border-gray-300"
-            />
-            公認大会
-          </label>
-        </div>
-        <input type="hidden" name="kind" value="individual" />
-        <div>
-          <label className="block text-sm font-medium text-gray-700">
-            日付 <span className="text-red-500">*</span>
-          </label>
-          <input
-            name="eventDate"
-            type="date"
-            required
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-          />
-        </div>
-        <div className="grid grid-cols-2 gap-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-700">開始時間</label>
-            <input
-              name="startTime"
-              type="time"
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700">終了時間</label>
-            <input
-              name="endTime"
-              type="time"
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-            />
-          </div>
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700">場所</label>
-          <input
-            name="location"
-            type="text"
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700">定員</label>
-          <input
-            name="capacity"
-            type="number"
-            min="1"
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-          />
-        </div>
-        <div className="grid grid-cols-2 gap-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-700">大会申込締切</label>
-            <input
-              name="entryDeadline"
-              type="date"
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700">会内締切</label>
-            <input
-              name="internalDeadline"
-              type="date"
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-            />
-          </div>
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700">大会グループ</label>
-          <select
-            name="eventGroupId"
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-          >
-            <option value="">なし</option>
-            {groups.map((g) => (
-              <option key={g.id} value={g.id}>{g.name}</option>
-            ))}
-          </select>
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">参加可能な級</label>
-          <div className="flex gap-4">
-            {['A', 'B', 'C', 'D', 'E'].map((grade) => (
-              <label key={grade} className="flex items-center gap-1 text-sm">
-                <input
-                  name={`grade_${grade}`}
-                  type="checkbox"
-                  className="rounded border-gray-300"
-                />
-                {grade}級
-              </label>
-            ))}
-          </div>
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700">説明</label>
-          <textarea
-            name="description"
-            rows={3}
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700">ステータス</label>
-          <select
-            name="status"
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-          >
-            <option value="draft">下書き</option>
-            <option value="published">公開</option>
-          </select>
-        </div>
-        <div className="flex gap-3">
-          <button
-            type="submit"
-            className="rounded-md bg-brand px-4 py-2 text-sm text-white hover:opacity-90"
-          >
-            作成
-          </button>
-          <Link href="/events" className="rounded-md bg-gray-100 px-4 py-2 text-sm hover:bg-gray-200">
-            キャンセル
-          </Link>
-        </div>
-      </form>
+    <div className="flex flex-col gap-4">
+      <h1 className="font-display text-xl font-bold text-ink mb-4">イベント作成</h1>
+      <EventForm
+        mode="create"
+        action={createEvent}
+        groups={groups}
+        cancelHref="/events"
+      />
     </div>
   )
 }

--- a/apps/web/src/app/(app)/events/page.tsx
+++ b/apps/web/src/app/(app)/events/page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import { db } from '@/lib/db'
 import { events, eventAttendances } from '@kagetra/shared/schema'
-import { asc, eq, count, gte } from 'drizzle-orm'
+import { and, asc, eq, count, gte, inArray } from 'drizzle-orm'
 import { auth } from '@/auth'
 import { Card, Pill, StatusPill } from '@/components/ui'
 
@@ -20,20 +20,30 @@ export default async function EventsPage() {
     timeZone: 'Asia/Tokyo',
   })
 
-  const [eventList, attendCounts] = await Promise.all([
-    db.query.events.findMany({
-      where: gte(events.eventDate, todayStr),
-      orderBy: [asc(events.eventDate)],
-    }),
-    db
-      .select({
-        eventId: eventAttendances.eventId,
-        count: count(),
-      })
-      .from(eventAttendances)
-      .where(eq(eventAttendances.attend, true))
-      .groupBy(eventAttendances.eventId),
-  ])
+  // Fetch event list first so the attendance aggregate can be scoped to the
+  // visible IDs — otherwise we'd scan every row in event_attendances, including
+  // rows for archived events rendered on /events-archive.
+  const eventList = await db.query.events.findMany({
+    where: gte(events.eventDate, todayStr),
+    orderBy: [asc(events.eventDate)],
+  })
+  const visibleEventIds = eventList.map((e) => e.id)
+  const attendCounts =
+    visibleEventIds.length === 0
+      ? []
+      : await db
+          .select({
+            eventId: eventAttendances.eventId,
+            count: count(),
+          })
+          .from(eventAttendances)
+          .where(
+            and(
+              inArray(eventAttendances.eventId, visibleEventIds),
+              eq(eventAttendances.attend, true),
+            ),
+          )
+          .groupBy(eventAttendances.eventId)
   const attendCountMap = new Map(attendCounts.map((c) => [c.eventId, c.count]))
 
   return (
@@ -54,7 +64,7 @@ export default async function EventsPage() {
       {eventList.length === 0 ? (
         <Card>
           <div className="text-center text-ink-meta py-6">
-            イベントはまだありません
+            現在のイベントはありません
           </div>
         </Card>
       ) : (

--- a/apps/web/src/app/(app)/events/page.tsx
+++ b/apps/web/src/app/(app)/events/page.tsx
@@ -33,11 +33,16 @@ export default async function EventsPage() {
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between">
         <h1 className="font-display text-xl font-bold text-ink">イベント一覧</h1>
-        {isAdmin && (
-          <Link href="/events/new" className={NEW_LINK_CLASS}>
-            新規作成
+        <div className="flex items-center gap-3">
+          <Link href="/events-archive" className="text-sm text-brand">
+            過去のイベント →
           </Link>
-        )}
+          {isAdmin && (
+            <Link href="/events/new" className={NEW_LINK_CLASS}>
+              新規作成
+            </Link>
+          )}
+        </div>
       </div>
       {eventList.length === 0 ? (
         <Card>

--- a/apps/web/src/app/(app)/events/page.tsx
+++ b/apps/web/src/app/(app)/events/page.tsx
@@ -3,6 +3,12 @@ import { db } from '@/lib/db'
 import { events, eventAttendances } from '@kagetra/shared/schema'
 import { desc, eq, count } from 'drizzle-orm'
 import { auth } from '@/auth'
+import { Card, Pill, StatusPill } from '@/components/ui'
+
+// Btn primary mirrored as a Link className since wrapping <Link> in <Btn>
+// would nest it inside a <button>.
+const NEW_LINK_CLASS =
+  'inline-flex items-center justify-center gap-1.5 rounded-lg font-semibold transition-colors h-8 px-3 text-xs bg-brand text-white hover:bg-brand-hover'
 
 export default async function EventsPage() {
   const session = await auth()
@@ -24,71 +30,70 @@ export default async function EventsPage() {
   const attendCountMap = new Map(attendCounts.map((c) => [c.eventId, c.count]))
 
   return (
-    <div className="space-y-4">
+    <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-xl font-bold">イベント一覧</h2>
+        <h1 className="font-display text-xl font-bold text-ink">イベント一覧</h1>
         {isAdmin && (
-          <Link
-            href="/events/new"
-            className="rounded-md bg-brand px-4 py-2 text-sm text-white hover:opacity-90"
-          >
+          <Link href="/events/new" className={NEW_LINK_CLASS}>
             新規作成
           </Link>
         )}
       </div>
-      <div className="space-y-3">
-        {eventList.length === 0 ? (
-          <p className="text-sm text-gray-500">イベントはまだありません</p>
-        ) : (
-          eventList.map((event) => {
-            const attendCount = attendCountMap.get(event.id) ?? 0
-            return (
-              <Link
-                key={event.id}
-                href={`/events/${event.id}`}
-                className="block rounded-lg bg-white p-4 shadow-sm hover:shadow-md transition-shadow"
-              >
-                <div className="flex items-start justify-between">
-                  <div>
+      {eventList.length === 0 ? (
+        <Card>
+          <div className="text-center text-ink-meta py-6">
+            イベントはまだありません
+          </div>
+        </Card>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {eventList.map((event) => (
+            <Link
+              key={event.id}
+              href={`/events/${event.id}`}
+              className="block"
+            >
+              <Card>
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2">
-                      <h3 className="font-medium">{event.title}</h3>
+                      <span className="font-medium text-ink truncate">
+                        {event.title}
+                      </span>
                       {event.official && (
-                        <span className="rounded-full bg-green-100 px-2 py-0.5 text-xs text-green-700">
+                        <Pill tone="success" size="sm">
                           公認
-                        </span>
+                        </Pill>
                       )}
                     </div>
-                    <p className="mt-1 text-sm text-gray-500">
+                    <div className="mt-1 text-xs text-ink-meta">
                       {event.eventDate}
                       {event.startTime && ` ${event.startTime}`}
                       {event.endTime && `〜${event.endTime}`}
-                    </p>
-                    {event.location && (
-                      <p className="text-sm text-gray-500">{event.location}</p>
-                    )}
-                    <div className="mt-1 flex items-center gap-3">
-                      {event.internalDeadline && (
-                        <span className="text-xs text-gray-400">会内締切: {event.internalDeadline}</span>
-                      )}
-                      {attendCount > 0 && (
-                        <span className="text-xs text-green-600">参加{attendCount}名</span>
-                      )}
                     </div>
+                    {event.location && (
+                      <div className="mt-0.5 text-xs text-ink-meta">
+                        {event.location}
+                      </div>
+                    )}
+                    {event.internalDeadline && (
+                      <div className="mt-0.5 text-xs text-ink-meta">
+                        締切: {event.internalDeadline}
+                      </div>
+                    )}
                   </div>
-                  <span className={`rounded-full px-2 py-1 text-xs ${
-                    event.status === 'published' ? 'bg-green-100 text-green-700' :
-                    event.status === 'cancelled' ? 'bg-red-100 text-red-700' :
-                    event.status === 'done' ? 'bg-blue-100 text-blue-700' :
-                    'bg-gray-100 text-gray-600'
-                  }`}>
-                    {event.status === 'published' ? '公開' : event.status === 'cancelled' ? '中止' : event.status === 'done' ? '終了' : '下書き'}
-                  </span>
+                  <div className="flex flex-col items-end gap-1.5 shrink-0">
+                    <StatusPill status={event.status} size="sm" />
+                    <span className="text-xs text-ink-meta">
+                      参加 {attendCountMap.get(event.id) ?? 0}名
+                    </span>
+                  </div>
                 </div>
-              </Link>
-            )
-          })
-        )}
-      </div>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/web/src/app/(app)/events/page.tsx
+++ b/apps/web/src/app/(app)/events/page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import { db } from '@/lib/db'
 import { events, eventAttendances } from '@kagetra/shared/schema'
-import { desc, eq, count } from 'drizzle-orm'
+import { asc, eq, count, gte } from 'drizzle-orm'
 import { auth } from '@/auth'
 import { Card, Pill, StatusPill } from '@/components/ui'
 
@@ -14,9 +14,16 @@ export default async function EventsPage() {
   const session = await auth()
   const isAdmin = session?.user.role === 'admin' || session?.user.role === 'vice_admin'
 
+  // JST today; events.eventDate is YYYY-MM-DD so lexicographic compare is correct.
+  // Past events are surfaced on /events-archive — listing them here too would double-list.
+  const todayStr = new Date().toLocaleDateString('sv-SE', {
+    timeZone: 'Asia/Tokyo',
+  })
+
   const [eventList, attendCounts] = await Promise.all([
     db.query.events.findMany({
-      orderBy: [desc(events.eventDate)],
+      where: gte(events.eventDate, todayStr),
+      orderBy: [asc(events.eventDate)],
     }),
     db
       .select({

--- a/apps/web/src/components/events/event-form.test.tsx
+++ b/apps/web/src/components/events/event-form.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { EventForm } from './event-form'
+
+const noop = () => {}
+const groups = [
+  { id: 1, name: 'グループA' },
+  { id: 2, name: 'グループB' },
+]
+
+describe('EventForm', () => {
+  it("mode='create' で「作成」ボタンが表示される", () => {
+    render(
+      <EventForm
+        mode="create"
+        action={noop}
+        groups={groups}
+        cancelHref="/events"
+      />,
+    )
+    expect(screen.getByRole('button', { name: '作成' })).toBeTruthy()
+  })
+
+  it("mode='edit' で「更新」ボタンが表示され、defaultValues の title が input に入っている", () => {
+    render(
+      <EventForm
+        mode="edit"
+        action={noop}
+        groups={groups}
+        cancelHref="/events/1"
+        defaultValues={{ title: '春の大会' }}
+      />,
+    )
+    expect(screen.getByRole('button', { name: '更新' })).toBeTruthy()
+    const titleInput = screen.getByDisplayValue('春の大会') as HTMLInputElement
+    expect(titleInput.name).toBe('title')
+  })
+
+  it('groups が select option としてレンダリングされる', () => {
+    render(
+      <EventForm
+        mode="create"
+        action={noop}
+        groups={groups}
+        cancelHref="/events"
+      />,
+    )
+    const optionA = screen.getByRole('option', {
+      name: 'グループA',
+    }) as HTMLOptionElement
+    const optionB = screen.getByRole('option', {
+      name: 'グループB',
+    }) as HTMLOptionElement
+    expect(optionA.value).toBe('1')
+    expect(optionB.value).toBe('2')
+  })
+})

--- a/apps/web/src/components/events/event-form.tsx
+++ b/apps/web/src/components/events/event-form.tsx
@@ -1,0 +1,246 @@
+import Link from 'next/link'
+import { Btn, Card } from '@/components/ui'
+
+export interface EventFormProps {
+  mode: 'create' | 'edit'
+  action: (formData: FormData) => void | Promise<void>
+  groups: { id: number; name: string }[]
+  cancelHref: string
+  defaultValues?: {
+    title?: string | null
+    formalName?: string | null
+    official?: boolean
+    kind?: string
+    eventDate?: string | null
+    startTime?: string | null
+    endTime?: string | null
+    location?: string | null
+    capacity?: number | null
+    entryDeadline?: string | null
+    internalDeadline?: string | null
+    eventGroupId?: number | null
+    eligibleGrades?: string[] | null
+    description?: string | null
+    status?: string
+  }
+}
+
+const LABEL_CLASS = 'block text-xs font-semibold text-ink-meta tracking-[0.02em]'
+const FIELD_CLASS =
+  'mt-1 block w-full rounded-md border border-border bg-canvas px-3 py-2 text-sm text-ink focus:outline-none focus:ring-2 focus:ring-brand/30'
+const REQUIRED_MARK = <span className="ml-0.5 text-accent">*</span>
+const GRADES = ['A', 'B', 'C', 'D', 'E'] as const
+// Btn primary/secondary share these base classes; mirror them for the
+// `<Link>`-rendered cancel action since wrapping <Link> in <Btn> would
+// nest it inside a <button>.
+const CANCEL_LINK_CLASS =
+  'inline-flex items-center justify-center gap-1.5 rounded-lg font-semibold transition-colors h-10 px-4 text-sm bg-surface text-ink-2 border border-border hover:bg-surface-alt'
+
+/**
+ * Shared event create/edit form. Renders inside a {@link Card} and submits via
+ * the `action` server action. Field markup stays as plain HTML elements +
+ * Tailwind tokens so server-action wiring remains straightforward and so the
+ * lower-level inputs do not need to be lifted into separate primitives.
+ */
+export function EventForm({
+  mode,
+  action,
+  groups,
+  cancelHref,
+  defaultValues,
+}: EventFormProps) {
+  const eligibleGrades = defaultValues?.eligibleGrades ?? null
+  const submitLabel = mode === 'create' ? '作成' : '更新'
+
+  return (
+    <Card>
+      <form action={action} className="space-y-4">
+        <div>
+          <label className={LABEL_CLASS}>
+            タイトル{REQUIRED_MARK}
+          </label>
+          <input
+            name="title"
+            type="text"
+            required
+            defaultValue={defaultValues?.title ?? ''}
+            className={FIELD_CLASS}
+          />
+        </div>
+
+        <div>
+          <label className={LABEL_CLASS}>正式名称</label>
+          <input
+            name="formalName"
+            type="text"
+            defaultValue={defaultValues?.formalName ?? ''}
+            className={FIELD_CLASS}
+          />
+        </div>
+
+        <div>
+          <label className="flex items-center gap-2 text-xs font-semibold text-ink-meta tracking-[0.02em]">
+            <input
+              name="official"
+              type="checkbox"
+              defaultChecked={defaultValues?.official ?? true}
+              className="rounded border-border"
+            />
+            公認大会
+          </label>
+        </div>
+
+        <input
+          type="hidden"
+          name="kind"
+          value={defaultValues?.kind ?? 'individual'}
+        />
+
+        <div>
+          <label className={LABEL_CLASS}>
+            日付{REQUIRED_MARK}
+          </label>
+          <input
+            name="eventDate"
+            type="date"
+            required
+            defaultValue={defaultValues?.eventDate ?? ''}
+            className={FIELD_CLASS}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className={LABEL_CLASS}>開始時間</label>
+            <input
+              name="startTime"
+              type="time"
+              defaultValue={defaultValues?.startTime ?? ''}
+              className={FIELD_CLASS}
+            />
+          </div>
+          <div>
+            <label className={LABEL_CLASS}>終了時間</label>
+            <input
+              name="endTime"
+              type="time"
+              defaultValue={defaultValues?.endTime ?? ''}
+              className={FIELD_CLASS}
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className={LABEL_CLASS}>場所</label>
+          <input
+            name="location"
+            type="text"
+            defaultValue={defaultValues?.location ?? ''}
+            className={FIELD_CLASS}
+          />
+        </div>
+
+        <div>
+          <label className={LABEL_CLASS}>定員</label>
+          <input
+            name="capacity"
+            type="number"
+            min="1"
+            defaultValue={defaultValues?.capacity ?? ''}
+            className={FIELD_CLASS}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className={LABEL_CLASS}>大会申込締切</label>
+            <input
+              name="entryDeadline"
+              type="date"
+              defaultValue={defaultValues?.entryDeadline ?? ''}
+              className={FIELD_CLASS}
+            />
+          </div>
+          <div>
+            <label className={LABEL_CLASS}>会内締切</label>
+            <input
+              name="internalDeadline"
+              type="date"
+              defaultValue={defaultValues?.internalDeadline ?? ''}
+              className={FIELD_CLASS}
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className={LABEL_CLASS}>大会グループ</label>
+          <select
+            name="eventGroupId"
+            defaultValue={defaultValues?.eventGroupId ?? ''}
+            className={FIELD_CLASS}
+          >
+            <option value="">--</option>
+            {groups.map((g) => (
+              <option key={g.id} value={g.id}>
+                {g.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className={`${LABEL_CLASS} mb-2`}>参加可能な級</label>
+          <div className="flex gap-4">
+            {GRADES.map((g) => (
+              <label
+                key={g}
+                className="flex items-center gap-1 text-sm text-ink"
+              >
+                <input
+                  name={`grade_${g}`}
+                  type="checkbox"
+                  defaultChecked={eligibleGrades?.includes(g) ?? false}
+                  className="rounded border-border"
+                />
+                {g}級
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className={LABEL_CLASS}>説明</label>
+          <textarea
+            name="description"
+            rows={3}
+            defaultValue={defaultValues?.description ?? ''}
+            className={FIELD_CLASS}
+          />
+        </div>
+
+        <div>
+          <label className={LABEL_CLASS}>ステータス</label>
+          <select
+            name="status"
+            defaultValue={defaultValues?.status ?? 'draft'}
+            className={FIELD_CLASS}
+          >
+            <option value="draft">下書き</option>
+            <option value="published">公開</option>
+            {mode === 'edit' && <option value="cancelled">中止</option>}
+            {mode === 'edit' && <option value="done">終了</option>}
+          </select>
+        </div>
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Link href={cancelHref} className={CANCEL_LINK_CLASS}>
+            キャンセル
+          </Link>
+          <Btn type="submit" kind="primary" size="md">
+            {submitLabel}
+          </Btn>
+        </div>
+      </form>
+    </Card>
+  )
+}

--- a/apps/web/src/components/events/event-form.tsx
+++ b/apps/web/src/components/events/event-form.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import type { EventKind, EventStatus } from '@kagetra/shared/types'
 import { Btn, Card } from '@/components/ui'
 
 export interface EventFormProps {
@@ -10,7 +11,7 @@ export interface EventFormProps {
     title?: string | null
     formalName?: string | null
     official?: boolean
-    kind?: string
+    kind?: EventKind
     eventDate?: string | null
     startTime?: string | null
     endTime?: string | null
@@ -21,7 +22,7 @@ export interface EventFormProps {
     eventGroupId?: number | null
     eligibleGrades?: string[] | null
     description?: string | null
-    status?: string
+    status?: EventStatus
   }
 }
 

--- a/apps/web/src/components/ui/attendance-counts.test.tsx
+++ b/apps/web/src/components/ui/attendance-counts.test.tsx
@@ -2,46 +2,46 @@ import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { AttendanceCounts } from './attendance-counts'
 
+// Domain rule: unanswered users are folded into the non-attending count,
+// so callers pass a single `nonAttendingCount` (explicit-false + unanswered).
 const ev = {
   attendIds: [1, 2, 3],
-  absentIds: [4, 5],
-  unansweredCount: 7,
+  nonAttendingCount: 9,
 }
 
 describe('AttendanceCounts', () => {
-  it('variant=cards でカードが3つ並び、参加/不参加/未回答ラベルと数値が表示される', () => {
+  it('variant=cards でカードが2つ並び、参加/不参加ラベルと数値が表示される', () => {
     const { container } = render(<AttendanceCounts ev={ev} variant="cards" />)
     const cards = container.querySelectorAll('[data-card]')
-    expect(cards).toHaveLength(3)
+    expect(cards).toHaveLength(2)
     expect(screen.getByText('参加')).toBeTruthy()
     expect(screen.getByText('不参加')).toBeTruthy()
-    expect(screen.getByText('未回答')).toBeTruthy()
-    // Counts rendered (3, 2, 7)
+    expect(screen.queryByText('未回答')).toBeNull()
+    // Counts rendered (3, 9)
     expect(screen.getByText('3')).toBeTruthy()
-    expect(screen.getByText('2')).toBeTruthy()
-    expect(screen.getByText('7')).toBeTruthy()
+    expect(screen.getByText('9')).toBeTruthy()
   })
 
-  it('variant=cards は既定値で、省略時も 3 カード表示', () => {
+  it('variant=cards は既定値で、省略時も 2 カード表示', () => {
     const { container } = render(<AttendanceCounts ev={ev} />)
-    expect(container.querySelectorAll('[data-card]')).toHaveLength(3)
+    expect(container.querySelectorAll('[data-card]')).toHaveLength(2)
   })
 
   it('variant=bar でバーセグメントと凡例が表示され、凡例に各カウントが含まれる', () => {
     const { container } = render(<AttendanceCounts ev={ev} variant="bar" />)
-    // Three non-zero segments expected
+    // Two non-zero segments expected
     const segs = container.querySelectorAll('[data-segment]')
-    expect(segs).toHaveLength(3)
+    expect(segs).toHaveLength(2)
     // Legend lines include counts
     expect(screen.getByText(/参加\s*3/)).toBeTruthy()
-    expect(screen.getByText(/不参加\s*2/)).toBeTruthy()
-    expect(screen.getByText(/未回答\s*7/)).toBeTruthy()
+    expect(screen.getByText(/不参加\s*9/)).toBeTruthy()
+    expect(screen.queryByText(/未回答/)).toBeNull()
   })
 
   it('variant=bar で count=0 のセグメントは描画されない', () => {
     const { container } = render(
       <AttendanceCounts
-        ev={{ attendIds: [1], absentIds: [], unansweredCount: 0 }}
+        ev={{ attendIds: [1], nonAttendingCount: 0 }}
         variant="bar"
       />,
     )

--- a/apps/web/src/components/ui/attendance-counts.tsx
+++ b/apps/web/src/components/ui/attendance-counts.tsx
@@ -1,8 +1,13 @@
 import { cn } from '@/lib/utils'
 
 export interface AttendanceEvent {
-  attendIds: number[]
-  absentIds: number[]
+  /**
+   * Attending user IDs. Type is widened to accept either numeric or string IDs
+   * since callers may pass DB-native string PKs (e.g. event_attendances.userId);
+   * the component itself only reads `.length` from these arrays.
+   */
+  attendIds: readonly (number | string)[]
+  absentIds: readonly (number | string)[]
   unansweredCount: number
 }
 

--- a/apps/web/src/components/ui/attendance-counts.tsx
+++ b/apps/web/src/components/ui/attendance-counts.tsx
@@ -7,8 +7,12 @@ export interface AttendanceEvent {
    * the component itself only reads `.length` from these arrays.
    */
   attendIds: readonly (number | string)[]
-  absentIds: readonly (number | string)[]
-  unansweredCount: number
+  /**
+   * Count of users who are not attending. By domain rule, unanswered users are
+   * treated as not attending (未回答 = 不参加扱い), so callers should fold the
+   * unanswered count into this value rather than surfacing it as a third bucket.
+   */
+  nonAttendingCount: number
 }
 
 export interface AttendanceCountsProps {
@@ -17,14 +21,14 @@ export interface AttendanceCountsProps {
 }
 
 interface SegmentSpec {
-  key: 'attend' | 'absent' | 'unanswered'
+  key: 'attend' | 'nonAttending'
   value: number
   /** Inline `background` value — CSS variable for brand, literal hex for others. */
   background: string
 }
 
 interface CardSpec {
-  key: 'attend' | 'absent' | 'unanswered'
+  key: 'attend' | 'nonAttending'
   label: string
   count: number
   /** Tailwind classes combining bg + fg tones. */
@@ -32,7 +36,7 @@ interface CardSpec {
 }
 
 /**
- * Renders attendance tallies as either a 3-up tone-tinted card grid (default)
+ * Renders attendance tallies as either a 2-up tone-tinted card grid (default)
  * or a horizontal stacked bar with legend.
  *
  * The bar variant uses inline `flex: n` on each segment so segment widths
@@ -50,11 +54,10 @@ export function AttendanceCounts({
         value: ev.attendIds.length,
         background: 'var(--kg-brand)',
       },
-      { key: 'absent', value: ev.absentIds.length, background: '#F3B4B4' },
       {
-        key: 'unanswered',
-        value: ev.unansweredCount,
-        background: '#F3D78A',
+        key: 'nonAttending',
+        value: ev.nonAttendingCount,
+        background: '#F3B4B4',
       },
     ]
     return (
@@ -72,8 +75,9 @@ export function AttendanceCounts({
         </div>
         <div className="flex justify-between mt-2 text-[11px]">
           <span className="text-success-fg">● 参加 {ev.attendIds.length}</span>
-          <span className="text-danger-fg">● 不参加 {ev.absentIds.length}</span>
-          <span className="text-warn-fg">● 未回答 {ev.unansweredCount}</span>
+          <span className="text-danger-fg">
+            ● 不参加 {ev.nonAttendingCount}
+          </span>
         </div>
       </div>
     )
@@ -87,21 +91,15 @@ export function AttendanceCounts({
       classes: 'bg-success-bg text-success-fg',
     },
     {
-      key: 'absent',
+      key: 'nonAttending',
       label: '不参加',
-      count: ev.absentIds.length,
+      count: ev.nonAttendingCount,
       classes: 'bg-danger-bg text-danger-fg',
-    },
-    {
-      key: 'unanswered',
-      label: '未回答',
-      count: ev.unansweredCount,
-      classes: 'bg-warn-bg text-warn-fg',
     },
   ]
 
   return (
-    <div className="grid grid-cols-3 gap-1.5">
+    <div className="grid grid-cols-2 gap-1.5">
       {cards.map((c) => (
         <div
           key={c.key}

--- a/apps/web/src/components/ui/status-pill.test.tsx
+++ b/apps/web/src/components/ui/status-pill.test.tsx
@@ -27,9 +27,9 @@ describe('StatusPill', () => {
     expect(el.className).toContain('bg-neutral-bg')
   })
 
-  // Regression: `status in STATUS_MAP` would return true for inherited keys
-  // like `toString` and try to render `Object.prototype.toString` as a mapping.
-  // `Object.hasOwn` + type guard must fall back to 下書き instead.
+  // Guardrail: Object.prototype-inherited keys like `toString` /
+  // `hasOwnProperty` must not leak through any lookup — the helper must
+  // treat them as unknown statuses and fall back to 下書き.
   it('Object.prototype 由来のキー (toString) でも 下書き にフォールバック', () => {
     render(<StatusPill status="toString" />)
     expect(screen.getByText('下書き')).toBeTruthy()

--- a/apps/web/src/components/ui/status-pill.tsx
+++ b/apps/web/src/components/ui/status-pill.tsx
@@ -1,44 +1,25 @@
-import { Pill, type PillSize, type PillTone } from './pill'
-
-type KnownStatus = 'published' | 'cancelled' | 'done'
+import { eventStatus } from '@/lib/event-status'
+import { Pill, type PillSize } from './pill'
 
 export interface StatusPillProps {
   /**
-   * Event lifecycle status. Known values map to predefined label/tone pairs;
-   * anything else falls back to 下書き (draft).
+   * Event lifecycle status. Known values map to predefined label/tone pairs
+   * via `eventStatus`; anything else falls back to 下書き (draft).
    */
-  status: KnownStatus | (string & {})
+  status: string | null | undefined
   size?: PillSize
-}
-
-interface StatusMapping {
-  label: string
-  tone: PillTone
-}
-
-const STATUS_MAP: Record<KnownStatus, StatusMapping> = {
-  published: { label: '公開', tone: 'success' },
-  cancelled: { label: '中止', tone: 'danger' },
-  done: { label: '終了', tone: 'info' },
-}
-
-const DEFAULT_MAPPING: StatusMapping = { label: '下書き', tone: 'neutral' }
-
-function isKnownStatus(status: string): status is KnownStatus {
-  return Object.hasOwn(STATUS_MAP, status)
 }
 
 /**
  * Pill variant that renders event lifecycle status in Japanese.
- *
- * Unknown `status` values render as 下書き so legacy/unexpected codes still
- * display something sensible.
+ * Label/tone mapping lives in `@/lib/event-status` so it stays a single
+ * source of truth for server-rendered pages and helpers.
  */
 export function StatusPill({ status, size }: StatusPillProps) {
-  const mapping = isKnownStatus(status) ? STATUS_MAP[status] : DEFAULT_MAPPING
+  const { label, tone } = eventStatus(status)
   return (
-    <Pill tone={mapping.tone} size={size}>
-      {mapping.label}
+    <Pill tone={tone} size={size}>
+      {label}
     </Pill>
   )
 }

--- a/apps/web/src/lib/event-status.test.ts
+++ b/apps/web/src/lib/event-status.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { eventStatus } from './event-status'
+
+describe('eventStatus', () => {
+  it("returns '公開' + success tone for 'published'", () => {
+    expect(eventStatus('published')).toEqual({
+      label: '公開',
+      tone: 'success',
+    })
+  })
+
+  it("returns '中止' + danger tone for 'cancelled'", () => {
+    expect(eventStatus('cancelled')).toEqual({
+      label: '中止',
+      tone: 'danger',
+    })
+  })
+
+  it("returns '終了' + info tone for 'done'", () => {
+    expect(eventStatus('done')).toEqual({ label: '終了', tone: 'info' })
+  })
+
+  it("returns '下書き' + neutral tone for 'draft'", () => {
+    expect(eventStatus('draft')).toEqual({
+      label: '下書き',
+      tone: 'neutral',
+    })
+  })
+
+  it("returns '下書き' + neutral tone for null", () => {
+    expect(eventStatus(null)).toEqual({ label: '下書き', tone: 'neutral' })
+  })
+
+  it("returns '下書き' + neutral tone for undefined", () => {
+    expect(eventStatus(undefined)).toEqual({
+      label: '下書き',
+      tone: 'neutral',
+    })
+  })
+
+  it("returns '下書き' + neutral tone for an unknown status string", () => {
+    expect(eventStatus('foo')).toEqual({ label: '下書き', tone: 'neutral' })
+  })
+})

--- a/apps/web/src/lib/event-status.ts
+++ b/apps/web/src/lib/event-status.ts
@@ -1,0 +1,21 @@
+import type { PillTone } from '@/components/ui'
+
+export interface EventStatusResult {
+  label: string
+  tone: PillTone
+}
+
+export function eventStatus(
+  status: string | null | undefined,
+): EventStatusResult {
+  switch (status) {
+    case 'published':
+      return { label: '公開', tone: 'success' }
+    case 'cancelled':
+      return { label: '中止', tone: 'danger' }
+    case 'done':
+      return { label: '終了', tone: 'info' }
+    default:
+      return { label: '下書き', tone: 'neutral' }
+  }
+}


### PR DESCRIPTION
## Summary
- 既存 4 ページ (`/events`, `/events/[id]`, `/events/new`, `/events/[id]/edit`) を Card / Pill / StatusPill / DescList / AttendanceCounts / Btn primitives で再スタイル
- `/events-archive` 新規実装 (過去イベント, `eventDate < today` JST, 開催日降順, フィルタ無し)
- `/events/[id]` 詳細を design.md:158-200 仕様に揃え、RSVP を **sticky 単一トグル**化（参加する ↔ 参加をキャンセル）
- `EventForm` を抽出 (`new`/`edit` 共通、Server Component、Card-wrapped)
- `eventStatus` pure helper を抽出 (`role-label.ts` と同じパターン)

## Phase breakdown
| # | 内容 | コミット |
|---|---|---|
| 1 | `eventStatus` helper + 7 tests | fd5ab1e |
| 2 | `EventForm` 抽出 + 3 tests (new 213→66, edit 242→97 lines) | 031ccbd |
| 3 | `/events` 一覧再スタイル | 9038f2c |
| 4 | `/events/[id]` 詳細再スタイル + sticky 単一トグル RSVP | ec7c464 |
| 5 | `/events-archive` 新規 | eb294ea |
| 6 | `/events` → `/events-archive` 導線 | 2e70003 |

## Notable changes
- **`AttendanceCounts.AttendanceEvent.attendIds`/`absentIds` の型を `readonly (number \| string)[]` に拡張** — DB-native string PK (`event_attendances.userId` is text) を受け付けるため。既存利用箇所は `.length` のみで型互換
- **comment フィールドを `/events/[id]` UI から削除** — DB column は残置、Server Action は `null` を受領（design.md:201-209 の RSVP シートは別 PR）
- **「公認/非公認」二択表示 → 「公認」のみ Pill 表示** （非公認は何も出さない）
- **`submitAttendance` Server Action のシグネチャは無変更** — UI のみ単一トグル化、`attend=true/false` を hidden input で送る

## Out of scope (確定済み)
- `/members` 一覧、`/events/[id]/admin` 集計 — Phase 2+ 新機能扱い
- RSVP ボトムシート (不参加/未定 + コメント) — 別 PR
- `/events-archive` のフィルタ (年/種類セレクタ等) — 後続で必要なら追加
- carryover Nit: `signIn` callback の deactivated user 拒否直接テスト — 別 PR

## Test plan
- [x] `pnpm --filter=@kagetra/web test` → **85/85 PASS** (既存 75 + event-status 7 + event-form 3)
- [x] `pnpm --filter=@kagetra/web check-types` → 0 errors
- [x] `pnpm --filter=@kagetra/web lint` → 0 warnings
- [x] events 配下のハードコード Tailwind 色 (`bg-(white|gray|green|red|blue|yellow)-`, `text-(gray|green|red|blue|yellow)-`) を grep で完全排除確認
- [ ] CI green
- [ ] dev 実機: `/events` 一覧 + 過去リンク表示
- [ ] dev 実機: `/events/[id]` sticky トグル 4 状態 (未回答→参加 / 参加→キャンセル / 一般会員締切後→警告 / admin締切後→CTA)
- [ ] dev 実機: `/events/new` `/events/[id]/edit` フォーム送信
- [ ] dev 実機: `/events-archive` 過去イベント表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)