### PR TITLE
fix(mail-inbox): archive mail_messages when draft is finalized

### DIFF
--- a/apps/web/src/app/(app)/admin/mail-inbox/actions.test.ts
+++ b/apps/web/src/app/(app)/admin/mail-inbox/actions.test.ts
@@ -3,6 +3,7 @@ import { eq } from 'drizzle-orm'
 import {
   eventGroups,
   events,
+  mailMessages,
   mailWorkerJobs,
   tournamentDrafts,
 } from '@kagetra/shared/schema'
@@ -92,6 +93,12 @@ function buildApproveFormData(overrides: Partial<Record<string, string>> = {}) {
 async function getDraft(id: number) {
   return testDb.query.tournamentDrafts.findFirst({
     where: eq(tournamentDrafts.id, id),
+  })
+}
+
+async function getMail(id: number) {
+  return testDb.query.mailMessages.findFirst({
+    where: eq(mailMessages.id, id),
   })
 }
 
@@ -322,6 +329,28 @@ describe('admin/mail-inbox actions', () => {
       })
       expect(inserted?.eventGroupId).toBe(group.id)
     })
+
+    it('承認後、対応する mail_messages.status が archived になる', async () => {
+      // Regression for worklog 2026-05-12 session 3: approveDraft only
+      // updated tournament_drafts.status, so an `ai_failed` mail rescued
+      // through manual approval stayed at status='ai_failed' on the mail
+      // row, fooling the reextract CLI's filter into retargeting it.
+      const admin = await createAdmin()
+      await setAuthSession({ id: admin.id, role: 'admin' })
+      const mail = await createMailMessage({ status: 'ai_failed' })
+      const draft = await createTournamentDraft({
+        messageId: mail.id,
+        status: 'ai_failed',
+      })
+
+      await approveDraft(
+        draft.id,
+        buildApproveFormData({ title: '救済承認 + アーカイブ' }),
+      )
+
+      const afterMail = await getMail(mail.id)
+      expect(afterMail?.status).toBe('archived')
+    })
   })
 
   describe('rejectDraft', () => {
@@ -399,6 +428,22 @@ describe('admin/mail-inbox actions', () => {
         expect(after?.status).toBe(status)
       },
     )
+
+    it('却下後、対応する mail_messages.status が archived になる', async () => {
+      // Companion to approveDraft's archive test — rejection is also an
+      // operator-closed terminal state and must sync the mail row.
+      const admin = await createAdmin()
+      await setAuthSession({ id: admin.id, role: 'admin' })
+      const mail = await createMailMessage({ status: 'ai_done' })
+      const draft = await createTournamentDraft({ messageId: mail.id })
+
+      const fd = new FormData()
+      fd.set('rejection_reason', '対象外の通知')
+      await rejectDraft(draft.id, fd)
+
+      const afterMail = await getMail(mail.id)
+      expect(afterMail?.status).toBe('archived')
+    })
   })
 
   describe('linkDraftToEvent', () => {
@@ -467,6 +512,21 @@ describe('admin/mail-inbox actions', () => {
         expect(after?.status).toBe(status)
       },
     )
+
+    it('既存 events 紐付け後、対応する mail_messages.status が archived になる', async () => {
+      // Companion to approveDraft's archive test — linking is also an
+      // operator-closed terminal state and must sync the mail row.
+      const admin = await createAdmin()
+      await setAuthSession({ id: admin.id, role: 'admin' })
+      const mail = await createMailMessage({ status: 'ai_done' })
+      const draft = await createTournamentDraft({ messageId: mail.id })
+      const target = await createEvent({ title: 'Link target' })
+
+      await linkDraftToEvent(draft.id, target.id)
+
+      const afterMail = await getMail(mail.id)
+      expect(afterMail?.status).toBe('archived')
+    })
   })
 
   describe('reextractDraft', () => {

--- a/apps/web/src/app/(app)/admin/mail-inbox/actions.ts
+++ b/apps/web/src/app/(app)/admin/mail-inbox/actions.ts
@@ -8,6 +8,7 @@ import { db } from '@/lib/db'
 import {
   eventGroups,
   events,
+  mailMessages,
   mailWorkerJobs,
   tournamentDrafts,
 } from '@kagetra/shared/schema'
@@ -92,11 +93,25 @@ export async function approveDraft(draftId: number, formData: FormData) {
           inArray(tournamentDrafts.status, APPROVABLE_STATUSES),
         ),
       )
-      .returning({ id: tournamentDrafts.id })
+      .returning({
+        id: tournamentDrafts.id,
+        messageId: tournamentDrafts.messageId,
+      })
 
     if (updated.length === 0) {
       throw new Error('draft is not approvable')
     }
+
+    // Sync mail_messages.status when the draft is finalized so the inbox
+    // list filter and the mail-worker re-extract path can rely on a single
+    // source of truth for "operator-closed". Without this, drafts approved
+    // from an `ai_failed` mail leave the mail row stuck in `ai_failed` and
+    // the reextract CLI would (incorrectly) retarget it — see worklog
+    // 2026-05-12 session 3 (mail_id=12 orphan).
+    await tx
+      .update(mailMessages)
+      .set({ status: 'archived', updatedAt: sql`now()` })
+      .where(eq(mailMessages.id, updated[0]!.messageId))
   })
 
   revalidatePath('/admin/mail-inbox')
@@ -115,26 +130,37 @@ export async function rejectDraft(draftId: number, formData: FormData) {
   // event, and a previously linked draft being re-rejected keeps its history.
   // Status guard prevents flipping an already-finalized draft (approved /
   // rejected / superseded) via direct call.
-  const updated = await db
-    .update(tournamentDrafts)
-    .set({
-      status: 'rejected',
-      rejectedByUserId: session.user.id,
-      rejectedAt: sql`now()`,
-      rejectionReason: reason,
-      updatedAt: sql`now()`,
-    })
-    .where(
-      and(
-        eq(tournamentDrafts.id, draftId),
-        inArray(tournamentDrafts.status, APPROVABLE_STATUSES),
-      ),
-    )
-    .returning({ id: tournamentDrafts.id })
+  await db.transaction(async (tx) => {
+    const updated = await tx
+      .update(tournamentDrafts)
+      .set({
+        status: 'rejected',
+        rejectedByUserId: session.user.id,
+        rejectedAt: sql`now()`,
+        rejectionReason: reason,
+        updatedAt: sql`now()`,
+      })
+      .where(
+        and(
+          eq(tournamentDrafts.id, draftId),
+          inArray(tournamentDrafts.status, APPROVABLE_STATUSES),
+        ),
+      )
+      .returning({
+        id: tournamentDrafts.id,
+        messageId: tournamentDrafts.messageId,
+      })
 
-  if (updated.length === 0) {
-    throw new Error('draft is not rejectable')
-  }
+    if (updated.length === 0) {
+      throw new Error('draft is not rejectable')
+    }
+
+    // Sync mail_messages.status — see approveDraft for rationale.
+    await tx
+      .update(mailMessages)
+      .set({ status: 'archived', updatedAt: sql`now()` })
+      .where(eq(mailMessages.id, updated[0]!.messageId))
+  })
 
   revalidatePath('/admin/mail-inbox')
   revalidatePath(`/admin/mail-inbox/${draftId}`)
@@ -177,26 +203,37 @@ export async function linkDraftToEvent(draftId: number, eventId: number) {
   })
   if (!target) throw new Error('Event not found')
 
-  const updated = await db
-    .update(tournamentDrafts)
-    .set({
-      status: 'approved',
-      eventId,
-      approvedByUserId: session.user.id,
-      approvedAt: sql`now()`,
-      updatedAt: sql`now()`,
-    })
-    .where(
-      and(
-        eq(tournamentDrafts.id, draftId),
-        inArray(tournamentDrafts.status, APPROVABLE_STATUSES),
-      ),
-    )
-    .returning({ id: tournamentDrafts.id })
+  await db.transaction(async (tx) => {
+    const updated = await tx
+      .update(tournamentDrafts)
+      .set({
+        status: 'approved',
+        eventId,
+        approvedByUserId: session.user.id,
+        approvedAt: sql`now()`,
+        updatedAt: sql`now()`,
+      })
+      .where(
+        and(
+          eq(tournamentDrafts.id, draftId),
+          inArray(tournamentDrafts.status, APPROVABLE_STATUSES),
+        ),
+      )
+      .returning({
+        id: tournamentDrafts.id,
+        messageId: tournamentDrafts.messageId,
+      })
 
-  if (updated.length === 0) {
-    throw new Error('draft is not linkable')
-  }
+    if (updated.length === 0) {
+      throw new Error('draft is not linkable')
+    }
+
+    // Sync mail_messages.status — see approveDraft for rationale.
+    await tx
+      .update(mailMessages)
+      .set({ status: 'archived', updatedAt: sql`now()` })
+      .where(eq(mailMessages.id, updated[0]!.messageId))
+  })
 
   revalidatePath('/admin/mail-inbox')
   revalidatePath(`/admin/mail-inbox/${draftId}`)


### PR DESCRIPTION
## Summary

`approveDraft` / `rejectDraft` / `linkDraftToEvent` updated only `tournament_drafts.status`, leaving the parent `mail_messages.status` (typically `ai_done` or `ai_failed` at that point) untouched. This caused a data sync gap: an approved draft could coexist with an `ai_failed` mail row.

**Concrete example** (worklog 2026-05-12 session 3): `mail_id=12` has `tournament_drafts.status='approved'` but `mail_messages.status='ai_failed'`. Pre-existing inconsistency from when admin approved a draft whose parent mail had never recovered from the pre-PR #24 bytea bug.

**Downstream impact**: `apps/mail-worker/src/reextract.ts` selects mail rows by `mail_messages.status IN ('ai_done', 'ai_failed', 'archived', 'ai_processing')`. An operator-approved mail still in `ai_failed` would get re-AI-classified on the next reextract run, wasting an Anthropic call (and risking a `superseded` flip on the draft that `persistOutcome` then preserves anyway). One source of truth for "operator-closed" prevents this.

## Fix

Inside each action's transaction, additionally update the mail row to `archived`:

```ts
await tx
  .update(mailMessages)
  .set({ status: 'archived', updatedAt: sql`now()` })
  .where(eq(mailMessages.id, draft.messageId))
```

- `approveDraft`: already in a transaction (events.INSERT + drafts.UPDATE). One UPDATE added inside.
- `rejectDraft`, `linkDraftToEvent`: wrapped in `db.transaction(async (tx) => { ... })` so the two-row mutation is atomic.

The `tournament_drafts.UPDATE().returning(...)` is extended to also return `messageId`, so no extra SELECT is needed and the status-guard semantics are preserved (guard miss → empty returning → throw → tx rollback).

## Why 'archived' and not a new status

`mail_message_status` enum already has `archived`, and `apps/web/src/app/(app)/admin/mail-inbox/page.tsx` already maps it to 「アーカイブ」 in the STATUS_LABEL table. No schema migration needed.

## Scope notes

- **`reextractDraft` is NOT touched.** `classifyMail + persistOutcome` already updates `mail_messages.status` on the reextract path; PR #24 effect measurement confirmed 29 mails flipping `ai_failed → ai_done` correctly through that path.
- **Existing orphans are NOT backfilled.** `mail_id=12` and any siblings in dev DB stay in `ai_failed` after this PR. Backfill is a one-shot data migration concern (handful of rows in dev, zero in fresh prod) and folding it into this fix would mix code change and data change. Open as a separate carryover.
- **`superseded` drafts are NOT touched** (noise reclassification path). The mail itself was successfully AI-processed; `ai_done` is correct.

## Test plan

- [x] `pnpm --filter @kagetra/web check-types` — clean
- [x] `pnpm --filter @kagetra/web test src/app/(app)/admin/mail-inbox/actions.test.ts` — 47 tests pass (44 existing + 3 new for approve / reject / link → mail archived)
- [x] `pnpm --filter @kagetra/web test` — 21 files / 174 tests pass (full regression)
- [x] `pnpm --filter @kagetra/web lint` — 0 warnings

## Reference

- Worklog 2026-05-12 セッション 3「mail_messages.status と tournament_drafts.status の sync gap (新規 carryover)」
- mail_id=12 (横浜大会結果報告) が discovered orphan の代表例

🤖 Generated with [Claude Code](https://claude.com/claude-code)