### PR TITLE
fix(mail-inbox): wire list cards to detail page

### DIFF
--- a/apps/web/src/app/(app)/admin/mail-inbox/page.test.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/page.test.tsx
@@ -1,0 +1,71 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { closeTestDb, truncateAll } from '@/test-utils/db'
+import {
+  createAdmin,
+  createMailMessage,
+  createTournamentDraft,
+} from '@/test-utils/seed'
+import { mockAuthModule, setAuthSession } from '@/test-utils/auth-mock'
+
+// Mirrors [id]/page.test.tsx — `notFound` / `redirect` rethrow so the page
+// short-circuits cleanly under jsdom. The list page only redirects on
+// non-admin sessions and tests always set admin, so neither should fire.
+// `useRouter` is also stubbed because TriggerFetchButton (Client Component
+// rendered inside the list page) calls it during render under jsdom.
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(() => {
+    throw new Error('NEXT_NOT_FOUND')
+  }),
+  redirect: vi.fn((url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`)
+  }),
+  useRouter: vi.fn(() => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+  })),
+}))
+vi.mock('@/auth', () => mockAuthModule())
+
+const { default: MailInboxPage } = await import('./page')
+
+async function renderPage() {
+  const ui = await MailInboxPage()
+  return render(ui)
+}
+
+describe('admin/mail-inbox list page', () => {
+  beforeEach(async () => {
+    await truncateAll()
+  })
+  afterAll(async () => {
+    await closeTestDb()
+  })
+
+  it('DraftCard が詳細ページへのリンクで wrap されている', async () => {
+    // worklog 2026-05-09 で発見したリグレッション: 一覧 Card が href を
+    // 持たず、URL 直打ち以外では詳細ページに辿り着けなかった。Link wiring
+    // が壊れると承認フローへの入口が消えるので href の値まで固定する。
+    const admin = await createAdmin()
+    await setAuthSession({ id: admin.id, role: 'admin' })
+    const mail = await createMailMessage({ subject: 'list link wiring test' })
+    const draft = await createTournamentDraft({
+      messageId: mail.id,
+      status: 'pending_review',
+    })
+
+    await renderPage()
+
+    // Anchor by the status pill text, then walk up to the enclosing <a>.
+    const statusPill = screen.getByText('承認待ち')
+    const anchor = statusPill.closest('a')
+    expect(anchor).not.toBeNull()
+    expect(anchor!.getAttribute('href')).toBe(
+      `/admin/mail-inbox/${draft.id}`,
+    )
+  })
+})

--- a/apps/web/src/app/(app)/admin/mail-inbox/page.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/page.tsx
@@ -1,4 +1,5 @@
 import { auth } from '@/auth'
+import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { desc } from 'drizzle-orm'
 import { db } from '@/lib/db'
@@ -120,10 +121,11 @@ export default async function MailInboxPage() {
         },
       },
       // PR3 addition: 1:0..1 — at most one tournament_drafts row per mail
-      // (UNIQUE on message_id). PR4 will add the detail page + approval
-      // form; here we just need enough columns for the inline DraftCard.
+      // (UNIQUE on message_id). PR4 added the detail page + approval form;
+      // we select `id` so the inline card can wrap-link into /[id].
       draft: {
         columns: {
+          id: true,
           status: true,
           confidence: true,
           isCorrection: true,
@@ -251,7 +253,14 @@ export default async function MailInboxPage() {
                     {row.fromName ? `${row.fromName} <${row.fromAddress}>` : row.fromAddress}
                   </div>
                   <AttachmentList items={row.attachments} />
-                  {row.draft && <DraftCard draft={row.draft} />}
+                  {row.draft && (
+                    <Link
+                      href={`/admin/mail-inbox/${row.draft.id}`}
+                      className="block"
+                    >
+                      <DraftCard draft={row.draft} />
+                    </Link>
+                  )}
                 </div>
               </Card>
             )


### PR DESCRIPTION
## Summary
- `worklog 2026-05-09` の手動 UI 検証で発見: `/admin/mail-inbox` 一覧の Card に `href` が無く、URL 直打ち以外で `/admin/mail-inbox/[id]` (承認 / 却下 / 再抽出 / 既存 events 紐付け画面) に到達できなかった
- `<DraftCard>` を `<Link>` で wrap して、events / schedule の一覧と同じ pattern に揃える
- `DraftCard` 自体は touch せず、URL 構築は親 page の責務に保持 (`id` prop をコンポーネントに持ち込まずに別画面で再利用できるようにするため)

## Changes
- `apps/web/src/app/(app)/admin/mail-inbox/page.tsx`
  - `db.query.mailMessages.findMany` の `with.draft.columns` に `id: true` を追加 (URL 構築用)
  - `{row.draft && <DraftCard ... />}` を `<Link href={\`/admin/mail-inbox/${row.draft.id}\`} className="block">` で wrap
  - `import Link from 'next/link'` を追加
- `apps/web/src/app/(app)/admin/mail-inbox/page.test.tsx` 新規
  - 一覧 Server Component の RTL test。`screen.getByText('承認待ち').closest('a')` で wrapper anchor を取り、`href` が `/admin/mail-inbox/{draft.id}` を指すことを assert
  - `next/navigation` mock に `useRouter` も加える (TriggerFetchButton が Client Component で `useRouter` を呼ぶため)

## Test plan
- [x] `pnpm --filter @kagetra/web exec tsc --noEmit` 型チェック pass
- [x] `pnpm --filter @kagetra/web lint` No warnings or errors
- [x] `pnpm --filter @kagetra/web test` 21 files / 168 tests all pass (新規 page.test.tsx 含む)
- [ ] Manual: dev server で `/admin/mail-inbox` を開き、AI 抽出済み draft の Card をクリック → `/admin/mail-inbox/{id}` に遷移することを確認
- [ ] Codex レビュー (CLAUDE.md ルール 7 DoD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)