### PR TITLE
chore(mail-worker): wire up real ESLint (flat config + typescript-eslint)

### DIFF
--- a/apps/mail-worker/eslint.config.mjs
+++ b/apps/mail-worker/eslint.config.mjs
@@ -1,0 +1,26 @@
+import js from '@eslint/js'
+import tseslint from 'typescript-eslint'
+import globals from 'globals'
+
+export default tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    languageOptions: {
+      globals: { ...globals.node },
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
+    },
+  },
+  {
+    ignores: ['dist/**', 'build/**', 'node_modules/**', '*.config.mjs'],
+  },
+)

--- a/apps/mail-worker/package.json
+++ b/apps/mail-worker/package.json
@@ -35,7 +35,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@eslint/js": "^10.0.1",
+    "@eslint/js": "^9.39.4",
     "@kagetra/typescript-config": "workspace:*",
     "@types/mailparser": "^3.4.6",
     "@types/node": "^22.0.0",

--- a/apps/mail-worker/package.json
+++ b/apps/mail-worker/package.json
@@ -18,7 +18,7 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsup src/index.ts --format esm --outDir dist --clean",
     "check-types": "tsc --noEmit",
-    "lint": "echo 'no lint configured yet'",
+    "lint": "eslint src test scripts",
     "test": "vitest run"
   },
   "dependencies": {
@@ -35,14 +35,18 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@kagetra/typescript-config": "workspace:*",
     "@types/mailparser": "^3.4.6",
     "@types/node": "^22.0.0",
     "@types/pg": "^8.11.0",
+    "eslint": "^9.0.0",
+    "globals": "^17.6.0",
     "jszip": "^3.10.1",
     "tsup": "^8.4.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",
+    "typescript-eslint": "^8.59.3",
     "vitest": "^3.2.0"
   }
 }

--- a/apps/mail-worker/scripts/seed-system-channel.ts
+++ b/apps/mail-worker/scripts/seed-system-channel.ts
@@ -51,7 +51,7 @@ interface RawArgs {
 }
 
 function printUsage(): void {
-   
+
   console.log(`Usage: tsx apps/mail-worker/scripts/seed-system-channel.ts [options]
 
 Seed or rotate the line_channels row with status='system'. Idempotent:
@@ -175,17 +175,17 @@ export async function runSeed(args: SeedArgs): Promise<'inserted' | 'updated' | 
 
     if (args.dryRun) {
       if (existing.length === 0) {
-         
+
         console.log('[dry-run] would INSERT new system channel:')
-         
+
         console.log(redactForLog(args))
         return 'dry-run-insert'
       }
-       
+
       console.log(
         `[dry-run] would UPDATE existing system channel id=${existing[0]?.id ?? '<unknown>'}:`,
       )
-       
+
       console.log(redactForLog(args))
       return 'dry-run-update'
     }
@@ -200,7 +200,7 @@ export async function runSeed(args: SeedArgs): Promise<'inserted' | 'updated' | 
         notificationLineUserId: args.notificationLineUserId,
         note: args.note,
       })
-       
+
       console.log('Inserted new system channel')
       return 'inserted'
     }
@@ -217,7 +217,7 @@ export async function runSeed(args: SeedArgs): Promise<'inserted' | 'updated' | 
         updatedAt: new Date(),
       })
       .where(eq(lineChannels.status, 'system'))
-     
+
     console.log(
       `Updated existing system channel id=${existing[0]?.id ?? '<unknown>'}`,
     )
@@ -271,7 +271,7 @@ if (
       process.exit(code)
     })
     .catch((err) => {
-       
+
       console.error('[seed-system-channel] fatal:', err)
       process.exit(1)
     })

--- a/apps/mail-worker/scripts/seed-system-channel.ts
+++ b/apps/mail-worker/scripts/seed-system-channel.ts
@@ -51,7 +51,7 @@ interface RawArgs {
 }
 
 function printUsage(): void {
-  // eslint-disable-next-line no-console
+   
   console.log(`Usage: tsx apps/mail-worker/scripts/seed-system-channel.ts [options]
 
 Seed or rotate the line_channels row with status='system'. Idempotent:
@@ -175,17 +175,17 @@ export async function runSeed(args: SeedArgs): Promise<'inserted' | 'updated' | 
 
     if (args.dryRun) {
       if (existing.length === 0) {
-        // eslint-disable-next-line no-console
+         
         console.log('[dry-run] would INSERT new system channel:')
-        // eslint-disable-next-line no-console
+         
         console.log(redactForLog(args))
         return 'dry-run-insert'
       }
-      // eslint-disable-next-line no-console
+       
       console.log(
         `[dry-run] would UPDATE existing system channel id=${existing[0]?.id ?? '<unknown>'}:`,
       )
-      // eslint-disable-next-line no-console
+       
       console.log(redactForLog(args))
       return 'dry-run-update'
     }
@@ -200,7 +200,7 @@ export async function runSeed(args: SeedArgs): Promise<'inserted' | 'updated' | 
         notificationLineUserId: args.notificationLineUserId,
         note: args.note,
       })
-      // eslint-disable-next-line no-console
+       
       console.log('Inserted new system channel')
       return 'inserted'
     }
@@ -217,7 +217,7 @@ export async function runSeed(args: SeedArgs): Promise<'inserted' | 'updated' | 
         updatedAt: new Date(),
       })
       .where(eq(lineChannels.status, 'system'))
-    // eslint-disable-next-line no-console
+     
     console.log(
       `Updated existing system channel id=${existing[0]?.id ?? '<unknown>'}`,
     )
@@ -271,7 +271,7 @@ if (
       process.exit(code)
     })
     .catch((err) => {
-      // eslint-disable-next-line no-console
+       
       console.error('[seed-system-channel] fatal:', err)
       process.exit(1)
     })

--- a/apps/mail-worker/src/index.ts
+++ b/apps/mail-worker/src/index.ts
@@ -76,7 +76,7 @@ function parseArgs(argv: readonly string[]): CliFlags {
 }
 
 function printUsage(): void {
-  // eslint-disable-next-line no-console
+   
   console.log(`Usage: mail-worker [flags]
 
   --once                 Run pipeline once and exit (P1 default; --watch is PR5).
@@ -134,7 +134,7 @@ async function main(): Promise<void> {
   // so operators know why a manual `pnpm start` looks at the last 7 days.
   const cronSince = flags.since ?? defaultLiveSince()
   if (!flags.since && !flags.mockImap) {
-    // eslint-disable-next-line no-console
+     
     console.log(
       `[mail-worker] --since not provided; defaulting to last ${LIVE_DEFAULT_SINCE_DAYS} days (since=${cronSince.toISOString()}). Pass --since=YYYY-MM-DD to override.`,
     )
@@ -162,7 +162,7 @@ async function main(): Promise<void> {
         logger: log,
         llmExtractor,
       })
-      // eslint-disable-next-line no-console
+       
       console.log('pipeline summary:', summary)
       return
     }
@@ -178,7 +178,7 @@ async function main(): Promise<void> {
         logger: log,
         llmExtractor,
       })
-      // eslint-disable-next-line no-console
+       
       console.log('pipeline summary:', summary)
       return
     }
@@ -225,7 +225,7 @@ async function main(): Promise<void> {
           llmExtractor,
         })
         await markJobDone(db, job.id, summary.runId)
-        // eslint-disable-next-line no-console
+         
         console.log('pipeline summary:', summary)
       } catch (err) {
         // runOnce may throw on top-level IMAP failure; the run row is already
@@ -251,7 +251,7 @@ async function main(): Promise<void> {
         logger: log,
         llmExtractor,
       })
-      // eslint-disable-next-line no-console
+       
       console.log('pipeline summary:', summary)
     }
   } finally {
@@ -318,19 +318,19 @@ function consoleLogger() {
   return {
     info: (msg: string, ctx?: Record<string, unknown>) => {
       if (LEVEL_RANK.info < minRank) return
-      // eslint-disable-next-line no-console
+       
       console.log(format(msg, ctx))
     },
     warn: (msg: string, ctx?: Record<string, unknown>) => {
       if (LEVEL_RANK.warn < minRank) return
-      // eslint-disable-next-line no-console
+       
       console.warn(format(msg, ctx))
     },
   }
 }
 
 main().catch((err) => {
-  // eslint-disable-next-line no-console
+   
   console.error('[mail-worker] fatal:', err)
   process.exitCode = 1
 })

--- a/apps/mail-worker/src/index.ts
+++ b/apps/mail-worker/src/index.ts
@@ -76,7 +76,7 @@ function parseArgs(argv: readonly string[]): CliFlags {
 }
 
 function printUsage(): void {
-   
+
   console.log(`Usage: mail-worker [flags]
 
   --once                 Run pipeline once and exit (P1 default; --watch is PR5).
@@ -134,7 +134,7 @@ async function main(): Promise<void> {
   // so operators know why a manual `pnpm start` looks at the last 7 days.
   const cronSince = flags.since ?? defaultLiveSince()
   if (!flags.since && !flags.mockImap) {
-     
+
     console.log(
       `[mail-worker] --since not provided; defaulting to last ${LIVE_DEFAULT_SINCE_DAYS} days (since=${cronSince.toISOString()}). Pass --since=YYYY-MM-DD to override.`,
     )
@@ -162,7 +162,7 @@ async function main(): Promise<void> {
         logger: log,
         llmExtractor,
       })
-       
+
       console.log('pipeline summary:', summary)
       return
     }
@@ -178,7 +178,7 @@ async function main(): Promise<void> {
         logger: log,
         llmExtractor,
       })
-       
+
       console.log('pipeline summary:', summary)
       return
     }
@@ -225,7 +225,7 @@ async function main(): Promise<void> {
           llmExtractor,
         })
         await markJobDone(db, job.id, summary.runId)
-         
+
         console.log('pipeline summary:', summary)
       } catch (err) {
         // runOnce may throw on top-level IMAP failure; the run row is already
@@ -251,7 +251,7 @@ async function main(): Promise<void> {
         logger: log,
         llmExtractor,
       })
-       
+
       console.log('pipeline summary:', summary)
     }
   } finally {
@@ -318,19 +318,19 @@ function consoleLogger() {
   return {
     info: (msg: string, ctx?: Record<string, unknown>) => {
       if (LEVEL_RANK.info < minRank) return
-       
+
       console.log(format(msg, ctx))
     },
     warn: (msg: string, ctx?: Record<string, unknown>) => {
       if (LEVEL_RANK.warn < minRank) return
-       
+
       console.warn(format(msg, ctx))
     },
   }
 }
 
 main().catch((err) => {
-   
+
   console.error('[mail-worker] fatal:', err)
   process.exitCode = 1
 })

--- a/apps/mail-worker/src/reextract.ts
+++ b/apps/mail-worker/src/reextract.ts
@@ -158,7 +158,7 @@ function jstYearMonthDay(date: Date): {
 }
 
 function printUsage(): void {
-   
+
   console.log(`Usage: tsx apps/mail-worker/src/reextract.ts --since=YYYY-MM-DD [--include-prefilter-noise] [--status=ai_processing,ai_failed]
 
 Re-classifies all mails in (ai_done, ai_failed, archived, ai_processing) status
@@ -250,7 +250,7 @@ async function main(): Promise<number> {
       statuses: args.statuses,
     })
 
-     
+
     console.log(
       `[reextract] ${targets.length} mails since ${args.since.toISOString()}` +
         (args.includePrefilterNoise ? ' (incl. pre-filter noise)' : ''),
@@ -260,13 +260,13 @@ async function main(): Promise<number> {
       try {
         const outcome = await classifyMail(db, t.id, llm, { force: true })
         const tally = await persistOutcome(db, t.id, outcome)
-         
+
         console.log(
           `[reextract] [${t.id}] ${outcome.kind} (drafts: +${tally.draftsInserted} new, ${tally.draftsUpdated} updated, ${tally.draftsPreserved} preserved)`,
         )
       } catch (err) {
         failures += 1
-         
+
         console.error(
           `[reextract] [${t.id}] FAILED:`,
           err instanceof Error ? err.message : err,
@@ -298,7 +298,7 @@ if (
       process.exit(code)
     })
     .catch((err) => {
-       
+
       console.error('[reextract] fatal:', err)
       process.exit(1)
     })

--- a/apps/mail-worker/src/reextract.ts
+++ b/apps/mail-worker/src/reextract.ts
@@ -158,7 +158,7 @@ function jstYearMonthDay(date: Date): {
 }
 
 function printUsage(): void {
-  // eslint-disable-next-line no-console
+   
   console.log(`Usage: tsx apps/mail-worker/src/reextract.ts --since=YYYY-MM-DD [--include-prefilter-noise] [--status=ai_processing,ai_failed]
 
 Re-classifies all mails in (ai_done, ai_failed, archived, ai_processing) status
@@ -250,7 +250,7 @@ async function main(): Promise<number> {
       statuses: args.statuses,
     })
 
-    // eslint-disable-next-line no-console
+     
     console.log(
       `[reextract] ${targets.length} mails since ${args.since.toISOString()}` +
         (args.includePrefilterNoise ? ' (incl. pre-filter noise)' : ''),
@@ -260,13 +260,13 @@ async function main(): Promise<number> {
       try {
         const outcome = await classifyMail(db, t.id, llm, { force: true })
         const tally = await persistOutcome(db, t.id, outcome)
-        // eslint-disable-next-line no-console
+         
         console.log(
           `[reextract] [${t.id}] ${outcome.kind} (drafts: +${tally.draftsInserted} new, ${tally.draftsUpdated} updated, ${tally.draftsPreserved} preserved)`,
         )
       } catch (err) {
         failures += 1
-        // eslint-disable-next-line no-console
+         
         console.error(
           `[reextract] [${t.id}] FAILED:`,
           err instanceof Error ? err.message : err,
@@ -298,7 +298,7 @@ if (
       process.exit(code)
     })
     .catch((err) => {
-      // eslint-disable-next-line no-console
+       
       console.error('[reextract] fatal:', err)
       process.exit(1)
     })

--- a/apps/mail-worker/test/classify/classifier.test.ts
+++ b/apps/mail-worker/test/classify/classifier.test.ts
@@ -32,7 +32,6 @@ const FIXTURES_DIR = fileURLToPath(new URL('../fixtures/llm/', import.meta.url))
 // are the convenience handles tests use to insert the right `mail_messages`
 // row before invoking the classifier.
 const TOURNAMENT_SUBJECT = '[taikai-ajka:828] 第65回全日本選手権大会/ご案内'
-const ML_TOURNAMENT_SUBJECT = '[taikai-ajka:829] 第66回標榜大会のご案内'
 const NEWSLETTER_SUBJECT = 'Weekly Update: New Features Available'
 const CORRECTION_SUBJECT = 'Re: 【訂正】第65回全日本選手権大会のご案内'
 

--- a/apps/mail-worker/test/pipeline-ai.test.ts
+++ b/apps/mail-worker/test/pipeline-ai.test.ts
@@ -27,9 +27,7 @@ async function loadPayload(filename: string): Promise<ExtractionPayload> {
   return FixtureFileSchema.parse(JSON.parse(raw)).payload
 }
 
-const TOURNAMENT_SUBJECT = '[taikai-ajka:828] 第65回全日本選手権大会/ご案内'
 const ML_TOURNAMENT_SUBJECT = '[taikai-ajka:829] 第66回標榜大会のご案内'
-const NEWSLETTER_SUBJECT = 'Weekly Update: New Features Available'
 
 async function buildExtractor(): Promise<FixtureLLMExtractor> {
   return new FixtureLLMExtractor(await loadFixturesFromDir(LLM_FIXTURE_DIR))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@eslint/js':
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@9.39.4(jiti@2.6.1))
       '@kagetra/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config
@@ -133,6 +136,12 @@ importers:
       '@types/pg':
         specifier: ^8.11.0
         version: 8.20.0
+      eslint:
+        specifier: ^9.0.0
+        version: 9.39.4(jiti@2.6.1)
+      globals:
+        specifier: ^17.6.0
+        version: 17.6.0
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
@@ -145,6 +154,9 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.59.3
+        version: 8.59.3(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^3.2.0
         version: 3.2.4(@types/node@22.19.17)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)
@@ -921,6 +933,15 @@ packages:
     resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/js@10.0.1':
+    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^10.0.0
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+
   '@eslint/js@9.39.4':
     resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1614,8 +1635,23 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/eslint-plugin@8.59.3':
+    resolution: {integrity: sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.59.3
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/parser@8.58.2':
     resolution: {integrity: sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.59.3':
+    resolution: {integrity: sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -1627,12 +1663,28 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/project-service@8.59.3':
+    resolution: {integrity: sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/scope-manager@8.58.2':
     resolution: {integrity: sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/scope-manager@8.59.3':
+    resolution: {integrity: sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/tsconfig-utils@8.58.2':
     resolution: {integrity: sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/tsconfig-utils@8.59.3':
+    resolution: {integrity: sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -1644,12 +1696,29 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/type-utils@8.59.3':
+    resolution: {integrity: sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/types@8.58.2':
     resolution: {integrity: sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.59.3':
+    resolution: {integrity: sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.58.2':
     resolution: {integrity: sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/typescript-estree@8.59.3':
+    resolution: {integrity: sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -1661,8 +1730,19 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/utils@8.59.3':
+    resolution: {integrity: sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/visitor-keys@8.58.2':
     resolution: {integrity: sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.59.3':
+    resolution: {integrity: sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
@@ -2569,6 +2649,10 @@ packages:
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  globals@17.6.0:
+    resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
     engines: {node: '>=18'}
 
   globalthis@1.0.4:
@@ -3816,6 +3900,13 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
+  typescript-eslint@8.59.3:
+    resolution: {integrity: sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -4489,6 +4580,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@eslint/js@10.0.1(eslint@9.39.4(jiti@2.6.1))':
+    optionalDependencies:
+      eslint: 9.39.4(jiti@2.6.1)
+
   '@eslint/js@9.39.4': {}
 
   '@eslint/object-schema@2.1.7': {}
@@ -5036,12 +5131,40 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.59.3
+      '@typescript-eslint/type-utils': 8.59.3(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.3
+      eslint: 9.39.4(jiti@2.6.1)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.58.2
       '@typescript-eslint/types': 8.58.2
       '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.58.2
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.59.3
+      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.3
       debug: 4.4.3
       eslint: 9.39.4(jiti@2.6.1)
       typescript: 5.9.3
@@ -5057,12 +5180,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.59.3(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.59.3(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.3
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@8.58.2':
     dependencies:
       '@typescript-eslint/types': 8.58.2
       '@typescript-eslint/visitor-keys': 8.58.2
 
+  '@typescript-eslint/scope-manager@8.59.3':
+    dependencies:
+      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/visitor-keys': 8.59.3
+
   '@typescript-eslint/tsconfig-utils@8.58.2(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/tsconfig-utils@8.59.3(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
@@ -5078,7 +5219,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/type-utils@8.59.3(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.6.1)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@8.58.2': {}
+
+  '@typescript-eslint/types@8.59.3': {}
 
   '@typescript-eslint/typescript-estree@8.58.2(typescript@5.9.3)':
     dependencies:
@@ -5086,6 +5241,21 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@5.9.3)
       '@typescript-eslint/types': 8.58.2
       '@typescript-eslint/visitor-keys': 8.58.2
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.7.4
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.59.3(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.59.3(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.3(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/visitor-keys': 8.59.3
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
@@ -5106,9 +5276,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.59.3(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.59.3
+      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@8.58.2':
     dependencies:
       '@typescript-eslint/types': 8.58.2
+      eslint-visitor-keys: 5.0.1
+
+  '@typescript-eslint/visitor-keys@8.59.3':
+    dependencies:
+      '@typescript-eslint/types': 8.59.3
       eslint-visitor-keys: 5.0.1
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
@@ -5189,6 +5375,14 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.3.3
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
 
   '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
     dependencies:
@@ -6125,6 +6319,8 @@ snapshots:
       is-glob: 4.0.3
 
   globals@14.0.0: {}
+
+  globals@17.6.0: {}
 
   globalthis@1.0.4:
     dependencies:
@@ -7465,6 +7661,17 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
+  typescript-eslint@8.59.3(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   typescript@5.9.3: {}
 
   uc.micro@2.1.0: {}
@@ -7607,7 +7814,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,8 +122,8 @@ importers:
         version: 4.3.6
     devDependencies:
       '@eslint/js':
-        specifier: ^10.0.1
-        version: 10.0.1(eslint@9.39.4(jiti@2.6.1))
+        specifier: ^9.39.4
+        version: 9.39.4
       '@kagetra/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config
@@ -932,15 +932,6 @@ packages:
   '@eslint/eslintrc@3.3.5':
     resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/js@10.0.1':
-    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-    peerDependencies:
-      eslint: ^10.0.0
-    peerDependenciesMeta:
-      eslint:
-        optional: true
 
   '@eslint/js@9.39.4':
     resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
@@ -4579,10 +4570,6 @@ snapshots:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
-
-  '@eslint/js@10.0.1(eslint@9.39.4(jiti@2.6.1))':
-    optionalDependencies:
-      eslint: 9.39.4(jiti@2.6.1)
 
   '@eslint/js@9.39.4': {}
 


### PR DESCRIPTION
## Why
carryover 🟢 mail-worker 実 lint 配線 を消化。これまで `apps/mail-worker/package.json` の lint script は `echo 'no lint configured yet'` placeholder で、PR #28 ship 時に Verification subagent から「実 lint 配線なし」と指摘されていた。

## What
- **`apps/mail-worker/eslint.config.mjs` 新規** (flat config):
  - `@eslint/js` recommended + `typescript-eslint` recommended
  - Node globals
  - `@typescript-eslint/no-unused-vars` に `_` prefix 例外 (TS 慣習)
- **`package.json`**: dev deps に `eslint` (^9.0.0) / `@eslint/js` (^9.39.4) / `typescript-eslint` / `globals` 追加、`lint` script を `eslint src test scripts` に変更 (web の `^9.0.0` と major 整合)
- **既存 code の lint pass のため最小修正** (本 PR scope 内):
  - **22 件の Unused eslint-disable directive を `--fix` で自動削除** (`scripts/seed-system-channel.ts` / `src/index.ts` / `src/reextract.ts`)
  - **空白だけの行 (--fix の残骸) を空行化** (Codex r1 nit 反映、sed 一括)
  - **3 件の dead-code (test 内の使われていない subject const) を削除**:
    - `test/classify/classifier.test.ts`: `ML_TOURNAMENT_SUBJECT`
    - `test/pipeline-ai.test.ts`: `TOURNAMENT_SUBJECT`, `NEWSLETTER_SUBJECT`

## How tested
- `pnpm --filter @kagetra/mail-worker lint` → **exit 0** (0 errors, 0 warnings)
- `pnpm --filter @kagetra/mail-worker check-types` → **exit 0** (clean)
- `pnpm --filter @kagetra/mail-worker test` → **180/180 pass**

## Codex review (auto-review-loop dogfood、6 PR 目 / 2R 収束 2 回目)
- R1: needs_changes — should_fix 1 件 (`@eslint/js@^10.0.1` → `@eslint/js@^9.0.0`) + nit 3 件 (空白行)
- R2: **pass** — R1 修正 (commit c494f36) 反映で全て解消、blockers / should_fix / nits 全て 0
- 累計 tokens: 81,299 / 500,000

## Out of scope
- 他 package (`apps/api`, `packages/shared`) の lint 配線 (carryover 表記が「mail-worker 実 lint 配線」だったため、scope 厳守)
- ESLint rule の細かい tuning (recommended ベースで pass する最小構成、将来 rule 追加は別 PR で)

## Test plan checklist
- [x] `pnpm --filter @kagetra/mail-worker lint` exit 0
- [x] `pnpm --filter @kagetra/mail-worker check-types` exit 0
- [x] `pnpm --filter @kagetra/mail-worker test` → **180/180** (regression 0)
- [x] Codex R2 pass (R1 should_fix + nit 全消化)

🤖 Generated with [Claude Code](https://claude.com/claude-code)