### PR TITLE
docs(handover): 引き継ぎ書 3 訂正 (reextract / db:push --force / 別環境引き継ぎ)

### DIFF
--- a/docs/dev/local-dev-setup.md
+++ b/docs/dev/local-dev-setup.md
@@ -295,7 +295,7 @@ dev DB は各マシンで Docker Compose で独立に起動し、データは **
 
 - prod は別物 (Lightsail Postgres)、dev はあくまでローカル動作確認用で永続性が要らない
 - 各マシンで `pnpm --filter @kagetra/shared db:push --force` (1-3 節参照) でスキーマだけ揃え、mail / draft / event 等のデータは `mail-worker` を走らせて環境ごとに生成し直す方が単純
-- 環境差分 (Yahoo IMAP App Password、Anthropic API key、Cookie 等) も同様、`<repo root>/.env` と `apps/web/.env.local` は手動コピー
+- 環境差分 (Yahoo IMAP App Password、Anthropic API key、Cookie 等) も同様、1-2 節の env 3 ファイル (`<repo root>/.env` / `apps/web/.env.local` / `packages/shared/.env`) を手動コピー (`packages/shared/.env` は drizzle-kit の `db:push` / `db:generate` に必要、これがないと別環境で `DATABASE_URL` 未設定で詰まる)
 
 ### 6-2. (任意) pg_dump で前環境 DB を移植する場合
 

--- a/docs/dev/local-dev-setup.md
+++ b/docs/dev/local-dev-setup.md
@@ -316,7 +316,7 @@ docker exec -i kagetra-db psql -U kagetra kagetra < /tmp/dev-snapshot.sql
 - `bytea` 列 (`mail_attachments.data`) も含まれて転送される (1 mail あたり ~1MB、PDF 添付の多い数十通で数十 MB)
 - `mail_worker_jobs.claimed_at` は前環境のローカル時刻のまま残るが、`recoverStaleClaimedJobs` の 1h 閾値 (`apps/mail-worker/src/jobs.ts`) を過ぎていれば次回 dispatcher tick で `pending` に戻るので大抵問題なし (`mail_worker_runs` は履歴行で stale 回収対象外)
 - secret (`ANTHROPIC_API_KEY` / `YAHOO_IMAP_APP_PASSWORD` 等) は DB に格納されないので dump には含まれない — 新環境で別途 `<repo root>/.env` を作成
-- 復元手順は **空 DB から直接 psql restore** が一番 clean。pg_dump の default 出力は `CREATE TABLE` + `INSERT` 両方含むので、空 volume から `up -d db` した直後の DB に `psql ... < snapshot.sql` を打てば schema + data が一気に再構築される。`db:push --force` を先に打つと `CREATE TABLE` 衝突になるので **打たない**。volume が以前のもので残っていたら `docker compose down -v db` で消してから `up -d db`
+- 復元手順は **空 DB から直接 psql restore** が一番 clean。pg_dump の default 出力は `CREATE TABLE` + `INSERT` 両方含むので、空 volume から `up -d db` した直後の DB に `psql ... < snapshot.sql` を打てば schema + data が一気に再構築される。`db:push --force` を先に打つと `CREATE TABLE` 衝突になるので **打たない**。volume が以前のもので残っていたら `docker compose -f docker/docker-compose.yml down -v` で消してから `up -d db` (起動側 1-3 節と同じ compose file 指定、`down -v` はサービス引数を取らないので project 全体を down する)
 
 ### 6-3. mail-worker 再走で draft 再生成
 

--- a/docs/dev/local-dev-setup.md
+++ b/docs/dev/local-dev-setup.md
@@ -86,10 +86,10 @@ YAHOO_IMAP_APP_PASSWORD=...
 
 ```bash
 docker compose -f docker/docker-compose.yml up -d db
-pnpm --filter @kagetra/shared db:push --force   # TTY 不要にするため --force 必須
+pnpm --filter @kagetra/shared db:push --force   # 確認 prompt を skip するため (= destructive change も silent に適用)
 ```
 
-`--force` は drizzle-kit が「変更を確認するか？」プロンプトを出すのを回避するためで、開発 DB のみで使う。dev DB が空 or 既知のスキーマなら破壊なしで適用される。
+`--force` は drizzle-kit の「destructive change を実施するか?」確認プロンプトを **skip する** flag。skip 対象は `DROP COLUMN` / `NOT NULL 変更` / `column type 変更` 等の破壊操作も含むため、知らない schema 差分があると **silent にデータが壊れる**。**dev DB かつゼロからセットアップ時 (= 全テーブル create) は安全**、既存 dev DB に打つときは `pnpm --filter @kagetra/shared db:generate` で diff SQL を事前確認するのが安全。本番 DB には絶対使わず、`packages/shared/drizzle/` の migration SQL を `psql` で適用する。
 
 ---
 
@@ -194,7 +194,7 @@ pnpm --filter @kagetra/mail-worker start --since=2026-04-01
 
 - **承認** → `events` に INSERT、draft.status を `approved` へ
 - **却下** → 理由付きで `rejected` へ
-- **再抽出** → 同じメールを Claude に再投入 (新規 draft 行を作って superseded リンク)
+- **再抽出** → 同じメールを Claude に再投入。実装は **既存 draft 行を `persistOutcome` で UPSERT 上書き** (`prompt_version` / `ai_model` / `ai_raw_response` 等が新値で更新)。approved / rejected 状態の draft は保護されて上書きされない。`superseded_by_draft_id` カラムは「ある draft を別 draft の訂正版として手動で紐付ける」用に設計されたが現状の UI からは設定されない (常に NULL)。再抽出で AI 判定が tournament → noise に反転した場合は、既存 draft の `status` だけが `superseded` に flip され、このカラム自体は触れられない (`apps/mail-worker/src/classify/classifier.ts` noise branch)。
 - **既存イベントに紐付ける** → `linked_event_id` を設定
 
 各操作は `apps/web/src/app/(app)/admin/mail-inbox/actions.ts` の Server Action で実装。terminal status (approved/rejected/superseded) からの遷移は guard でブロック。
@@ -284,7 +284,52 @@ pnpm --filter @kagetra/mail-worker start --since=2026-04-01
 
 ---
 
-## 6. 関連ドキュメント
+## 6. 別環境引き継ぎ (家 ↔ 会社)
+
+家・会社の 2 マシン間でこのリポジトリを引き継ぐときの前提と手順。
+
+### 6-1. DB は環境ごとローカル
+
+dev DB は各マシンで Docker Compose で独立に起動し、データは **別環境間で共有しない** 前提。
+理由:
+
+- prod は別物 (Lightsail Postgres)、dev はあくまでローカル動作確認用で永続性が要らない
+- 各マシンで `pnpm --filter @kagetra/shared db:push --force` (1-3 節参照) でスキーマだけ揃え、mail / draft / event 等のデータは `mail-worker` を走らせて環境ごとに生成し直す方が単純
+- 環境差分 (Yahoo IMAP App Password、Anthropic API key、Cookie 等) も同様、`<repo root>/.env` と `apps/web/.env.local` は手動コピー
+
+### 6-2. (任意) pg_dump で前環境 DB を移植する場合
+
+「直近 1 ヶ月の mail-worker プローブ結果をそのまま使いたい」「approved/rejected で運用した state を維持したい」などで前環境の dev DB を持っていくなら:
+
+```bash
+# 前環境で snapshot を取る
+docker exec kagetra-db pg_dump -U kagetra kagetra > /tmp/dev-snapshot.sql
+# scp /tmp/dev-snapshot.sql to new env
+
+# 新環境で復元
+docker compose -f docker/docker-compose.yml up -d db
+docker exec -i kagetra-db psql -U kagetra kagetra < /tmp/dev-snapshot.sql
+```
+
+注意点:
+
+- `bytea` 列 (`mail_attachments.data`) も含まれて転送される (1 mail あたり ~1MB、PDF 添付の多い数十通で数十 MB)
+- `mail_worker_jobs.claimed_at` は前環境のローカル時刻のまま残るが、`recoverStaleClaimedJobs` の 1h 閾値 (`apps/mail-worker/src/jobs.ts`) を過ぎていれば次回 dispatcher tick で `pending` に戻るので大抵問題なし (`mail_worker_runs` は履歴行で stale 回収対象外)
+- secret (`ANTHROPIC_API_KEY` / `YAHOO_IMAP_APP_PASSWORD` 等) は DB に格納されないので dump には含まれない — 新環境で別途 `<repo root>/.env` を作成
+- 復元手順は **空 DB から直接 psql restore** が一番 clean。pg_dump の default 出力は `CREATE TABLE` + `INSERT` 両方含むので、空 volume から `up -d db` した直後の DB に `psql ... < snapshot.sql` を打てば schema + data が一気に再構築される。`db:push --force` を先に打つと `CREATE TABLE` 衝突になるので **打たない**。volume が以前のもので残っていたら `docker compose down -v db` で消してから `up -d db`
+
+### 6-3. mail-worker 再走で draft 再生成
+
+DB を共有しない場合、draft / mail データは:
+
+- 各環境で `pnpm --filter @kagetra/mail-worker start --since=YYYY-MM-DD` を打って自分の DB に作る
+- Anthropic API key と Yahoo IMAP App Password が両環境に揃っていれば、同じメール群から (確率的に同じ) draft が出る
+- 「家でだけ approved にした draft」を会社に持っていきたい場合は 6-2 の pg_dump 経路を選ぶ
+- 範囲を絞った再走には PR #28 で入った `reextract --status=...` filter が使える (例: `pnpm --filter @kagetra/mail-worker exec tsx src/reextract.ts --since=2026-04-30 --status=ai_processing` で stuck row だけ retry)
+
+---
+
+## 7. 関連ドキュメント
 
 - [docs/worklog.md](../worklog.md) — セッション間の作業ログ
 - [docs/features/mail-tournament-import/](../features/mail-tournament-import/) — PR1〜PR5 の plan / decision


### PR DESCRIPTION
## Why
carryover に残っていた doc 訂正系 3 本を 1 PR で消化:
1. 🟡 reextract 仕様の doc 訂正 (worklog 5/8 + 引き継ぎ書 5/7)
2. 🟡 `db:push --force` 引き継ぎ書記述の正確化
3. 🟡 別環境引き継ぎ手順整理 (DB は環境ごとローカル / pg_dump オプション併記)

引き継ぎ書 (`docs/dev/local-dev-setup.md`) の操作説明が実装と乖離していて、新しい環境セットアップで詰まる / 誤解する原因になっていた。worklog 履歴は historical context として残置、引き継ぎ書側のみ訂正。

## What
- **再抽出仕様 (L197)**: 「新規 draft 行を作って superseded リンク」→ 実装通り「既存 draft 行を `persistOutcome` で UPSERT 上書き」に訂正。approved/rejected 保護の挙動と `superseded_by_draft_id` カラムの実際の semantics (手動訂正版リンク用に設計、現状 UI 未配線、noise 反転時は status のみ flip) も明記
- **db:push --force (L89/L92)**: 「TTY 不要 / 破壊なし」→ 確認プロンプト skip だけで destructive change (`DROP COLUMN` / `NOT NULL 変更` / `column type 変更`) も silent に適用される旨を明示。安全な使い方 (ゼロからセットアップ時 or `db:generate` で diff 事前確認) も書き、本番 DB 禁止を strong に明記
- **新 6 節「別環境引き継ぎ (家 ↔ 会社)」を挿入**:
  - 6-1: DB は環境ごとローカル前提 (各環境で `db:push --force` + `mail-worker` 再走で再構築)
  - 6-2: (任意) pg_dump で前環境 DB を移植する場合 — 空 DB から psql restore が clean、`db:push` 先打ちは `CREATE TABLE` 衝突になる旨明記、bytea/secret/`recoverStaleClaimedJobs` の注意点
  - 6-3: mail-worker 再走で draft 再生成 — PR #28 の `reextract --status=...` filter で pinpoint 再走を紹介
- 旧 6 節「関連ドキュメント」は 7 節に繰り上げ

Code Quality subagent (Claude) の指摘で:
- `mail_worker_jobs.claimed_at` に訂正 (元 `mail_worker_runs.claimed_at` は存在しない列の誤参照、code 読んで verify 済み)
- `<repo root>/.env` の表記揃え (既存 1-2 節と同じ)
- `superseded_by_draft_id` の direction を実装に合わせて修正 (元は逆向きに記述していた)

## How tested
- doc only PR、code 変更なし
- 全ての claim を `apps/mail-worker/src/{classify/classifier.ts, persist/draft.ts, reextract.ts, jobs.ts}` + `packages/shared/src/schema/{mail-worker.ts, tournament-drafts.ts}` の実装と照合済み (Code Quality subagent が cross-reference verify)
- 既存 doc の表記 (`<repo root>/.env` / 1-3 節参照 / `pnpm --filter @kagetra/shared db:generate` 等) と整合確認

## Out of scope
- worklog 5/8 の historical 記述は残置 (セッション履歴の改変はしない)
- `docs/deploy/mail-worker.md` (本番運用 doc) には追記なし (今回の 3 本は dev 用 doc 限定)
- carryover Nits (L306 docker container 名 portability / L319 説明補足 / 6-2 構造 promotion) は ship 後に都度判断で defer

## Test plan checklist
- [x] 3 修正と 1 新 section が `docs/dev/local-dev-setup.md` のみに集約
- [x] worklog / other docs / code 変更ゼロ
- [x] `<repo root>/.env` 表記揃え (4 既存 + 2 新規 = 6 箇所統一)
- [x] 新 6 節の bash command 全て実行可能 (`docker exec kagetra-db pg_dump` / `psql ... < snapshot.sql`)
- [x] 旧 6 節「関連ドキュメント」が 7 節に繰り上げ
- [x] code 実装と整合 (subagent verify 済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)