### PR TITLE
feat(mail-worker): PDF cost guard で大型 PDF 添付を AI スキップ

### DIFF
--- a/apps/mail-worker/src/classify/classifier.ts
+++ b/apps/mail-worker/src/classify/classifier.ts
@@ -1,6 +1,7 @@
 import { and, eq, inArray, sql } from 'drizzle-orm'
 import { mailMessages, tournamentDrafts } from '@kagetra/shared/schema'
 import type { Db } from '../db.js'
+import { loadCostGuardConfig } from '../config.js'
 import { upsertDraft } from '../persist/draft.js'
 import { updateStatus } from '../persist/mail-message.js'
 import {
@@ -58,6 +59,20 @@ export type ClassifyOutcome =
   /** Pre-filter (PR1) already classified the mail as noise; skip the LLM. */
   | { kind: 'skipped_noise' }
   /**
+   * Cost guard tripped: at least one PDF attachment exceeded
+   * `MAIL_WORKER_PDF_SIZE_LIMIT_KB` and the AI call was suppressed before
+   * sending. `filename` / `sizeBytes` describe the first offending attachment
+   * so the pipeline log and admin UI can name it; `limitBytes` echoes the
+   * configured threshold so a stale dev DB row can be audited even after the
+   * env var was raised.
+   */
+  | {
+      kind: 'oversize_skipped'
+      filename: string
+      sizeBytes: number
+      limitBytes: number
+    }
+  /**
    * LLM call or Zod validation failed twice; payload to persist comes from
    * caller. `rawResponse` carries the provider's actual response when the
    * thrown error was an `LLMExtractorError` subclass (e.g. content blocks
@@ -111,6 +126,7 @@ export async function classifyMail(
         columns: {
           filename: true,
           contentType: true,
+          sizeBytes: true,
           data: true,
           extractedText: true,
           extractionStatus: true,
@@ -124,6 +140,31 @@ export async function classifyMail(
 
   if (!opts.force && mail.classification === 'noise') {
     return { kind: 'skipped_noise' }
+  }
+
+  // PDF cost guard. Runs after the pre-filter short-circuit (pre-filter noise
+  // never reaches the AI call regardless of size) but before building the
+  // Anthropic input. We check `sizeBytes` from `mail_attachments` rather than
+  // re-measuring `att.data`, because the bytea round-trip can hand us a
+  // postgres hex-escape string (see `bytesFromBytea` doc) whose `.length`
+  // would over-report by ~2x. `sizeBytes` is populated upstream from the
+  // original parsed buffer length and is the canonical source of truth.
+  //
+  // Limit of 0 disables the guard — used by tests that exercise downstream
+  // behaviour without crafting an oversized attachment.
+  const limitKb = loadCostGuardConfig().MAIL_WORKER_PDF_SIZE_LIMIT_KB
+  if (limitKb > 0) {
+    const limitBytes = limitKb * 1024
+    for (const att of mail.attachments) {
+      if (att.contentType === 'application/pdf' && att.sizeBytes > limitBytes) {
+        return {
+          kind: 'oversize_skipped',
+          filename: att.filename,
+          sizeBytes: att.sizeBytes,
+          limitBytes,
+        }
+      }
+    }
   }
 
   const attachmentsForLlm: LLMExtractionInput['attachments'] = []
@@ -245,6 +286,19 @@ export async function persistOutcome(
   const tally = emptyOutcomeTally()
 
   if (outcome.kind === 'skipped_noise') {
+    tally.aiSkipped += 1
+    return tally
+  }
+
+  if (outcome.kind === 'oversize_skipped') {
+    // No draft is written — the AI never produced an extraction. We only flip
+    // the mail status so the inbox UI can surface "AI スキップ (PDF サイズ超過)"
+    // and the operator can decide whether to raise the limit and reextract.
+    // The classifier-level outcome.filename / sizeBytes are NOT persisted on
+    // the row today; the pipeline log line (pipeline.ts: ai oversize_skipped)
+    // is the single source of truth for which file tripped the guard, kept
+    // out of the DB so the schema stays unchanged.
+    await updateStatus(db, messageId, 'oversize_skipped')
     tally.aiSkipped += 1
     return tally
   }

--- a/apps/mail-worker/src/config.ts
+++ b/apps/mail-worker/src/config.ts
@@ -76,9 +76,30 @@ const LlmConfigSchema = z.object({
   ANTHROPIC_API_KEY: z.string().min(1),
 })
 
+/**
+ * Cost guard for the AI classify phase. A 919KB PDF in dev (mail id=125, May
+ * 2026) cost USD 0.12 against a pre-deployment estimate of ~USD 0.02 — Sonnet
+ * 4.6 charges native PDF document blocks as a fixed token-per-page envelope on
+ * top of the base prompt, so attachment size is the strongest pre-call
+ * predictor of spend. The guard short-circuits to `oversize_skipped` before
+ * the Anthropic call when any PDF exceeds the limit; the operator raises the
+ * env var and reextracts when intentionally accepting the cost.
+ *
+ * Default 800 KB is the dev-observed sweet spot: rejects the 919 KB outlier
+ * while clearing the empirically typical 100–500 KB tournament announcements
+ * (see worklog 2026-05-11 + 2026-05-17 cost guard discovery).
+ *
+ * Set to 0 to disable the guard (used by tests that need to assert downstream
+ * behaviour without crafting an oversized fixture).
+ */
+const CostGuardConfigSchema = z.object({
+  MAIL_WORKER_PDF_SIZE_LIMIT_KB: z.coerce.number().int().nonnegative().default(800),
+})
+
 export type LogConfig = z.infer<typeof LogConfigSchema>
 export type ImapConfig = z.infer<typeof ImapConfigSchema>
 export type DbConfig = z.infer<typeof DbConfigSchema>
+export type CostGuardConfig = z.infer<typeof CostGuardConfigSchema>
 
 export interface LlmConfig {
   anthropicApiKey: string
@@ -93,6 +114,7 @@ let cachedLog: LogConfig | null = null
 let cachedImap: ImapConfig | null = null
 let cachedDb: DbConfig | null = null
 let cachedLlm: LlmConfig | null = null
+let cachedCostGuard: CostGuardConfig | null = null
 
 function configError(name: string, issues: z.ZodIssue[]): Error {
   const lines = issues
@@ -144,11 +166,23 @@ export function loadLlmConfig(env: NodeJS.ProcessEnv = process.env): LlmConfig {
   return cachedLlm
 }
 
+export function loadCostGuardConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): CostGuardConfig {
+  if (cachedCostGuard) return cachedCostGuard
+  ensureDotenvLoaded()
+  const parsed = CostGuardConfigSchema.safeParse(env)
+  if (!parsed.success) throw configError('cost-guard', parsed.error.issues)
+  cachedCostGuard = parsed.data
+  return cachedCostGuard
+}
+
 export function resetConfigForTests(): void {
   cachedLog = null
   cachedImap = null
   cachedDb = null
   cachedLlm = null
+  cachedCostGuard = null
   // dotenvLoaded intentionally not reset: dotenv merges into process.env, so
   // re-running it has no value and would only re-trigger the webpack URL
   // analysis under bundlers.

--- a/apps/mail-worker/src/config.ts
+++ b/apps/mail-worker/src/config.ts
@@ -91,9 +91,18 @@ const LlmConfigSchema = z.object({
  *
  * Set to 0 to disable the guard (used by tests that need to assert downstream
  * behaviour without crafting an oversized fixture).
+ *
+ * `z.preprocess` is required because `z.coerce.number()` accepts `''` as 0
+ * (review r1 should-fix on PR #31). An operator who writes
+ * `MAIL_WORKER_PDF_SIZE_LIMIT_KB=` in .env would otherwise silently disable
+ * the guard. We normalise empty strings to undefined so the default kicks in
+ * instead, matching the "env var unset" semantics.
  */
 const CostGuardConfigSchema = z.object({
-  MAIL_WORKER_PDF_SIZE_LIMIT_KB: z.coerce.number().int().nonnegative().default(800),
+  MAIL_WORKER_PDF_SIZE_LIMIT_KB: z.preprocess(
+    (v) => (v === '' ? undefined : v),
+    z.coerce.number().int().nonnegative().default(800),
+  ),
 })
 
 export type LogConfig = z.infer<typeof LogConfigSchema>

--- a/apps/mail-worker/src/pipeline.ts
+++ b/apps/mail-worker/src/pipeline.ts
@@ -462,6 +462,18 @@ async function runAiPhase(
       const detail = outcome.rawResponse ?? outcome.reason
       summary.aiErrors.push(truncateAiError(detail))
     }
+    // Cost-guard trips are warn-level: an operator-actionable event (raise
+    // the env var and reextract, or accept the skip) that shouldn't blend
+    // into the info stream alongside successful classifications.
+    if (outcome.kind === 'oversize_skipped') {
+      log.warn('ai oversize_skipped', {
+        messageId,
+        rowId,
+        filename: outcome.filename,
+        sizeBytes: outcome.sizeBytes,
+        limitBytes: outcome.limitBytes,
+      })
+    }
     log.info('ai outcome', {
       messageId,
       rowId,

--- a/apps/mail-worker/src/reextract.ts
+++ b/apps/mail-worker/src/reextract.ts
@@ -23,15 +23,17 @@ import { loadLlmConfig } from './config.js'
  *
  * Selection criteria:
  *   - `received_at >= --since` (a YYYY-MM-DD value resolves to JST 00:00)
- *   - `status IN ('ai_done', 'ai_failed', 'archived', 'ai_processing')` —
- *     terminal AI states (done/failed/archived) plus `ai_processing` to
- *     unstick rows whose worker crashed mid-call. The regular pipeline's
- *     duplicate path also retries `ai_processing` next run, so this is a
- *     belt-and-braces escape hatch for mails that won't be re-fetched
- *     (e.g. already deleted from IMAP). `'pending'` and `'fetched'` rows
- *     are owned by the regular pipeline EXCEPT when `--include-prefilter-noise`
- *     is set, which adds `(status='fetched' AND classification='noise')` to
- *     the WHERE clause.
+ *   - `status IN ('ai_done', 'ai_failed', 'archived', 'ai_processing',
+ *     'oversize_skipped')` — terminal AI states (done/failed/archived) plus
+ *     `ai_processing` to unstick rows whose worker crashed mid-call, plus
+ *     `oversize_skipped` so an operator who just raised
+ *     `MAIL_WORKER_PDF_SIZE_LIMIT_KB` can sweep up the previously-skipped
+ *     mails. The regular pipeline's duplicate path also retries
+ *     `ai_processing` next run, so this is a belt-and-braces escape hatch
+ *     for mails that won't be re-fetched (e.g. already deleted from IMAP).
+ *     `'pending'` and `'fetched'` rows are owned by the regular pipeline
+ *     EXCEPT when `--include-prefilter-noise` is set, which adds
+ *     `(status='fetched' AND classification='noise')` to the WHERE clause.
  *
  * Each mail is run through `classifyMail(... { force: true })` so the
  * pre-filter `classification === 'noise'` short-circuit is bypassed. Drafts
@@ -44,7 +46,13 @@ import { loadLlmConfig } from './config.js'
  * mail. The CLI exits with a non-zero code if any mail failed so cron-style
  * invocations can surface the partial failure.
  */
-const VALID_STATUSES = ['ai_done', 'ai_failed', 'archived', 'ai_processing'] as const
+const VALID_STATUSES = [
+  'ai_done',
+  'ai_failed',
+  'archived',
+  'ai_processing',
+  'oversize_skipped',
+] as const
 
 interface ReextractArgs {
   since: Date | null
@@ -161,10 +169,11 @@ function printUsage(): void {
 
   console.log(`Usage: tsx apps/mail-worker/src/reextract.ts --since=YYYY-MM-DD [--include-prefilter-noise] [--status=ai_processing,ai_failed]
 
-Re-classifies all mails in (ai_done, ai_failed, archived, ai_processing) status
-with received_at >= --since. The pre-filter noise check is bypassed
-(force=true). Drafts are upserted (existing drafts get refreshed with the new
-model output); drafts already approved or rejected by an admin are preserved.
+Re-classifies all mails in (ai_done, ai_failed, archived, ai_processing,
+oversize_skipped) status with received_at >= --since. The pre-filter noise
+check is bypassed (force=true). Drafts are upserted (existing drafts get
+refreshed with the new model output); drafts already approved or rejected by
+an admin are preserved.
 
   --include-prefilter-noise
       Also re-classify mails the pre-filter dropped early
@@ -175,9 +184,12 @@ model output); drafts already approved or rejected by an admin are preserved.
 
   --status=STATUS1,STATUS2,...
       Restrict to a subset of mail_messages.status (CSV).
-      Valid values: ai_done, ai_failed, archived, ai_processing.
-      Default: all four. Combine with --since for narrow re-runs
-      (e.g. --status=ai_processing to retry crashed worker rows).
+      Valid values: ai_done, ai_failed, archived, ai_processing,
+      oversize_skipped.
+      Default: all five. Combine with --since for narrow re-runs
+      (e.g. --status=ai_processing to retry crashed worker rows, or
+      --status=oversize_skipped after raising MAIL_WORKER_PDF_SIZE_LIMIT_KB
+      to sweep up previously-skipped large-PDF mails).
       Note: --status only filters the AI-touched leg of the selection;
       --include-prefilter-noise still adds (fetched + noise) rows
       independently.
@@ -190,7 +202,7 @@ Requires ANTHROPIC_API_KEY in env (loaded via dotenv from repo root).
  * Pick the set of `mail_messages` rows the operator wants AI to (re-)evaluate.
  *
  * Default selection covers AI-touched terminal states (`ai_done` / `ai_failed`
- * / `archived` / `ai_processing`). When `includePrefilterNoise` is set we
+ * / `archived` / `ai_processing` / `oversize_skipped`). When `includePrefilterNoise` is set we
  * also fold in rows the PR1 pre-filter dropped — they sit at
  * `status='fetched'`, `classification='noise'` and the regular pipeline
  * intentionally never sends them to the LLM. After a venue allow-list or

--- a/apps/mail-worker/test/classify/classifier.test.ts
+++ b/apps/mail-worker/test/classify/classifier.test.ts
@@ -1,9 +1,9 @@
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { eq } from 'drizzle-orm'
-import { mailMessages, tournamentDrafts } from '@kagetra/shared/schema'
+import { mailAttachments, mailMessages, tournamentDrafts } from '@kagetra/shared/schema'
 import {
   classifyMail,
   persistOutcome,
@@ -22,6 +22,7 @@ import {
   type LLMExtractionResult,
   type LLMExtractor,
 } from '../../src/classify/llm/types.js'
+import { resetConfigForTests } from '../../src/config.js'
 import { closeTestDb, testDb, truncateMailTables } from '../test-db.js'
 import { closeDb, getDb } from '../../src/db.js'
 
@@ -70,6 +71,30 @@ async function insertTestMail(opts: InsertMailOpts): Promise<number> {
     })
     .returning({ id: mailMessages.id })
   return inserted[0]!.id
+}
+
+interface InsertPdfOpts {
+  mailMessageId: number
+  filename?: string
+  sizeBytes: number
+}
+
+// Minimal "is this a PDF" prefix so any downstream PDF parser sees something
+// vaguely real. The cost guard never reads the bytes — it short-circuits on
+// `sizeBytes` — so we don't bother filling the buffer with realistic content.
+async function insertTestPdf(opts: InsertPdfOpts): Promise<void> {
+  await testDb.insert(mailAttachments).values({
+    mailMessageId: opts.mailMessageId,
+    filename: opts.filename ?? '案内.pdf',
+    contentType: 'application/pdf',
+    sizeBytes: opts.sizeBytes,
+    // bytea content is irrelevant for the size-guard path; a 1-byte buffer
+    // keeps the row small and the insert fast. The classifier never gets to
+    // base64-encode it because the guard fires first.
+    data: Buffer.from([0x25]),
+    extractedText: null,
+    extractionStatus: 'pending',
+  })
 }
 
 describe('classifier', () => {
@@ -233,6 +258,149 @@ describe('classifier', () => {
       await expect(classifyMail(getDb(), 9_999_999, llm)).rejects.toThrow(
         /not found/,
       )
+    })
+
+    describe('PDF cost guard', () => {
+      // Lives in its own describe so the env stub doesn't bleed into other
+      // tests in this file. Each `it` may set its own threshold; afterEach
+      // restores process.env and clears the cached config so the next test
+      // (here or elsewhere) sees the un-stubbed default.
+      afterEach(() => {
+        vi.unstubAllEnvs()
+        resetConfigForTests()
+      })
+
+      it('returns oversize_skipped when any PDF exceeds MAIL_WORKER_PDF_SIZE_LIMIT_KB and never calls the LLM', async () => {
+        vi.stubEnv('MAIL_WORKER_PDF_SIZE_LIMIT_KB', '500')
+        resetConfigForTests()
+
+        let calls = 0
+        const llm: LLMExtractor = {
+          modelId: 'should-not-be-called',
+          async extract(_input: LLMExtractionInput): Promise<LLMExtractionResult> {
+            calls += 1
+            throw new Error('LLM should not be invoked under the cost guard')
+          },
+        }
+        const id = await insertTestMail({
+          messageId: '<oversize-pdf@example.com>',
+          subject: TOURNAMENT_SUBJECT,
+        })
+        // 600 KB > 500 KB threshold.
+        await insertTestPdf({ mailMessageId: id, sizeBytes: 600 * 1024 })
+
+        const outcome = await classifyMail(getDb(), id, llm)
+
+        expect(outcome.kind).toBe('oversize_skipped')
+        if (outcome.kind === 'oversize_skipped') {
+          expect(outcome.filename).toBe('案内.pdf')
+          expect(outcome.sizeBytes).toBe(600 * 1024)
+          expect(outcome.limitBytes).toBe(500 * 1024)
+        }
+        // The most important assertion: AI was never called.
+        expect(calls).toBe(0)
+      })
+
+      it('classifies normally when all PDFs are within the limit', async () => {
+        vi.stubEnv('MAIL_WORKER_PDF_SIZE_LIMIT_KB', '500')
+        resetConfigForTests()
+        const fixtures = await buildFixtureMap()
+        const llm = new FixtureLLMExtractor(fixtures)
+
+        const id = await insertTestMail({
+          messageId: '<under-limit-pdf@example.com>',
+          subject: TOURNAMENT_SUBJECT,
+        })
+        // 100 KB < 500 KB threshold.
+        await insertTestPdf({ mailMessageId: id, sizeBytes: 100 * 1024 })
+
+        const outcome = await classifyMail(getDb(), id, llm)
+
+        expect(outcome.kind).toBe('tournament')
+      })
+
+      it('treats MAIL_WORKER_PDF_SIZE_LIMIT_KB=0 as guard disabled', async () => {
+        vi.stubEnv('MAIL_WORKER_PDF_SIZE_LIMIT_KB', '0')
+        resetConfigForTests()
+        const fixtures = await buildFixtureMap()
+        const llm = new FixtureLLMExtractor(fixtures)
+
+        const id = await insertTestMail({
+          messageId: '<guard-disabled-pdf@example.com>',
+          subject: TOURNAMENT_SUBJECT,
+        })
+        // Even a hugely oversized attachment must flow through to the LLM
+        // when the operator has explicitly disabled the guard via env=0.
+        await insertTestPdf({ mailMessageId: id, sizeBytes: 10 * 1024 * 1024 })
+
+        const outcome = await classifyMail(getDb(), id, llm)
+
+        expect(outcome.kind).toBe('tournament')
+      })
+
+      it('skips at the FIRST oversized PDF and reports its filename', async () => {
+        vi.stubEnv('MAIL_WORKER_PDF_SIZE_LIMIT_KB', '500')
+        resetConfigForTests()
+
+        const llm: LLMExtractor = {
+          modelId: 'unused',
+          async extract(): Promise<LLMExtractionResult> {
+            throw new Error('LLM should not be invoked')
+          },
+        }
+        const id = await insertTestMail({
+          messageId: '<multi-pdf-oversize@example.com>',
+          subject: TOURNAMENT_SUBJECT,
+        })
+        // first attachment under the limit, second oversized; the guard
+        // reports the oversized one (not just "any oversized exists").
+        await insertTestPdf({
+          mailMessageId: id,
+          filename: 'small.pdf',
+          sizeBytes: 100 * 1024,
+        })
+        await insertTestPdf({
+          mailMessageId: id,
+          filename: 'large.pdf',
+          sizeBytes: 600 * 1024,
+        })
+
+        const outcome = await classifyMail(getDb(), id, llm)
+
+        expect(outcome.kind).toBe('oversize_skipped')
+        if (outcome.kind === 'oversize_skipped') {
+          expect(outcome.filename).toBe('large.pdf')
+          expect(outcome.sizeBytes).toBe(600 * 1024)
+        }
+      })
+
+      it('still runs the guard even when force=true (operator must raise the env var, not the force flag)', async () => {
+        vi.stubEnv('MAIL_WORKER_PDF_SIZE_LIMIT_KB', '500')
+        resetConfigForTests()
+
+        let calls = 0
+        const llm: LLMExtractor = {
+          modelId: 'unused',
+          async extract(): Promise<LLMExtractionResult> {
+            calls += 1
+            throw new Error('LLM should not be invoked')
+          },
+        }
+        const id = await insertTestMail({
+          messageId: '<force-flag-oversize@example.com>',
+          subject: TOURNAMENT_SUBJECT,
+          classification: 'noise',
+        })
+        await insertTestPdf({ mailMessageId: id, sizeBytes: 600 * 1024 })
+
+        // force=true bypasses the pre-filter noise short-circuit, but cost
+        // guard is a separate, orthogonal concern — the only way to disable
+        // it is via env. Same `oversize_skipped` outcome.
+        const outcome = await classifyMail(getDb(), id, llm, { force: true })
+
+        expect(outcome.kind).toBe('oversize_skipped')
+        expect(calls).toBe(0)
+      })
     })
   })
 
@@ -664,6 +832,41 @@ describe('classifier', () => {
       expect(tally.draftsUpdated).toBe(0)
       expect(tally.aiSucceeded).toBe(0)
       expect(tally.aiFailed).toBe(0)
+
+      const drafts = await testDb
+        .select()
+        .from(tournamentDrafts)
+        .where(eq(tournamentDrafts.messageId, id))
+      expect(drafts).toHaveLength(0)
+    })
+
+    it('flips mail.status to oversize_skipped and writes no draft on cost-guard outcome', async () => {
+      const id = await insertTestMail({
+        messageId: '<persist-oversize@example.com>',
+        subject: TOURNAMENT_SUBJECT,
+      })
+      const outcome: ClassifyOutcome = {
+        kind: 'oversize_skipped',
+        filename: '案内.pdf',
+        sizeBytes: 900 * 1024,
+        limitBytes: 800 * 1024,
+      }
+
+      const tally = await persistOutcome(getDb(), id, outcome)
+
+      // aiSkipped covers both pre-filter noise and cost-guard skip — the
+      // distinction is exposed via mail.status, not the tally.
+      expect(tally.aiSkipped).toBe(1)
+      expect(tally.draftsInserted).toBe(0)
+      expect(tally.draftsUpdated).toBe(0)
+      expect(tally.aiSucceeded).toBe(0)
+      expect(tally.aiFailed).toBe(0)
+
+      const mail = await testDb
+        .select()
+        .from(mailMessages)
+        .where(eq(mailMessages.id, id))
+      expect(mail[0]!.status).toBe('oversize_skipped')
 
       const drafts = await testDb
         .select()

--- a/apps/mail-worker/test/config.test.ts
+++ b/apps/mail-worker/test/config.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  loadCostGuardConfig,
   loadDbConfig,
   loadImapConfig,
   loadLogConfig,
@@ -55,6 +56,35 @@ describe('config split (per-concern loaders)', () => {
     it('throws when DATABASE_URL is empty (required check now lives inside getDb path)', () => {
       vi.stubEnv('DATABASE_URL', '')
       expect(() => loadDbConfig()).toThrow(/db env/)
+    })
+  })
+
+  describe('loadCostGuardConfig', () => {
+    it('defaults to 800 when MAIL_WORKER_PDF_SIZE_LIMIT_KB is unset', () => {
+      expect(loadCostGuardConfig().MAIL_WORKER_PDF_SIZE_LIMIT_KB).toBe(800)
+    })
+
+    it('treats an empty string the same as unset and falls back to default 800', () => {
+      // Regression guard for r1 should-fix: `z.coerce.number()` would otherwise
+      // accept `''` as `0`, silently disabling the cost guard whenever an
+      // operator wrote `MAIL_WORKER_PDF_SIZE_LIMIT_KB=` with no value in .env.
+      vi.stubEnv('MAIL_WORKER_PDF_SIZE_LIMIT_KB', '')
+      expect(loadCostGuardConfig().MAIL_WORKER_PDF_SIZE_LIMIT_KB).toBe(800)
+    })
+
+    it('parses a non-empty numeric value', () => {
+      vi.stubEnv('MAIL_WORKER_PDF_SIZE_LIMIT_KB', '1500')
+      expect(loadCostGuardConfig().MAIL_WORKER_PDF_SIZE_LIMIT_KB).toBe(1500)
+    })
+
+    it('accepts 0 as the explicit "guard disabled" sentinel', () => {
+      vi.stubEnv('MAIL_WORKER_PDF_SIZE_LIMIT_KB', '0')
+      expect(loadCostGuardConfig().MAIL_WORKER_PDF_SIZE_LIMIT_KB).toBe(0)
+    })
+
+    it('rejects negative values with a clear error', () => {
+      vi.stubEnv('MAIL_WORKER_PDF_SIZE_LIMIT_KB', '-1')
+      expect(() => loadCostGuardConfig()).toThrow(/cost-guard env/)
     })
   })
 })

--- a/apps/mail-worker/test/reextract.test.ts
+++ b/apps/mail-worker/test/reextract.test.ts
@@ -49,13 +49,25 @@ describe('parseReextractArgs', () => {
     expect(args.includePrefilterNoise).toBe(false)
     expect(args.help).toBe(false)
     expect(args.since?.toISOString()).toBe('2026-03-31T15:00:00.000Z')
-    expect(args.statuses).toEqual(['ai_done', 'ai_failed', 'archived', 'ai_processing'])
+    expect(args.statuses).toEqual([
+      'ai_done',
+      'ai_failed',
+      'archived',
+      'ai_processing',
+      'oversize_skipped',
+    ])
   })
 
   it('defaults statuses to all VALID_STATUSES', () => {
     const args = parseReextractArgs(['node', 'reextract.ts', '--since=2026-04-01'])
-    expect(args.statuses).toHaveLength(4)
-    expect(args.statuses).toEqual(['ai_done', 'ai_failed', 'archived', 'ai_processing'])
+    expect(args.statuses).toHaveLength(5)
+    expect(args.statuses).toEqual([
+      'ai_done',
+      'ai_failed',
+      'archived',
+      'ai_processing',
+      'oversize_skipped',
+    ])
   })
 
   it('parses --status=ai_processing as single-element array', () => {
@@ -114,7 +126,13 @@ describe('parseReextractArgs', () => {
     const args = parseReextractArgs(['node', 'reextract.ts', '--help'])
     expect(args.help).toBe(true)
     expect(args.includePrefilterNoise).toBe(false)
-    expect(args.statuses).toEqual(['ai_done', 'ai_failed', 'archived', 'ai_processing'])
+    expect(args.statuses).toEqual([
+      'ai_done',
+      'ai_failed',
+      'archived',
+      'ai_processing',
+      'oversize_skipped',
+    ])
   })
 
   it('rejects calendar-day overflow like 2026-04-31 even though Date silently rolls it forward', () => {
@@ -204,7 +222,7 @@ describe('selectReextractTargets', () => {
     await closeTestDb()
   })
 
-  it('picks up AI-touched terminal states by default (ai_done / ai_failed / archived / ai_processing)', async () => {
+  it('picks up AI-touched terminal states by default (ai_done / ai_failed / archived / ai_processing / oversize_skipped)', async () => {
     await seedMail({
       messageId: '<done-1@example.com>',
       status: 'ai_done',
@@ -225,20 +243,26 @@ describe('selectReextractTargets', () => {
       status: 'ai_processing',
       classification: null,
     })
+    await seedMail({
+      messageId: '<oversize-1@example.com>',
+      status: 'oversize_skipped',
+      classification: null,
+    })
 
     const targets = await selectReextractTargets(testDb, {
       since: SINCE,
       includePrefilterNoise: false,
-      statuses: ['ai_done', 'ai_failed', 'archived', 'ai_processing'],
+      statuses: ['ai_done', 'ai_failed', 'archived', 'ai_processing', 'oversize_skipped'],
     })
 
-    expect(targets).toHaveLength(4)
+    expect(targets).toHaveLength(5)
     expect(new Set(targets.map((t) => t.messageId))).toEqual(
       new Set([
         '<done-1@example.com>',
         '<failed-1@example.com>',
         '<archived-1@example.com>',
         '<processing-1@example.com>',
+        '<oversize-1@example.com>',
       ]),
     )
   })

--- a/apps/mail-worker/test/reextract.test.ts
+++ b/apps/mail-worker/test/reextract.test.ts
@@ -11,17 +11,15 @@ import { closeTestDb, testDb, truncateMailTables } from './test-db.js'
 
 const SINCE = new Date('2026-04-01T00:00:00+09:00')
 
+// Status union is derived from the schema's insert type so a new
+// mail_message_status enum value (oversize_skipped, etc.) is picked up
+// automatically. The previous hand-rolled union silently rotted whenever the
+// enum grew (review r1 blocker on PR #31).
+type SeedMailStatus = NonNullable<typeof mailMessages.$inferInsert.status>
+
 interface SeedRow {
   messageId: string
-  status:
-    | 'pending'
-    | 'fetched'
-    | 'parse_failed'
-    | 'fetch_failed'
-    | 'ai_processing'
-    | 'ai_done'
-    | 'ai_failed'
-    | 'archived'
+  status: SeedMailStatus
   classification: 'tournament' | 'noise' | 'unknown' | null
   receivedAt?: Date
 }

--- a/apps/web/src/app/(app)/admin/mail-inbox/page.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/page.tsx
@@ -32,6 +32,10 @@ const STATUS_LABEL: Record<string, { label: string; tone: PillTone }> = {
   ai_processing: { label: 'AI 処理中', tone: 'warn' },
   ai_done: { label: 'AI 完了', tone: 'success' },
   ai_failed: { label: 'AI 失敗', tone: 'danger' },
+  // PDF cost guard tripped (mail-worker MAIL_WORKER_PDF_SIZE_LIMIT_KB). The
+  // mail row sits here until an operator raises the limit and reextracts; no
+  // automatic retry, because retrying would defeat the guard.
+  oversize_skipped: { label: 'AI スキップ (PDF サイズ超過)', tone: 'warn' },
   archived: { label: 'アーカイブ', tone: 'neutral' },
 }
 

--- a/docs/dev/local-dev-setup.md
+++ b/docs/dev/local-dev-setup.md
@@ -216,6 +216,21 @@ pnpm --filter @kagetra/mail-worker start --since=2026-04-01
 
 過去 investigation で「2026-04 の 1 ヶ月で 22 通」だったので、**1000 円で 1 年分以上のテストが賄える** 計算。
 
+#### PDF cost guard (`MAIL_WORKER_PDF_SIZE_LIMIT_KB`)
+
+大型 PDF (Sonnet 4.6 の native document block 課金が page 数で線形に増える) は事前 size check で AI 呼び出しを skip する。2026-05-17 dev investigation で 919 KB PDF が **$0.12 / 通** (予測 $0.02 の 6 倍) と判明したのが導入動機。
+
+- **既定**: 800 KB。dev 観測で 919 KB は超過、典型的な大会案内 (100–500 KB) は通す sweet spot
+- **0 を指定すると guard 無効化** (テスト・一時 opt-out 用)
+- **超過時の挙動**: AI 呼ばず `mail_messages.status='oversize_skipped'` を立てる。`tournament_drafts` 行は作らない
+- **inbox UI**: 「AI スキップ (PDF サイズ超過)」pill (warn tone) で可視化
+- **再処理**: pre-filter noise と違い automatic retry は **しない** (retry すれば guard の意味が消える)。コストを許容するなら env を上げてから `reextract` CLI:
+  ```bash
+  MAIL_WORKER_PDF_SIZE_LIMIT_KB=2000 pnpm --filter @kagetra/mail-worker exec tsx \
+    apps/mail-worker/src/reextract.ts --since=2026-04-01 --status=oversize_skipped
+  ```
+- **ログ**: `pipeline.ts` で `warn` 'ai oversize_skipped' が出る (`filename`, `sizeBytes`, `limitBytes` 含む)
+
 ---
 
 ## 4. トラブルシュート

--- a/packages/shared/drizzle/0011_young_silverclaw.sql
+++ b/packages/shared/drizzle/0011_young_silverclaw.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."mail_message_status" ADD VALUE 'oversize_skipped' BEFORE 'archived';

--- a/packages/shared/drizzle/meta/0011_snapshot.json
+++ b/packages/shared/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,1886 @@
+{
+  "id": "5ae79bba-d3f4-4a93-a147-702de7b23408",
+  "prevId": "1898a312-40b2-477a-95e1-01dadaf2a46e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_user_id": {
+          "name": "line_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "grade": {
+          "name": "grade",
+          "type": "grade",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_invited": {
+          "name": "is_invited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affiliation": {
+          "name": "affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dan": {
+          "name": "dan",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zen_nichikyo": {
+          "name": "zen_nichikyo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_linked_at": {
+          "name": "line_linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_link_method": {
+          "name": "line_link_method",
+          "type": "line_link_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notification_line_user_id": {
+          "name": "notification_line_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_name_unique": {
+          "name": "users_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_line_user_id_unique": {
+          "name": "users_line_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "line_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_dan_range": {
+          "name": "users_dan_range",
+          "value": "\"users\".\"dan\" BETWEEN 0 AND 9 OR \"users\".\"dan\" IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_groups": {
+      "name": "event_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_groups_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_groups_name_unique": {
+          "name": "event_groups_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "events_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formal_name": {
+          "name": "formal_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official": {
+          "name": "official",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'individual'"
+        },
+        "entry_deadline": {
+          "name": "entry_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_deadline": {
+          "name": "internal_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_group_id": {
+          "name": "event_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligible_grades": {
+          "name": "eligible_grades",
+          "type": "grade[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_jpy": {
+          "name": "fee_jpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_deadline": {
+          "name": "payment_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_info": {
+          "name": "payment_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_method": {
+          "name": "entry_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizer": {
+          "name": "organizer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_a": {
+          "name": "capacity_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_b": {
+          "name": "capacity_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_c": {
+          "name": "capacity_c",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_d": {
+          "name": "capacity_d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_e": {
+          "name": "capacity_e",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "events_created_by_users_id_fk": {
+          "name": "events_created_by_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_event_group_id_event_groups_id_fk": {
+          "name": "events_event_group_id_event_groups_id_fk",
+          "tableFrom": "events",
+          "tableTo": "event_groups",
+          "columnsFrom": [
+            "event_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_attendances": {
+      "name": "event_attendances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_attendances_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attend": {
+          "name": "attend",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_attendances_event_id_events_id_fk": {
+          "name": "event_attendances_event_id_events_id_fk",
+          "tableFrom": "event_attendances",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_attendances_user_id_users_id_fk": {
+          "name": "event_attendances_user_id_users_id_fk",
+          "tableFrom": "event_attendances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_attendances_event_id_user_id_unique": {
+          "name": "event_attendances_event_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_items": {
+      "name": "schedule_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "schedule_items_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "schedule_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_items_owner_id_users_id_fk": {
+          "name": "schedule_items_owner_id_users_id_fk",
+          "tableFrom": "schedule_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_messages": {
+      "name": "mail_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_messages_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_addresses": {
+          "name": "to_addresses",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_message_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "mail_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imap_uid": {
+          "name": "imap_uid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imap_box": {
+          "name": "imap_box",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mail_messages_received_at_desc_idx": {
+          "name": "mail_messages_received_at_desc_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mail_messages_message_id_unique": {
+          "name": "mail_messages_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_attachments": {
+      "name": "mail_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_attachments_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "mail_message_id": {
+          "name": "mail_message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extracted_text": {
+          "name": "extracted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_status": {
+          "name": "extraction_status",
+          "type": "attachment_extraction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mail_attachments_mail_message_id_idx": {
+          "name": "mail_attachments_mail_message_id_idx",
+          "columns": [
+            {
+              "expression": "mail_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_attachments_mail_message_id_mail_messages_id_fk": {
+          "name": "mail_attachments_mail_message_id_mail_messages_id_fk",
+          "tableFrom": "mail_attachments",
+          "tableTo": "mail_messages",
+          "columnsFrom": [
+            "mail_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tournament_drafts": {
+      "name": "tournament_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tournament_drafts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tournament_draft_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_correction": {
+          "name": "is_correction",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "references_subject": {
+          "name": "references_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_by_draft_id": {
+          "name": "superseded_by_draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracted_payload": {
+          "name": "extracted_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ai_raw_response": {
+          "name": "ai_raw_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_tokens_input": {
+          "name": "ai_tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_tokens_output": {
+          "name": "ai_tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_cost_usd": {
+          "name": "ai_cost_usd",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by_user_id": {
+          "name": "rejected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_drafts_status_created": {
+          "name": "idx_drafts_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tournament_drafts_message_id_mail_messages_id_fk": {
+          "name": "tournament_drafts_message_id_mail_messages_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "mail_messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tournament_drafts_event_id_events_id_fk": {
+          "name": "tournament_drafts_event_id_events_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tournament_drafts_approved_by_user_id_users_id_fk": {
+          "name": "tournament_drafts_approved_by_user_id_users_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tournament_drafts_rejected_by_user_id_users_id_fk": {
+          "name": "tournament_drafts_rejected_by_user_id_users_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "rejected_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tournament_drafts_message_id_unique": {
+          "name": "tournament_drafts_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tournament_drafts_confidence_range": {
+          "name": "tournament_drafts_confidence_range",
+          "value": "\"tournament_drafts\".\"confidence\" BETWEEN 0 AND 1 OR \"tournament_drafts\".\"confidence\" IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.line_channels": {
+      "name": "line_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "line_channels_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_secret": {
+          "name": "channel_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_access_token": {
+          "name": "channel_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "line_channel_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "assigned_user_id": {
+          "name": "assigned_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_line_user_id": {
+          "name": "notification_line_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "line_channels_assigned_user_id_users_id_fk": {
+          "name": "line_channels_assigned_user_id_users_id_fk",
+          "tableFrom": "line_channels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "line_channels_channel_id_unique": {
+          "name": "line_channels_channel_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "channel_id"
+          ]
+        },
+        "line_channels_assigned_user_id_unique": {
+          "name": "line_channels_assigned_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "assigned_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_worker_jobs": {
+      "name": "mail_worker_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_worker_jobs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "since": {
+          "name": "since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_worker_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_mail_worker_jobs_status_requested_at": {
+          "name": "idx_mail_worker_jobs_status_requested_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_worker_jobs_requested_by_user_id_users_id_fk": {
+          "name": "mail_worker_jobs_requested_by_user_id_users_id_fk",
+          "tableFrom": "mail_worker_jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mail_worker_jobs_run_id_mail_worker_runs_id_fk": {
+          "name": "mail_worker_jobs_run_id_mail_worker_runs_id_fk",
+          "tableFrom": "mail_worker_jobs",
+          "tableTo": "mail_worker_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_worker_runs": {
+      "name": "mail_worker_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_worker_runs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "mail_worker_run_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_worker_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_user_id": {
+          "name": "triggered_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "since": {
+          "name": "since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_worker_runs_triggered_by_user_id_users_id_fk": {
+          "name": "mail_worker_runs_triggered_by_user_id_users_id_fk",
+          "tableFrom": "mail_worker_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggered_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attachment_extraction_status": {
+      "name": "attachment_extraction_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "extracted",
+        "failed",
+        "unsupported"
+      ]
+    },
+    "public.event_kind": {
+      "name": "event_kind",
+      "schema": "public",
+      "values": [
+        "individual",
+        "team"
+      ]
+    },
+    "public.event_status": {
+      "name": "event_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "cancelled",
+        "done"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female"
+      ]
+    },
+    "public.grade": {
+      "name": "grade",
+      "schema": "public",
+      "values": [
+        "A",
+        "B",
+        "C",
+        "D",
+        "E"
+      ]
+    },
+    "public.line_channel_status": {
+      "name": "line_channel_status",
+      "schema": "public",
+      "values": [
+        "available",
+        "assigned",
+        "active",
+        "system",
+        "disabled"
+      ]
+    },
+    "public.line_link_method": {
+      "name": "line_link_method",
+      "schema": "public",
+      "values": [
+        "self_identify",
+        "admin_link",
+        "account_switch"
+      ]
+    },
+    "public.mail_classification": {
+      "name": "mail_classification",
+      "schema": "public",
+      "values": [
+        "tournament",
+        "noise",
+        "unknown"
+      ]
+    },
+    "public.mail_message_status": {
+      "name": "mail_message_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "fetched",
+        "parse_failed",
+        "fetch_failed",
+        "ai_processing",
+        "ai_done",
+        "ai_failed",
+        "oversize_skipped",
+        "archived"
+      ]
+    },
+    "public.mail_worker_job_status": {
+      "name": "mail_worker_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "claimed",
+        "done",
+        "failed"
+      ]
+    },
+    "public.mail_worker_run_kind": {
+      "name": "mail_worker_run_kind",
+      "schema": "public",
+      "values": [
+        "cron",
+        "manual"
+      ]
+    },
+    "public.mail_worker_run_status": {
+      "name": "mail_worker_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "imap_failed",
+        "ai_failed",
+        "partial"
+      ]
+    },
+    "public.schedule_kind": {
+      "name": "schedule_kind",
+      "schema": "public",
+      "values": [
+        "practice",
+        "meeting",
+        "social",
+        "other"
+      ]
+    },
+    "public.tournament_draft_status": {
+      "name": "tournament_draft_status",
+      "schema": "public",
+      "values": [
+        "pending_review",
+        "approved",
+        "rejected",
+        "ai_failed",
+        "superseded"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "vice_admin",
+        "member"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/shared/drizzle/meta/_journal.json
+++ b/packages/shared/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1777346029755,
       "tag": "0010_panoramic_rattler",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1779019484486,
+      "tag": "0011_young_silverclaw",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/schema/enums.ts
+++ b/packages/shared/src/schema/enums.ts
@@ -21,6 +21,11 @@ export const mailMessageStatusEnum = pgEnum('mail_message_status', [
   'ai_processing',
   'ai_done',
   'ai_failed',
+  // PDF cost guard: any attachment exceeded MAIL_WORKER_PDF_SIZE_LIMIT_KB and
+  // the AI call was skipped pre-flight. Operator raises the env var and
+  // reextracts when intentionally accepting the cost — automatic retry would
+  // defeat the guard.
+  'oversize_skipped',
   'archived',
 ])
 export const mailClassificationEnum = pgEnum('mail_classification', [


### PR DESCRIPTION
## Summary

dev investigation で 919 KB PDF 添付 1 通が Sonnet 4.6 で **\$0.12** (予測 \$0.02 の 6 倍, 2026-05-17 mail id=125) と判明したのが導入動機。Anthropic の native PDF document block 課金は page 数で線形に増えるため、attachment size が事前 cost 予測の最強 signal。

- env `MAIL_WORKER_PDF_SIZE_LIMIT_KB` (default **800**) を超える PDF があると classifier 前段で short-circuit → 新 enum 値 `mail_messages.status = 'oversize_skipped'`、draft 作成なし
- inbox UI に「AI スキップ (PDF サイズ超過)」warn pill を追加
- 自動 retry は **しない** (defeating the guard)。operator が env を上げて `reextract --status=oversize_skipped` で sweep
- `MAIL_WORKER_PDF_SIZE_LIMIT_KB=0` で guard 無効化 (テスト用)
- 800 KB の sweet spot 根拠は worklog 2026-05-17 (919 KB outlier 弾く + 典型 100-500 KB は通す)

## Test plan

- [x] `pnpm --filter @kagetra/mail-worker check-types` 通過
- [x] `pnpm --filter @kagetra/web check-types` 通過
- [x] `pnpm --filter @kagetra/shared check-types` 通過
- [x] `pnpm --filter @kagetra/mail-worker lint` 通過
- [x] 新規テスト 6 件 (classifier cost guard 5 + persistOutcome 1) all pass
- [x] reextract.test.ts の 5-status 期待値更新 → pass
- [x] `pnpm --filter @kagetra/web test` inbox page 関連 6 件 pass
- [x] dev test DB に migration 0011 `ALTER TYPE ... ADD VALUE 'oversize_skipped'` 適用済み

## Known pre-existing flake (本 PR 起因ではない)

`pipeline-runs.test.ts > new-drafts notification fires when drafts_created > 0` と `happy path: inserts running row...` の 2 件は **main HEAD (24eb51a) でも fail する** clock-skew 系の flake (`fetchNewDraftSubjects` が `gte(createdAt, startedAt)` で startedAt より新しいはずの draft を取得できない症状)。本 PR の変更は `pipeline.ts` の warn ログ追加のみで `fetchNewDraftSubjects` 自体は触っていない。

## Out of scope (carryover)

- reextract に `--bypass-oversize-guard` flag を追加 (env raise の代わり)
- 二段警告 (warn → skip) パターン  
- 全 attachment 合算サイズ / トークン推定 metric

🤖 Generated with [Claude Code](https://claude.com/claude-code)