### PR TITLE
fix(mail-worker): hex-decode bytea returned by drizzle nested `with` so PDF attachments survive base64

### DIFF
--- a/apps/mail-worker/scripts/debug-pdf.ts
+++ b/apps/mail-worker/scripts/debug-pdf.ts
@@ -1,0 +1,453 @@
+/**
+ * Debug script for PDF base64 invalid bug (worklog 2026-05-08 + 2026-05-09
+ * carryover). Production pipeline returns
+ *   400 invalid_request_error: messages.0.content.0.pdf.source.base64.data:
+ *   The PDF specified was not valid.
+ * for ~60% of PDF attachments. The PDFs themselves are valid (verified via
+ * `file` → "PDF document, version 1.7, 4 page(s)") and DB-side bytea is
+ * intact (signature `255044462d312e37` = "%PDF-1.7" preserved), so this
+ * isolates whether the failure is inside Anthropic itself by posting the
+ * file directly with minimal wrapping — bypassing classifier.ts +
+ * extract/orchestrator.ts.
+ *
+ * Usage:
+ *   pnpm --filter @kagetra/mail-worker exec tsx scripts/debug-pdf.ts <pdf-path> [...more]
+ * Reads ANTHROPIC_API_KEY from <repo>/.env.
+ */
+import { config as loadDotenv } from 'dotenv'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { readFileSync } from 'node:fs'
+import Anthropic from '@anthropic-ai/sdk'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const envPath = resolve(here, '..', '..', '..', '.env')
+loadDotenv({ path: envPath })
+
+const apiKey = process.env.ANTHROPIC_API_KEY
+if (!apiKey) {
+  console.error(`ANTHROPIC_API_KEY missing in env (expected at ${envPath}).`)
+  process.exit(1)
+}
+const client = new Anthropic({ apiKey })
+
+async function probe(pdfPath: string): Promise<void> {
+  const buf = readFileSync(pdfPath)
+  const base64 = buf.toString('base64')
+  console.log(`\n=== ${pdfPath} ===`)
+  console.log(`  bytes=${buf.length}, base64.length=${base64.length}`)
+  console.log(`  first 16 bytes (hex) = ${buf.subarray(0, 16).toString('hex')}`)
+  console.log(`  base64 head/tail     = ${base64.slice(0, 24)} ... ${base64.slice(-24)}`)
+  try {
+    const res = await client.messages.create({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 200,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'document',
+              source: {
+                type: 'base64',
+                media_type: 'application/pdf',
+                data: base64,
+              },
+            },
+            {
+              type: 'text',
+              text: 'この PDF のタイトル (冒頭の見出し) を一行で答えてください。',
+            },
+          ],
+        },
+      ],
+    })
+    const text = res.content.find((b) => b.type === 'text')
+    const out = text && 'text' in text ? text.text : JSON.stringify(res.content)
+    console.log(`  SUCCESS: ${out}`)
+    console.log(`  tokens: in=${res.usage.input_tokens} out=${res.usage.output_tokens}`)
+  } catch (err) {
+    const e = err as { status?: number; error?: { error?: { type?: string } }; message?: string }
+    console.log(`  FAIL: status=${e.status ?? '?'} type=${e.error?.error?.type ?? '?'}`)
+    console.log(`        message: ${e.message?.slice(0, 250)}`)
+  }
+}
+
+// Production-like wrapping: invoke AnthropicSonnet46Extractor directly so we
+// see whether the failure is reproduced by mail-worker's actual configuration
+// (system prompt + cache_control + Zod-derived tools + forced tool_choice +
+// document block ordering). Loaded dynamically so the simple `probe()` mode
+// remains usable without compiling the rest of the package.
+async function probeProductionLike(pdfPath: string): Promise<void> {
+  const { AnthropicSonnet46Extractor } = await import(
+    '../src/classify/llm/anthropic.js'
+  )
+  const { buildSystemPrompt, PROMPT_VERSION } = await import(
+    '../src/classify/prompt.js'
+  )
+  const buf = readFileSync(pdfPath)
+  const base64 = buf.toString('base64')
+  console.log(`\n=== production-like wrapping: ${pdfPath} ===`)
+  const extractor = new AnthropicSonnet46Extractor({ apiKey: apiKey! })
+  try {
+    const res = await extractor.extract({
+      systemPrompt: buildSystemPrompt(),
+      promptVersion: PROMPT_VERSION,
+      emailMeta: {
+        subject: '横浜大会受付名簿テスト',
+        from: 'test@test.com',
+        date: new Date(),
+      },
+      emailBodyText: 'これは debug-pdf.ts の production-like 再現テストです。',
+      attachments: [{ kind: 'pdf', filename: 'test.pdf', base64 }],
+    })
+    console.log(`  SUCCESS: ${JSON.stringify(res.parsed).slice(0, 200)}`)
+    console.log(
+      `  tokens: in=${res.tokensInput} out=${res.tokensOutput} cost=$${res.costUsd}`,
+    )
+  } catch (err) {
+    const e = err as Error & { status?: number }
+    console.log(`  FAIL: status=${e.status ?? '?'}`)
+    console.log(`        message: ${e.message?.slice(0, 280)}`)
+  }
+}
+
+// Stage 3: pull `data` straight from mail_attachments and contrast with the
+// filesystem copy. Identical bytes → bug is elsewhere; differing bytes →
+// drizzle/pg are returning something other than a raw Buffer (hex-string
+// decoded as UTF-8, double-encoded base64, etc.).
+async function probeDbAttachment(
+  attachmentId: number,
+  fsPath: string,
+): Promise<void> {
+  const { getDb, closeDb } = await import('../src/db.js')
+  const { mailAttachments } = await import('@kagetra/shared/schema')
+  const { eq } = await import('drizzle-orm')
+  const db = getDb()
+  console.log(
+    `\n=== DB attachment id=${attachmentId} vs FS ${fsPath} ===`,
+  )
+  try {
+    const row = await db.query.mailAttachments.findFirst({
+      where: eq(mailAttachments.id, attachmentId),
+      columns: { data: true, filename: true, contentType: true },
+    })
+    if (!row) {
+      console.log('  not found')
+      return
+    }
+    const raw = row.data as unknown
+    console.log(`  drizzle returned typeof: ${typeof raw}`)
+    console.log(`  Buffer.isBuffer: ${Buffer.isBuffer(raw)}`)
+    console.log(
+      `  instanceof Uint8Array: ${raw instanceof Uint8Array}`,
+    )
+    const dbBuf = Buffer.isBuffer(raw)
+      ? raw
+      : Buffer.from(raw as ArrayLike<number>)
+    const fsBuf = readFileSync(fsPath)
+    console.log(`  DB length: ${dbBuf.length}, FS length: ${fsBuf.length}`)
+    console.log(`  DB first 16 hex: ${dbBuf.subarray(0, 16).toString('hex')}`)
+    console.log(`  FS first 16 hex: ${fsBuf.subarray(0, 16).toString('hex')}`)
+    console.log(`  DB last 16 hex : ${dbBuf.subarray(-16).toString('hex')}`)
+    console.log(`  FS last 16 hex : ${fsBuf.subarray(-16).toString('hex')}`)
+    console.log(
+      `  Buffer.compare(db, fs): ${Buffer.compare(dbBuf, fsBuf)} (0 = identical)`,
+    )
+
+    // Mimic classifier.ts:108 exactly and try Anthropic with that base64.
+    const base64 = Buffer.from(raw as ArrayLike<number>).toString('base64')
+    console.log(`  classifier-style base64 length: ${base64.length}`)
+    console.log(`  base64 head: ${base64.slice(0, 24)}`)
+    console.log(`  base64 tail: ${base64.slice(-24)}`)
+    try {
+      const res = await client.messages.create({
+        model: 'claude-sonnet-4-6',
+        max_tokens: 50,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'document',
+                source: {
+                  type: 'base64',
+                  media_type: 'application/pdf',
+                  data: base64,
+                },
+              },
+              {
+                type: 'text',
+                text: 'タイトルを一行で。',
+              },
+            ],
+          },
+        ],
+      })
+      const text = res.content.find((b) => b.type === 'text')
+      console.log(
+        `  Anthropic SUCCESS: ${text && 'text' in text ? text.text : '?'}`,
+      )
+    } catch (err) {
+      const e = err as { message?: string; status?: number }
+      console.log(`  Anthropic FAIL: status=${e.status ?? '?'} ${e.message?.slice(0, 200)}`)
+    }
+  } finally {
+    await closeDb()
+  }
+}
+
+// Stage 5: same wrapping as `classifyMail`, but selectively override
+// subject / body / date / filename to isolate which field triggers the
+// "The PDF specified was not valid" rejection.
+async function probeMailIsolated(
+  messageId: number,
+  isolate: {
+    subject?: string
+    body?: string
+    date?: Date
+    filename?: string
+    from?: string
+  },
+): Promise<void> {
+  const { getDb, closeDb } = await import('../src/db.js')
+  const { mailMessages } = await import('@kagetra/shared/schema')
+  const { eq } = await import('drizzle-orm')
+  const { AnthropicSonnet46Extractor } = await import(
+    '../src/classify/llm/anthropic.js'
+  )
+  const { buildSystemPrompt, PROMPT_VERSION } = await import(
+    '../src/classify/prompt.js'
+  )
+  const db = getDb()
+  try {
+    const mail = await db.query.mailMessages.findFirst({
+      where: eq(mailMessages.id, messageId),
+      with: {
+        attachments: {
+          columns: {
+            filename: true,
+            contentType: true,
+            data: true,
+            extractedText: true,
+            extractionStatus: true,
+          },
+        },
+      },
+    })
+    if (!mail) {
+      console.log('  mail not found')
+      return
+    }
+    const attachments: Array<
+      | { kind: 'pdf'; filename: string; base64: string }
+      | { kind: 'text'; filename: string; text: string }
+    > = []
+    for (const att of mail.attachments) {
+      if (
+        att.contentType === 'application/pdf' &&
+        att.extractionStatus !== 'failed'
+      ) {
+        const raw = att.data as unknown
+        // PATCH: drizzle's `with` returns bytea as `\x<hex>` string instead of
+        // Buffer. Detect that shape and hex-decode; fall back to the regular
+        // Buffer path for environments where drizzle behaves correctly.
+        const buf =
+          Buffer.isBuffer(raw)
+            ? raw
+            : typeof raw === 'string' && raw.startsWith('\\x')
+              ? Buffer.from(raw.slice(2), 'hex')
+              : Buffer.from(raw as ArrayLike<number>)
+        console.log(
+          `  [diag] raw typeof=${typeof raw} | patched buf.length=${buf.length} sig=${buf.subarray(0, 4).toString('hex')}`,
+        )
+        attachments.push({
+          kind: 'pdf',
+          filename: isolate.filename ?? att.filename,
+          base64: buf.toString('base64'),
+        })
+      } else if (att.extractedText) {
+        attachments.push({
+          kind: 'text',
+          filename: att.filename,
+          text: att.extractedText,
+        })
+      }
+    }
+    const extractor = new AnthropicSonnet46Extractor({ apiKey: apiKey! })
+    const desc = Object.entries(isolate)
+      .map(([k, v]) => `${k}=${typeof v === 'string' ? `"${v.slice(0, 30)}..."` : v}`)
+      .join(', ')
+    console.log(`\n=== isolated messageId=${messageId} [${desc || '(no overrides)'}] ===`)
+    try {
+      const res = await extractor.extract({
+        systemPrompt: buildSystemPrompt(),
+        promptVersion: PROMPT_VERSION,
+        emailMeta: {
+          subject: isolate.subject ?? mail.subject ?? '',
+          from: isolate.from ?? mail.fromAddress,
+          date: isolate.date ?? mail.receivedAt,
+        },
+        emailBodyText: isolate.body ?? mail.bodyText ?? mail.bodyHtml ?? '',
+        attachments,
+      })
+      console.log(`  SUCCESS: ${JSON.stringify(res.parsed).slice(0, 200)}`)
+    } catch (err) {
+      const e = err as Error & { status?: number }
+      console.log(`  FAIL: status=${e.status ?? '?'} ${e.message?.slice(0, 240)}`)
+    }
+  } finally {
+    await closeDb()
+  }
+}
+
+// Stage 6: same wrapping as `probeProductionLike`, but read PDF bytes from
+// the DB (mimicking what classifier.ts does) instead of the filesystem. If
+// this fails while FS variant succeeds, the bug lives in how drizzle/pg
+// hands the bytea over (e.g. shared ArrayBuffer subview).
+async function probeProductionLikeFromDb(attachmentId: number): Promise<void> {
+  const { getDb, closeDb } = await import('../src/db.js')
+  const { mailAttachments } = await import('@kagetra/shared/schema')
+  const { eq } = await import('drizzle-orm')
+  const { AnthropicSonnet46Extractor } = await import(
+    '../src/classify/llm/anthropic.js'
+  )
+  const { buildSystemPrompt, PROMPT_VERSION } = await import(
+    '../src/classify/prompt.js'
+  )
+  const db = getDb()
+  try {
+    const row = await db.query.mailAttachments.findFirst({
+      where: eq(mailAttachments.id, attachmentId),
+      columns: { data: true, filename: true },
+    })
+    if (!row) {
+      console.log('  attachment not found')
+      return
+    }
+    const raw = row.data as unknown
+    // EXACTLY mirror classifier.ts:108
+    const base64 = Buffer.from(raw as ArrayLike<number>).toString('base64')
+    console.log(
+      `\n=== production-like wrapping (DB-sourced base64) attachmentId=${attachmentId} ===`,
+    )
+    console.log(`  base64 length: ${base64.length}`)
+    const extractor = new AnthropicSonnet46Extractor({ apiKey: apiKey! })
+    try {
+      const res = await extractor.extract({
+        systemPrompt: buildSystemPrompt(),
+        promptVersion: PROMPT_VERSION,
+        emailMeta: {
+          subject: 'test',
+          from: 'test@test.com',
+          date: new Date(),
+        },
+        emailBodyText: 'short test body',
+        attachments: [{ kind: 'pdf', filename: 'test.pdf', base64 }],
+      })
+      console.log(`  SUCCESS: ${JSON.stringify(res.parsed).slice(0, 200)}`)
+    } catch (err) {
+      const e = err as Error & { status?: number }
+      console.log(`  FAIL: status=${e.status ?? '?'} ${e.message?.slice(0, 250)}`)
+    }
+  } finally {
+    await closeDb()
+  }
+}
+
+// Stage 4: run the real `classifyMail` against a stored mail_messages row.
+// This is the closest possible reproduction of the pipeline path short of
+// running `pnpm start` itself — same DB read, same builder, same extractor.
+async function probeClassifyMail(messageId: number): Promise<void> {
+  const { classifyMail } = await import('../src/classify/classifier.js')
+  const { AnthropicSonnet46Extractor } = await import(
+    '../src/classify/llm/anthropic.js'
+  )
+  const { getDb, closeDb } = await import('../src/db.js')
+  const db = getDb()
+  const llm = new AnthropicSonnet46Extractor({ apiKey: apiKey! })
+  console.log(`\n=== classifyMail messageId=${messageId} (force=true) ===`)
+  try {
+    const result = await classifyMail(db, messageId, llm, { force: true })
+    console.log(`  kind: ${result.kind}`)
+    if (result.kind === 'tournament' || result.kind === 'noise') {
+      const r = result as { result: { parsed: unknown; tokensInput: number; tokensOutput: number; costUsd: number } }
+      console.log(`  parsed: ${JSON.stringify(r.result.parsed).slice(0, 250)}`)
+      console.log(`  tokens: in=${r.result.tokensInput} out=${r.result.tokensOutput} cost=$${r.result.costUsd}`)
+    } else if (result.kind === 'failed') {
+      const r = result as { reason: string; rawResponse: string | null; attemptedModel: string }
+      console.log(`  reason: ${r.reason?.slice(0, 280)}`)
+      console.log(`  rawResponse: ${r.rawResponse?.slice(0, 280)}`)
+      console.log(`  model: ${r.attemptedModel}`)
+    }
+  } finally {
+    await closeDb()
+  }
+}
+
+const args = process.argv.slice(2)
+if (args.length === 0) {
+  console.error('Pass <pdf-path> [...more]    -- simple + production-like probes')
+  console.error('Or  --db <id> <pdf-path>     -- compare DB attachment vs FS file')
+  console.error('Or  --mail <message-id>      -- run classifyMail on a stored row')
+  process.exit(1)
+}
+if (args[0] === '--db-prod') {
+  const id = Number(args[1])
+  if (!Number.isInteger(id)) {
+    console.error('Usage: --db-prod <attachment-id>')
+    process.exit(1)
+  }
+  await probeProductionLikeFromDb(id)
+} else if (args[0] === '--mail') {
+  const id = Number(args[1])
+  if (!Number.isInteger(id)) {
+    console.error('Usage: --mail <message-id>')
+    process.exit(1)
+  }
+  await probeClassifyMail(id)
+} else if (args[0] === '--isolate') {
+  // --isolate <message-id> — run multiple probes to bisect which field triggers
+  // the rejection. Order: no-override baseline (= classifyMail) → subject only
+  // → body only → date only → filename only. Each call ~$0.01.
+  const id = Number(args[1])
+  if (!Number.isInteger(id)) {
+    console.error('Usage: --isolate <message-id>')
+    process.exit(1)
+  }
+  // baseline (should reproduce failure)
+  await probeMailIsolated(id, {})
+  // 4-field override (subject/body/date/filename) — still FAIL means trigger
+  // lives in fields outside that set (most likely `from`).
+  await probeMailIsolated(id, {
+    subject: 'test subject',
+    body: 'this is a short test body.',
+    date: new Date('2026-05-09T00:00:00Z'),
+    filename: 'test.pdf',
+  })
+  // 5-field override — adds `from`. If SUCCESS while #2 FAILs, from-address
+  // is the trigger.
+  await probeMailIsolated(id, {
+    subject: 'test subject',
+    body: 'this is a short test body.',
+    date: new Date('2026-05-09T00:00:00Z'),
+    filename: 'test.pdf',
+    from: 'test@example.com',
+  })
+  // from-only override (everything else from real mail) — confirms from is
+  // sufficient on its own.
+  await probeMailIsolated(id, { from: 'test@example.com' })
+} else if (args[0] === '--db') {
+  const id = Number(args[1])
+  const fsPath = args[2]
+  if (!Number.isInteger(id) || !fsPath) {
+    console.error('Usage: --db <attachment-id> <fs-pdf-path>')
+    process.exit(1)
+  }
+  await probeDbAttachment(id, fsPath)
+} else {
+  for (const p of args) {
+    await probe(p)
+    await probeProductionLike(p)
+  }
+}

--- a/apps/mail-worker/src/classify/classifier.ts
+++ b/apps/mail-worker/src/classify/classifier.ts
@@ -12,6 +12,36 @@ import {
 import { buildSystemPrompt, PROMPT_VERSION } from './prompt.js'
 
 /**
+ * Normalise a `bytea` column value into a `Buffer`.
+ *
+ * drizzle-orm/node-postgres returns bytea differently depending on the query
+ * shape: a direct `findFirst({ where })` returns a real `Buffer`, but a nested
+ * `findFirst({ with: { attachments: { columns: { data: true } } } })` returns
+ * the raw postgres hex-escape string (`"\\x255044462d..."`) — the same form
+ * `SELECT data FROM mail_attachments` would print in psql. Calling
+ * `Buffer.from(string)` on that re-interprets the literal `\x` characters as
+ * UTF-8 and corrupts the bytes, which manifests downstream as Anthropic's
+ *   400 invalid_request_error: messages.0.content.0.pdf.source.base64.data:
+ *   The PDF specified was not valid
+ * — verified 2026-05-11 via `apps/mail-worker/scripts/debug-pdf.ts` and the
+ * extended worklog. Hex-decode when we see that shape and fall back to the
+ * Buffer path so the helper stays correct under any future driver/version
+ * combination that hands raw bytes through directly.
+ */
+export function bytesFromBytea(raw: unknown): Buffer {
+  if (Buffer.isBuffer(raw)) return raw
+  if (typeof raw === 'string' && raw.startsWith('\\x')) {
+    return Buffer.from(raw.slice(2), 'hex')
+  }
+  if (raw instanceof Uint8Array) return Buffer.from(raw)
+  if (raw instanceof ArrayBuffer) return Buffer.from(raw)
+  // Other shapes (e.g. number[] from a third-party JSON serializer) fall
+  // through to the array-like overload. Cast is necessary because TS cannot
+  // narrow `unknown` past the runtime guards without a discriminator.
+  return Buffer.from(raw as ArrayLike<number>)
+}
+
+/**
  * What the classifier produced for a single mail. The pipeline (and the
  * `reextract` CLI) consume this discriminated union and decide which DB
  * mutations to issue: insert/update a draft row, bump
@@ -105,7 +135,7 @@ export async function classifyMail(
       attachmentsForLlm.push({
         kind: 'pdf',
         filename: att.filename,
-        base64: Buffer.from(att.data).toString('base64'),
+        base64: bytesFromBytea(att.data).toString('base64'),
       })
     } else if (att.extractedText) {
       // DOCX (or future text-extracted formats) — forward the extracted text.

--- a/apps/mail-worker/test/classify/bytes-from-bytea.test.ts
+++ b/apps/mail-worker/test/classify/bytes-from-bytea.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { bytesFromBytea } from '../../src/classify/classifier.js'
+
+/**
+ * Regression coverage for the PDF base64 bug discovered 2026-05-11.
+ *
+ * Background: drizzle-orm/node-postgres returns bytea differently depending on
+ * the query shape. A direct `findFirst()` returns a real `Buffer`, but a
+ * nested `findFirst({ with: { attachments: { columns: { data: true } } } })`
+ * returns the raw postgres hex-escape string (`"\\x<hex>"`). Calling
+ * `Buffer.from(string)` on that re-interprets the `\x...` characters as
+ * UTF-8 and corrupts the bytes, causing Anthropic to reject the PDF with
+ * `400 invalid_request_error: ... The PDF specified was not valid` for
+ * roughly 60% of attachments in the wild (worklog 2026-05-09 Phase 2 prove).
+ */
+describe('bytesFromBytea', () => {
+  it('returns the same Buffer instance when input is already a Buffer', () => {
+    const input = Buffer.from([0x25, 0x50, 0x44, 0x46])
+    const out = bytesFromBytea(input)
+    expect(out).toBe(input)
+  })
+
+  it('hex-decodes a postgres `\\x<hex>` escape string into the right bytes', () => {
+    // "\x25504446" should decode to "%PDF" (the PDF magic).
+    const out = bytesFromBytea('\\x25504446')
+    expect(out.toString('hex')).toBe('25504446')
+    expect(out.equals(Buffer.from('%PDF', 'utf8'))).toBe(true)
+  })
+
+  it('round-trips bytes → hex-escape → bytes losslessly so base64 stays canonical', () => {
+    // Models exactly what classifier.ts:108 hits in production: drizzle hands
+    // us the hex-escape; we must reach the same base64 as if we had the raw
+    // Buffer in hand. Anything else and Anthropic rejects the document.
+    const pdfHeader = Buffer.from([
+      0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37, // "%PDF-1.7"
+      0x0d, 0x0a, 0x25, 0xb5, 0xb5, 0xb5, 0xb5, 0x0d, // binary signature line
+    ])
+    const hexEscape = '\\x' + pdfHeader.toString('hex')
+    const out = bytesFromBytea(hexEscape)
+    expect(out.equals(pdfHeader)).toBe(true)
+    expect(out.toString('base64')).toBe(pdfHeader.toString('base64'))
+  })
+
+  it('falls back to Buffer.from for other input shapes (Uint8Array)', () => {
+    // Drizzle versions that hand bytea through as Uint8Array (no Buffer wrap)
+    // must still produce the right bytes — the helper covers this path
+    // defensively so it stays correct across driver upgrades.
+    const u8 = new Uint8Array([1, 2, 3, 4])
+    const out = bytesFromBytea(u8)
+    expect(Buffer.isBuffer(out)).toBe(true)
+    expect(out.equals(Buffer.from(u8))).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

worklog 2026-05-09 で発見した 🟠 carryover 「PDF base64 invalid bug 調査」の根本原因を特定し修正。Phase 2 プローブで `ai_failed` が 29/49 件 (60%) を占めていたのが本問題。

### 根本原因 (2026-05-11 切り分け確定)

`drizzle-orm/node-postgres` はクエリ形状で bytea の戻り値が変わる:

- `db.query.mailAttachments.findFirst({ where })` → **`Buffer`**
- `db.query.mailMessages.findFirst({ where, with: { attachments: { columns: { data: true } } } })` → **postgres hex-escape string `"\x255044..."`**

[classifier.ts:108](apps/mail-worker/src/classify/classifier.ts) は nested `with` で attachments を取得していたため後者の挙動を踏み、`Buffer.from(string)` がリテラル `\x` 文字を UTF-8 として解釈 → バイナリ破損 → Anthropic が下記で reject:

```
400 invalid_request_error: messages.0.content.0.pdf.source.base64.data:
The PDF specified was not valid
```

切り分け証跡 ([apps/mail-worker/scripts/debug-pdf.ts](apps/mail-worker/scripts/debug-pdf.ts)):

| 経路 | 結果 |
|---|---|
| FS read PDF → Anthropic 直接 | ✅ SUCCESS |
| FS read PDF → `extractor.extract()` (production wrapping) | ✅ SUCCESS |
| Direct `findFirst()` から取った bytes (= Buffer) → Anthropic | ✅ SUCCESS |
| Nested `with` 経由の bytes (= hex string) → 旧 classifier code | ❌ FAIL (再現) |
| Nested `with` + hex-decode patch | ✅ SUCCESS (tokens in=9830 / out=698 / cost=$0.04) |

## Changes

- **`src/classify/classifier.ts`** — 小さい `bytesFromBytea(raw: unknown): Buffer` を抽出 + export。
  - Buffer → そのまま identity 返却
  - `"\x..."` 文字列 → hex decode
  - `Uint8Array` / `ArrayBuffer` / array-like → `Buffer.from` フォールバック (将来 driver が直接 bytes を返す版に変わっても安全)
- **`test/classify/bytes-from-bytea.test.ts`** 新規 — 4 ケース unit test で 4 形状を pinning (Buffer identity / hex decode / round-trip base64 canonicality / Uint8Array fallback)
- **`scripts/debug-pdf.ts`** 新規 — 今回の切り分けに使った 6 段階 probe スクリプト (simple → production wrapping → DB vs FS 比較 → classifyMail → field isolation → DB+production wrap)。同じ症状が再発したときに再走できる diagnostics として永続化

## Test plan

- [x] `pnpm --filter @kagetra/mail-worker exec tsc --noEmit` pass
- [x] `pnpm --filter @kagetra/mail-worker test` 20 files / 174 tests all pass (新規 helper 4 件 + 既存 170 件 zero regression)
- [x] `classifyMail(db, 1, llm, { force: true })` (元 ai_failed) → `kind: noise` (= 当日案内、AI 判定正解) で SUCCESS、tokens 課金正常
- [ ] **マージ後**: 既存 dev DB の `ai_failed` 29 件を UI から「再抽出」して、新たに pending_review / noise / approved に分類されることを目視 (schema 変更なし、UPSERT 経路はそのまま)
- [ ] Codex レビュー (CLAUDE.md ルール 7 DoD)

## 影響範囲

- production-path に直接効く (Phase P3-A 最大の積み残し)
- 既存 `ai_failed` draft の DB データはそのまま、`reextract` で正常 classify に遷移する想定 (schema migration なし)
- worklog 5/8 carryover の「a/b/c 切り分け」(直接 base64 / 別 encoder / imap-client 経路) は **どれも原因でなかった**ことが副次的に確定

🤖 Generated with [Claude Code](https://claude.com/claude-code)