### PR TITLE
feat(mail-worker): add --status= CSV filter to reextract CLI

### DIFF
--- a/apps/mail-worker/src/reextract.ts
+++ b/apps/mail-worker/src/reextract.ts
@@ -44,13 +44,14 @@ import { loadLlmConfig } from './config.js'
  * mail. The CLI exits with a non-zero code if any mail failed so cron-style
  * invocations can surface the partial failure.
  */
+const VALID_STATUSES = ['ai_done', 'ai_failed', 'archived', 'ai_processing'] as const
+
 interface ReextractArgs {
   since: Date | null
   includePrefilterNoise: boolean
+  statuses: readonly (typeof VALID_STATUSES)[number][]
   help: boolean
 }
-
-const VALID_STATUSES = ['ai_done', 'ai_failed', 'archived', 'ai_processing'] as const
 
 // `^YYYY-MM-DD$`. The format check is shape-only; we still round-trip the
 // resulting Date back into JST y/m/d to catch values like `2026-04-31` that
@@ -64,6 +65,7 @@ function parseArgs(argv: readonly string[]): ReextractArgs {
   const args: ReextractArgs = {
     since: null,
     includePrefilterNoise: false,
+    statuses: [...VALID_STATUSES],
     help: false,
   }
   for (const a of argv.slice(2)) {
@@ -99,6 +101,22 @@ function parseArgs(argv: readonly string[]): ReextractArgs {
         throw new Error(`--since is not a valid calendar day: ${v}`)
       }
       args.since = date
+    } else if (a.startsWith('--status=')) {
+      const v = a.slice('--status='.length)
+      const parsed = v
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+      if (parsed.length === 0) {
+        throw new Error('--status must be a non-empty CSV')
+      }
+      for (const s of parsed) {
+        if (!(VALID_STATUSES as readonly string[]).includes(s)) {
+          throw new Error(`unknown status: ${s}`)
+        }
+      }
+      // Validated above — narrow string[] → typed status union array.
+      args.statuses = parsed as (typeof VALID_STATUSES)[number][]
     } else {
       // Unknown flag — fail loudly rather than silently no-op. Without this
       // a typo like `--include-prefiler-noise` would just be dropped and
@@ -141,7 +159,7 @@ function jstYearMonthDay(date: Date): {
 
 function printUsage(): void {
   // eslint-disable-next-line no-console
-  console.log(`Usage: tsx apps/mail-worker/src/reextract.ts --since=YYYY-MM-DD [--include-prefilter-noise]
+  console.log(`Usage: tsx apps/mail-worker/src/reextract.ts --since=YYYY-MM-DD [--include-prefilter-noise] [--status=ai_processing,ai_failed]
 
 Re-classifies all mails in (ai_done, ai_failed, archived, ai_processing) status
 with received_at >= --since. The pre-filter noise check is bypassed
@@ -154,6 +172,15 @@ model output); drafts already approved or rejected by an admin are preserved.
       change (venue allow-list, sender update, etc.) when previously-rejected
       mails should be evaluated by the AI. Default off — these rows are
       otherwise outside the selection.
+
+  --status=STATUS1,STATUS2,...
+      Restrict to a subset of mail_messages.status (CSV).
+      Valid values: ai_done, ai_failed, archived, ai_processing.
+      Default: all four. Combine with --since for narrow re-runs
+      (e.g. --status=ai_processing to retry crashed worker rows).
+      Note: --status only filters the AI-touched leg of the selection;
+      --include-prefilter-noise still adds (fetched + noise) rows
+      independently.
 
 Requires ANTHROPIC_API_KEY in env (loaded via dotenv from repo root).
 `)
@@ -175,17 +202,21 @@ Requires ANTHROPIC_API_KEY in env (loaded via dotenv from repo root).
  */
 export async function selectReextractTargets(
   db: Db,
-  args: { since: Date; includePrefilterNoise: boolean },
+  args: {
+    since: Date
+    includePrefilterNoise: boolean
+    statuses: readonly (typeof VALID_STATUSES)[number][]
+  },
 ): Promise<Array<{ id: number; messageId: string; subject: string | null }>> {
   const statusClause = args.includePrefilterNoise
     ? or(
-        inArray(mailMessages.status, [...VALID_STATUSES]),
+        inArray(mailMessages.status, [...args.statuses]),
         and(
           eq(mailMessages.status, 'fetched'),
           eq(mailMessages.classification, 'noise'),
         ),
       )
-    : inArray(mailMessages.status, [...VALID_STATUSES])
+    : inArray(mailMessages.status, [...args.statuses])
   return db
     .select({
       id: mailMessages.id,
@@ -216,6 +247,7 @@ async function main(): Promise<number> {
     const targets = await selectReextractTargets(db, {
       since: args.since,
       includePrefilterNoise: args.includePrefilterNoise,
+      statuses: args.statuses,
     })
 
     // eslint-disable-next-line no-console

--- a/apps/mail-worker/test/reextract.test.ts
+++ b/apps/mail-worker/test/reextract.test.ts
@@ -49,6 +49,55 @@ describe('parseReextractArgs', () => {
     expect(args.includePrefilterNoise).toBe(false)
     expect(args.help).toBe(false)
     expect(args.since?.toISOString()).toBe('2026-03-31T15:00:00.000Z')
+    expect(args.statuses).toEqual(['ai_done', 'ai_failed', 'archived', 'ai_processing'])
+  })
+
+  it('defaults statuses to all VALID_STATUSES', () => {
+    const args = parseReextractArgs(['node', 'reextract.ts', '--since=2026-04-01'])
+    expect(args.statuses).toHaveLength(4)
+    expect(args.statuses).toEqual(['ai_done', 'ai_failed', 'archived', 'ai_processing'])
+  })
+
+  it('parses --status=ai_processing as single-element array', () => {
+    const args = parseReextractArgs([
+      'node',
+      'reextract.ts',
+      '--since=2026-04-01',
+      '--status=ai_processing',
+    ])
+    expect(args.statuses).toEqual(['ai_processing'])
+  })
+
+  it('parses --status=ai_done,ai_failed as multi-element array (preserves order)', () => {
+    const args = parseReextractArgs([
+      'node',
+      'reextract.ts',
+      '--since=2026-04-01',
+      '--status=ai_done,ai_failed',
+    ])
+    expect(args.statuses).toEqual(['ai_done', 'ai_failed'])
+  })
+
+  it('throws on --status=invalid_status with the invalid name in the error message', () => {
+    expect(() =>
+      parseReextractArgs([
+        'node',
+        'reextract.ts',
+        '--since=2026-04-01',
+        '--status=invalid_status',
+      ]),
+    ).toThrow(/invalid_status/)
+  })
+
+  it('throws on empty --status= with a "non-empty CSV" message', () => {
+    expect(() =>
+      parseReextractArgs([
+        'node',
+        'reextract.ts',
+        '--since=2026-04-01',
+        '--status=',
+      ]),
+    ).toThrow(/non-empty CSV/)
   })
 
   it('sets includePrefilterNoise=true when --include-prefilter-noise is passed', () => {
@@ -65,6 +114,7 @@ describe('parseReextractArgs', () => {
     const args = parseReextractArgs(['node', 'reextract.ts', '--help'])
     expect(args.help).toBe(true)
     expect(args.includePrefilterNoise).toBe(false)
+    expect(args.statuses).toEqual(['ai_done', 'ai_failed', 'archived', 'ai_processing'])
   })
 
   it('rejects calendar-day overflow like 2026-04-31 even though Date silently rolls it forward', () => {
@@ -140,6 +190,7 @@ describe('reextract CLI entrypoint', () => {
     expect(result.status).toBe(0)
     expect(result.stdout).toContain('Usage:')
     expect(result.stdout).toContain('--include-prefilter-noise')
+    expect(result.stdout).toContain('--status=')
   }, 30_000)
 })
 
@@ -178,6 +229,7 @@ describe('selectReextractTargets', () => {
     const targets = await selectReextractTargets(testDb, {
       since: SINCE,
       includePrefilterNoise: false,
+      statuses: ['ai_done', 'ai_failed', 'archived', 'ai_processing'],
     })
 
     expect(targets).toHaveLength(4)
@@ -205,6 +257,7 @@ describe('selectReextractTargets', () => {
     const targets = await selectReextractTargets(testDb, {
       since: SINCE,
       includePrefilterNoise: false,
+      statuses: ['ai_done', 'ai_failed', 'archived', 'ai_processing'],
     })
     expect(targets).toHaveLength(0)
   })
@@ -224,6 +277,7 @@ describe('selectReextractTargets', () => {
     const targets = await selectReextractTargets(testDb, {
       since: SINCE,
       includePrefilterNoise: true,
+      statuses: ['ai_done', 'ai_failed', 'archived', 'ai_processing'],
     })
     expect(new Set(targets.map((t) => t.messageId))).toEqual(
       new Set(['<prefilter-noise@example.com>', '<done-1@example.com>']),
@@ -244,6 +298,7 @@ describe('selectReextractTargets', () => {
     const targets = await selectReextractTargets(testDb, {
       since: SINCE,
       includePrefilterNoise: true,
+      statuses: ['ai_done', 'ai_failed', 'archived', 'ai_processing'],
     })
     expect(targets).toHaveLength(0)
   })
@@ -265,8 +320,41 @@ describe('selectReextractTargets', () => {
     const targets = await selectReextractTargets(testDb, {
       since: SINCE,
       includePrefilterNoise: false,
+      statuses: ['ai_done', 'ai_failed', 'archived', 'ai_processing'],
     })
     expect(targets).toHaveLength(1)
     expect(targets[0]!.messageId).toBe('<in-window@example.com>')
+  })
+
+  it('respects statuses subset (only ai_processing rows returned even when ai_done present)', async () => {
+    await seedMail({
+      messageId: '<done-1@example.com>',
+      status: 'ai_done',
+      classification: 'tournament',
+    })
+    await seedMail({
+      messageId: '<failed-1@example.com>',
+      status: 'ai_failed',
+      classification: null,
+    })
+    await seedMail({
+      messageId: '<processing-1@example.com>',
+      status: 'ai_processing',
+      classification: null,
+    })
+    await seedMail({
+      messageId: '<archived-1@example.com>',
+      status: 'archived',
+      classification: 'tournament',
+    })
+
+    const targets = await selectReextractTargets(testDb, {
+      since: SINCE,
+      includePrefilterNoise: false,
+      statuses: ['ai_processing'],
+    })
+
+    expect(targets).toHaveLength(1)
+    expect(targets[0]!.messageId).toBe('<processing-1@example.com>')
   })
 })


### PR DESCRIPTION
## Why
🔴 mail-worker Windows native crash 調査 (id=125, status=ai_processing) を進めるとき、id=125 だけ pinpoint で再走したいが、現状の `reextract.ts` には status filter がなく `--since=2026-04-30` だと他 22 件 (ai_done 19 + archived 3) もまとめて走ってしまう (Anthropic API call ~$0.35 の無駄、approved/rejected draft は preserved だが API call は不要)。

worklog 5/12 セッション 3 carryover の 🟡 `reextract.ts` に `--status=...` filter 追加 を消化することで、crash 調査が安価 (1 mail = ~$0.015) に進められる。

## What
- `parseArgs` に `--status=ai_done,ai_failed` 形式 CSV を追加
  - 空 `--status=` → `throw "--status must be a non-empty CSV"`
  - 不正値 `--status=foo` → `throw "unknown status: foo"`
  - 重複 `--status=a --status=b` は last-wins (既存 `--since` と同挙動)
  - 未指定なら `VALID_STATUSES = ['ai_done', 'ai_failed', 'archived', 'ai_processing']` 全て (後方互換)
- `selectReextractTargets` の args 型に `statuses` を追加、`inArray(mailMessages.status, [...args.statuses])` で query 構築
  - `--include-prefilter-noise` の OR leg (`fetched + classification=noise`) は不変
  - 両 flag は直交独立、composable
- `printUsage` に新 flag 説明 + `--include-prefilter-noise` との non-interaction note を追加 (operator-facing)

## How tested
- `parseReextractArgs` に 5 ケース追加: defaults / single value / multi-value 順序保持 / invalid status throw / empty throw
- `selectReextractTargets` に 1 ケース追加: subset filter (`statuses: ['ai_processing']` で他 status 除外)
- 既存 ケースに defaults statuses regression guard を追加
- CLI entrypoint --help test に `--status=` 文字列 contain 確認を追加
- `pnpm --filter @kagetra/mail-worker test -- reextract` で 12 → **18 tests pass**
- `pnpm --filter @kagetra/mail-worker check-types` + `pnpm --filter @kagetra/shared check-types` clean
- 手動 CLI smoke: `tsx src/reextract.ts --help` で flag 説明表示確認、`--status=invalid_status` で exit 1 + `unknown status: invalid_status` 出力確認、`--status=` で exit 1 + `non-empty CSV` 出力確認

## Out of scope (本 PR には含めない)
- 🔴 mail-worker Windows native crash の再現テスト本体 (本 PR merge 後、別 plan で `--since=2026-04-30 --status=ai_processing` を打って id=125 の挙動観察)
- pre-filter noise leg (`fetched + classification=noise`) の挙動変更
- `--message-id` 限定など他の絞り込み機能

## Test plan checklist
- [x] Unit tests pass (18/18)
- [x] Type check pass (mail-worker + shared)
- [x] CLI --help shows new flag with non-interaction note
- [x] `--status=invalid_status` rejected with `unknown status: invalid_status`
- [x] `--status=` (empty) rejected with `non-empty CSV`
- [x] Backward compatible (未指定 = 既存挙動)

🤖 Generated with [Claude Code](https://claude.com/claude-code)