### PR TITLE
feat(deploy): Phase A — Oracle Cloud + DNS/SSL 手動セットアップ doc

### DIFF
--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -1,0 +1,52 @@
+# kagetra_new デプロイドキュメント index
+
+kagetra_new を Oracle Cloud Always Free (Tokyo) 上に本番デプロイする手順。
+Phase A-D の段階構成で進める。
+
+## 読む順序
+
+| Phase | doc | 概要 |
+|---|---|---|
+| A | `oracle-setup.md` | Oracle Cloud アカウント作成 → Tokyo ARM A1 インスタンス起動 → iptables/swap/user/Node/Docker セットアップ |
+| A | `dns-ssl.md` | お名前.com で `new.hokudaicarta.com` A レコード追加 → nginx → Let's Encrypt SSL |
+| B | `postgres.md` (今後追加) | Docker Compose で PostgreSQL 16 起動 + migration 適用 + 接続確認 |
+| B | `web.md` (今後追加) | apps/web (Next.js standalone) を systemd service として起動 |
+| B | `api.md` (今後追加) | apps/api (Hono) を systemd service として起動 |
+| P3-A 既存 | `mail-worker.md` | apps/mail-worker (cron 30 分) を systemd timer で起動 (既存) |
+| C | `backup-restore.md` (今後追加) | pg_dump → Cloudflare R2 日次バックアップ + 復元手順 |
+| D | `initial-launch-checklist.md` (今後追加) | 全 Phase 揃った後の初回起動・動作確認チェックリスト |
+
+## Phase 構成
+
+- **Phase A** (現在): インフラ準備 + 手動セットアップ doc のみ (コード
+  変更なし)
+- **Phase B**: アプリケーションデプロイ配線 (systemd unit /
+  docker-compose.prod.yml / nginx 設定 / migration script / 初期 admin
+  seed)
+- **Phase C**: バックアップ配線 (pg_dump → R2 + LINE 失敗通知 + 復元手順)
+- **Phase D**: 本番初回起動 + 動作確認 + ship
+
+## 確定済み構成
+
+| 項目 | 値 |
+|---|---|
+| インフラ | Oracle Cloud Always Free 東京 (ARM Ampere A1, 4 OCPU / 24GB RAM / 200GB SSD) |
+| OS | Ubuntu 22.04 LTS (aarch64) |
+| ドメイン | `new.hokudaicarta.com` (サブドメイン分離、root は旧 kagetra 並行稼働) |
+| DNS | お名前.com (移管しない) |
+| SSL | Let's Encrypt (certbot, 自動更新) |
+| reverse proxy | nginx (port 80/443 → web 3000 / api 3001) |
+| DB | PostgreSQL 16 (Docker 同居、localhost bind) |
+| バックアップ | Cloudflare R2 (10GB 無料 tier, 日次 03:00 JST + GFS rotation) |
+| LINE Login (production) | 新規取得 (redirect URI: `https://new.hokudaicarta.com/api/auth/callback/line`) |
+| LINE Bot (mail-worker 通知) | dev 流用 (notification userId のみ差し替え) |
+
+## 未スコープ (将来別 PR)
+
+- 自動デプロイ (GitHub Actions CD) — v1 は手動 deploy
+- 監視ツール (Datadog 等) — v1 は journalctl + LINE 通知のみ
+- 旧 kagetra からのデータ移行 — Phase 4 完了 + 本番安定確認後に別 PR で
+  実施
+- 写真アルバム (Phase 4) のオブジェクトストレージ移行検討 — 議論先送り
+- ドメイン cutover (`new.hokudaicarta.com` → root `hokudaicarta.com` 統一)
+  — データ移行完了後に別 PR

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -35,7 +35,8 @@ Phase A-D の段階構成で進める。
 | ドメイン | `new.hokudaicarta.com` (サブドメイン分離、root は旧 kagetra 並行稼働) |
 | DNS | お名前.com (移管しない) |
 | SSL | Let's Encrypt (certbot, 自動更新) |
-| reverse proxy | nginx (port 80/443 → web 3000 / api 3001) |
+| reverse proxy | nginx (port 80/443 → web 3000 デフォルト、Hono API は別 path prefix or 別サブドメインで分離 — Phase B で詳細設計) |
+| 認証経路の注意 | LINE Login の redirect URI は `/api/auth/callback/line` で Next.js (web 3000) の Auth.js App Router が処理する。Phase B で `/api/*` を Hono (api 3001) に全部流すと Auth.js callback が壊れるため、`/api/auth/*` は明示的に web 3000 にルートする (or Hono を `/hono-api/*` 等に分離) |
 | DB | PostgreSQL 16 (Docker 同居、localhost bind) |
 | バックアップ | Cloudflare R2 (10GB 無料 tier, 日次 03:00 JST + GFS rotation) |
 | LINE Login (production) | 新規取得 (redirect URI: `https://new.hokudaicarta.com/api/auth/callback/line`) |

--- a/docs/deploy/dns-ssl.md
+++ b/docs/deploy/dns-ssl.md
@@ -1,0 +1,140 @@
+# DNS (お名前.com) + nginx + Let's Encrypt SSL
+
+kagetra_new の本番ドメイン `new.hokudaicarta.com` を Oracle Cloud
+インスタンスに向け、nginx + Let's Encrypt で HTTPS 化するまでの手順。
+お名前.com 取得済の `hokudaicarta.com` を流用し、サブドメイン分離方式で
+旧 kagetra (root) と並行稼働する。
+
+## 0. 前提
+
+- ドメイン: `hokudaicarta.com` (お名前.com 取得済)
+- 旧 kagetra: root `hokudaicarta.com` で稼働中 → **一切触らない**
+- 新システム: `new.hokudaicarta.com` でサブドメイン分離
+- DNS 管理: **お名前.com のまま** (移管しない、`new` の A レコードを
+  追加するだけ)
+- 前提: Oracle インスタンス起動済 + 80/443 が外部から到達可能
+  (`oracle-setup.md` §1-§5 完了)
+- インスタンス Public IP: Oracle Cloud Console → Instances → 詳細画面で
+  確認
+
+## 1. お名前.com で A レコード追加
+
+1. お名前.com Navi にログイン
+2. ドメイン → DNS 関連機能 → DNS 設定/転送設定 → `hokudaicarta.com` 選択
+3. DNS レコード設定 → 追加で以下を入力:
+   - ホスト名: `new`
+   - TYPE: `A`
+   - VALUE: Oracle インスタンスの Public IP
+   - TTL: `3600` (1 時間、変更時の反映時間トレードオフ)
+   - 優先度: 空欄
+4. 確認画面で「DNS レコード設定用ネームサーバー変更不要」が選択されている
+   ことを確認 → 設定
+5. 旧 kagetra の root レコード (`hokudaicarta.com` の A) は触らない
+
+## 2. DNS 反映待ち
+
+- お名前.com の DNS 反映は通常 5 分〜数時間、最大 24-48h
+- 確認 (ローカル PC から):
+
+  ```bash
+  dig new.hokudaicarta.com +short
+  ```
+
+  → Oracle インスタンスの Public IP が返れば反映完了
+- 反映前は次の §5 certbot が DNS-01 challenge で失敗するので、必ず DNS
+  反映後に進む
+
+## 3. nginx インストール
+
+- Ubuntu 22.04 (Oracle インスタンス上で実行):
+
+  ```bash
+  sudo apt update
+  sudo apt install -y nginx
+  ```
+
+- 起動確認:
+
+  ```bash
+  sudo systemctl status nginx
+  curl -I http://localhost
+  ```
+
+- 外部からの確認 (ローカル PC で):
+
+  ```bash
+  curl -I http://new.hokudaicarta.com
+  ```
+
+  → 200 OK で「Welcome to nginx!」default page が返れば OK
+- 502 や connection refused → §4 (Security List) または iptables
+  (`oracle-setup.md` §5) を再確認
+
+## 4. nginx reverse proxy 設定 (Phase A スコープ: default page まで)
+
+- Phase A では default page が `http://new.hokudaicarta.com` で見える
+  状態まで構築
+- Phase B で web (port 3000) / api (port 3001) への reverse proxy 設定を
+  本格追加
+- nginx default の `/etc/nginx/sites-enabled/default` はこの段階では
+  触らない
+
+## 5. certbot で Let's Encrypt SSL 取得
+
+- certbot + nginx plugin インストール:
+
+  ```bash
+  sudo apt install -y certbot python3-certbot-nginx
+  ```
+
+- 証明書取得 (HTTP-01 challenge、port 80 経由で Let's Encrypt から検証
+  ping を受ける):
+
+  ```bash
+  # メールアドレス入力 (証明書失効通知用)、利用規約同意 (Y)、
+  # HTTPS リダイレクト設定で `2` (Redirect, HTTP → HTTPS 自動) を選択。
+  sudo certbot --nginx -d new.hokudaicarta.com
+  ```
+
+- 自動更新 timer 確認:
+
+  ```bash
+  sudo systemctl list-timers | grep certbot
+  ```
+
+  → `certbot.timer` が active (2 回/日チェック、期限 30 日前で自動更新)
+
+## 6. SSL 動作確認
+
+- ローカル PC から:
+
+  ```bash
+  curl -I https://new.hokudaicarta.com
+  ```
+
+  → `HTTP/2 200`, `server: nginx/...`, `strict-transport-security: ...`
+  が返れば OK
+- ブラウザで `https://new.hokudaicarta.com` を開き、鍵マーク + 「証明書:
+  Let's Encrypt」確認
+- 証明書期限確認:
+
+  ```bash
+  sudo certbot certificates
+  ```
+
+## 7. トラブルシュート
+
+| 症状 | 原因と対応 |
+|---|---|
+| `dig` が IP を返さない | DNS 反映待ち (最大 24-48h)、お名前.com の DNS 設定画面で A レコード追加されていることを再確認 |
+| `curl http://new.hokudaicarta.com` connection refused | iptables で 80/443 が ACCEPT されていない、`sudo iptables -L INPUT --line-numbers` で INPUT 6 行目に 80/443 ACCEPT があることを確認 (`oracle-setup.md` §5) |
+| `curl` is timeout | Security List で 80/443 ingress が開いていない、Oracle Cloud Console で確認 (`oracle-setup.md` §4) |
+| certbot が `Connection refused` で失敗 | port 80 が外部から到達可能でない、§3 の `curl -I http://new.hokudaicarta.com` で 200 が返ることを先に確認 |
+| certbot が `DNS problem: NXDOMAIN` | DNS 反映完了前に certbot 実行、§2 の `dig` で IP が返ってから再実行 |
+| certbot 自動更新 timer が動かない | `sudo systemctl enable --now certbot.timer` で有効化、`sudo certbot renew --dry-run` で更新 simulation 実行 |
+
+## 参考リンク
+
+- [Let's Encrypt 公式](https://letsencrypt.org/)
+- [certbot User Guide (nginx)](https://eff-certbot.readthedocs.io/en/latest/using.html)
+- [お名前.com Navi (DNS 設定)](https://navi.onamae.com/)

--- a/docs/deploy/dns-ssl.md
+++ b/docs/deploy/dns-ssl.md
@@ -41,8 +41,8 @@ kagetra_new の本番ドメイン `new.hokudaicarta.com` を Oracle Cloud
   ```
 
   → Oracle インスタンスの Public IP が返れば反映完了
-- 反映前は次の §5 certbot が DNS-01 challenge で失敗するので、必ず DNS
-  反映後に進む
+- 反映前は次の §5 certbot が HTTP-01 challenge (port 80 経由で `new.
+  hokudaicarta.com` への到達性検証) で失敗するので、必ず DNS 反映後に進む
 
 ## 3. nginx インストール
 
@@ -112,8 +112,10 @@ kagetra_new の本番ドメイン `new.hokudaicarta.com` を Oracle Cloud
   curl -I https://new.hokudaicarta.com
   ```
 
-  → `HTTP/2 200`, `server: nginx/...`, `strict-transport-security: ...`
-  が返れば OK
+  → `HTTP/2 200` と `server: nginx/...` が返れば OK (HSTS ヘッダー
+  `strict-transport-security` は certbot --nginx 標準では付与されない、
+  必要なら Phase B で nginx に `add_header Strict-Transport-Security ...
+  always;` を明示追加してから期待ヘッダに加える)
 - ブラウザで `https://new.hokudaicarta.com` を開き、鍵マーク + 「証明書:
   Let's Encrypt」確認
 - 証明書期限確認:

--- a/docs/deploy/oracle-setup.md
+++ b/docs/deploy/oracle-setup.md
@@ -53,11 +53,14 @@ LTS aarch64 image を使う前提。
 
 - Networking → Virtual Cloud Networks → 該当 VCN → Security Lists →
   Default Security List → Add Ingress Rules
-- 追加するルール 1 件:
-  - Source CIDR: `0.0.0.0/0`
-  - IP Protocol: TCP
-  - Destination Port Range: `80,443` (カンマ区切りで両ポート同時可)
-  - Stateless: OFF
+- 追加するルール 2 件 (80 と 443 を別々の Ingress Rule として 2 回追加。
+  OCI の Destination Port Range はコンソール仕様により単一ポートか範囲
+  (`8000-8999`) を前提とするため、`80,443` のカンマ区切りは確実に
+  受け付けられる保証がない):
+  - ルール 1: Source CIDR `0.0.0.0/0` / IP Protocol `TCP` /
+    Destination Port Range `80` / Stateless OFF
+  - ルール 2: Source CIDR `0.0.0.0/0` / IP Protocol `TCP` /
+    Destination Port Range `443` / Stateless OFF
 - SSH (22) はデフォルトで開いている (変更不要)
 - **PostgreSQL 5432 は絶対に外から開けない** (Phase B で Docker 同居、
   `127.0.0.1:5432` バインド厳守)

--- a/docs/deploy/oracle-setup.md
+++ b/docs/deploy/oracle-setup.md
@@ -83,8 +83,10 @@ LTS aarch64 image を使う前提。
   sudo netfilter-persistent save
   ```
 
-- 検証: `sudo iptables -L INPUT --line-numbers` で INPUT 6 行目に ACCEPT
-  が挿入されていること
+- 検証: `sudo iptables -L INPUT --line-numbers` で **INPUT の REJECT より
+  前に 80 と 443 の ACCEPT 両方** が並んでいること (`-I INPUT 6` を 2 回
+  実行すると後から挿入した 443 が 6 行目に、80 は 7 行目に押し下がる。
+  どちらも REJECT より前にあれば OK)
 - ufw は使わない (iptables-persistent と競合、Oracle image にはデフォルト
   未インストール)
 

--- a/docs/deploy/oracle-setup.md
+++ b/docs/deploy/oracle-setup.md
@@ -1,0 +1,170 @@
+# Oracle Cloud Always Free セットアップ (Tokyo / ARM Ampere A1)
+
+kagetra_new の本番インスタンスを Oracle Cloud Always Free (東京 region、
+ARM Ampere A1 4 OCPU/24GB RAM/200GB SSD) に立てるまでの手順。Ubuntu 22.04
+LTS aarch64 image を使う前提。
+
+## 0. 前提
+
+- Oracle Cloud Always Free tier (Tokyo region) — 永続無料、課金条件は
+  Always Free 枠超過時のみ
+- スペック: ARM Ampere A1 Flex 4 OCPU / 24 GB RAM / 200 GB Block Volume /
+  10 TB outbound transfer/月
+- OS: Ubuntu 22.04 LTS (Canonical-Ubuntu-22.04-aarch64 系 image)
+- ホーム region: **Japan East (Tokyo)** — テナンシ作成時に決定、後から
+  変更不可
+- アカウントは Pay-as-you-go へ昇格推奨 (詳細 §2、Always Free 枠内は
+  課金 0)
+
+## 1. アカウント作成
+
+- oracle.com/cloud/free でサインアップ
+- ホーム region 選択時に必ず **Japan East (Tokyo)** を選ぶ (後変更不可、
+  間違えたらテナンシ作り直し)
+- クレカ認証必須 (Always Free 内は課金されないが入力必須)
+- 住所は英語表記、氏名は日本語 OK
+- 認証完了まで数十分〜数時間
+
+## 2. Pay-as-you-go 昇格 (推奨)
+
+- 理由 1: ARM A1 Tokyo は常時枯渇傾向 → 昇格すると priority queue 入りで
+  Out of Capacity 回避
+- 理由 2: 30 日無アクセス / CPU < 20%/7d で Always Free インスタンスが
+  suspend されるが、Pay-as-you-go では idle reclaim 対象外
+- Always Free 枠内の利用なら**課金は発生しない** (重要)
+- 手順: Billing → Upgrade and Manage Payment → Upgrade to Pay As You Go
+- 反映に 1-2 日かかる場合あり
+
+## 3. ARM Ampere A1 インスタンス作成
+
+- Compute → Instances → Create instance
+- Shape: **VM.Standard.A1.Flex (4 OCPU / 24 GB)** に変更
+- Image: Canonical Ubuntu 22.04 (Build for aarch64)
+- Networking: 既存 VCN + Subnet (デフォルトでよい)
+- SSH 鍵: **「Paste public keys」を選択し、ローカル `ssh-keygen -t ed25519`
+  生成済の公開鍵を貼り付け** ("Generate a key pair for me" は秘密鍵 DL
+  1 回限りで詰むリスクあり、避ける)
+- ログインユーザー: `ubuntu` (Ubuntu image のデフォルト)
+- Boot Volume: 200 GB (Always Free 上限) に拡張可
+- 罠: Tokyo で "Out of host capacity" 出る場合 → §2 Pay-as-you-go 昇格
+  + 別 AZ (AD-1/2/3) 順番に試行 + コンソール 30 秒毎リトライ
+
+## 4. Security List (VCN firewall)
+
+- Networking → Virtual Cloud Networks → 該当 VCN → Security Lists →
+  Default Security List → Add Ingress Rules
+- 追加するルール 1 件:
+  - Source CIDR: `0.0.0.0/0`
+  - IP Protocol: TCP
+  - Destination Port Range: `80,443` (カンマ区切りで両ポート同時可)
+  - Stateless: OFF
+- SSH (22) はデフォルトで開いている (変更不要)
+- **PostgreSQL 5432 は絶対に外から開けない** (Phase B で Docker 同居、
+  `127.0.0.1:5432` バインド厳守)
+- 罠: Security List だけ開けても次の §5 iptables を通らないと外部通信
+  不可
+
+## 5. iptables (Ubuntu image の鬼門)
+
+- Oracle 提供の Ubuntu image は **`iptables-persistent` で INPUT チェーン
+  末尾に `REJECT all` が入っている** → Security List で 80/443 開けても
+  弾かれる
+- 80/443 を INPUT の早い位置に挿入する必要あり
+- コマンド (順序重要、`-I INPUT 6` で REJECT より前に挿入):
+
+  ```bash
+  # `-I INPUT 6` で 6 行目に挿入 (末尾の REJECT より前に来るのが肝)。
+  # `-A INPUT` (append) では REJECT に先に当たって弾かれる。
+  sudo iptables -I INPUT 6 -m state --state NEW -p tcp --dport 80 -j ACCEPT
+  sudo iptables -I INPUT 6 -m state --state NEW -p tcp --dport 443 -j ACCEPT
+  sudo netfilter-persistent save
+  ```
+
+- 検証: `sudo iptables -L INPUT --line-numbers` で INPUT 6 行目に ACCEPT
+  が挿入されていること
+- ufw は使わない (iptables-persistent と競合、Oracle image にはデフォルト
+  未インストール)
+
+## 6. swap 4GB 作成
+
+- 24GB RAM あるが PostgreSQL + Next.js + Hono + mail-worker 同居の OOM
+  保険として 4GB
+- 8GB 以上は swap thrashing で逆効果
+- コマンド:
+
+  ```bash
+  sudo fallocate -l 4G /swapfile
+  sudo chmod 600 /swapfile
+  sudo mkswap /swapfile
+  sudo swapon /swapfile
+  # 再起動後も有効化するため fstab に追記
+  echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+  # vm.swappiness=10 は DB サーバー推奨値 (default 60 だと不要 swap 多発)
+  sudo sysctl vm.swappiness=10
+  echo 'vm.swappiness=10' | sudo tee -a /etc/sysctl.conf
+  ```
+
+- vm.swappiness=10 は DB サーバー推奨値 (default 60 だと不要 swap 多発)
+
+## 7. system user 作成
+
+- mail-worker.md と同じ `kagetra` user を使う (本番は web/api/mail-worker
+  全て同 user で運用)
+- **`-m` 付けない罠**: `/etc/skel` 由来の `.bashrc` が home に作られると
+  後の `git clone /opt/kagetra` が「destination is not empty」で失敗
+- コマンド:
+
+  ```bash
+  # `-m` は付けない。`/etc/skel` 由来の .bashrc が home にコピーされて
+  # 後の `git clone /opt/kagetra` が失敗するため。
+  sudo useradd -r -s /bin/bash -d /opt/kagetra kagetra
+  sudo install -d -o kagetra -g kagetra -m 0755 /opt/kagetra
+  ```
+
+- (Phase B で `git clone https://github.com/poponta2020/kagetra_new.git /opt/kagetra`
+  を実行)
+
+## 8. Node.js / corepack / Docker インストール
+
+- Node.js 22.13+ (mail-worker `engines.node` 要件): NodeSource apt
+  repository 経由
+
+  ```bash
+  curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+  sudo apt-get install -y nodejs
+  node --version  # v22.x 確認
+  ```
+
+- corepack 有効化 (pnpm を Node 同梱経由で解決):
+
+  ```bash
+  sudo corepack enable
+  ```
+
+- Docker (Ubuntu 22.04 ARM64 公式 apt 経由): Docker 公式手順
+  https://docs.docker.com/engine/install/ubuntu/ に従う
+- kagetra user を docker group に追加 (docker compose 実行用):
+
+  ```bash
+  sudo usermod -aG docker kagetra
+  ```
+
+## 9. Always Free 維持の注意点
+
+- **30 日無アクセス**: アカウントが abandoned 判定で suspend → 月 1 回
+  コンソールログインで OK
+- **CPU 利用率 < 20% (7 日 95th percentile)**: idle 判定でインスタンス
+  停止 (削除ではないが、再起動時 Out of Capacity リスク)
+- 本番運用 (web + api + mail-worker 30min cron) では通常閾値を超える想定
+  だが、心配なら軽い cron で負荷生成
+- **決定打**: §2 Pay-as-you-go 昇格で両方とも対象外になる
+- TOS 違反例 (kagetra は該当なし): マイニング / VPN プロキシ販売 /
+  トラフィック中継
+
+## 参考リンク
+
+- [Oracle Cloud Free Tier FAQ](https://www.oracle.com/cloud/free/faq/)
+- [Oracle: Always Free Resources 公式 doc](https://docs.oracle.com/en-us/iaas/Content/FreeTier/freetier_topic-Always_Free_Resources.htm)
+- [Resolving Out of Capacity (Hitrov, OCI CLI 自動リトライ)](https://hitrov.medium.com/resolving-oracle-cloud-out-of-capacity-issue-and-getting-free-vps-with-4-arm-cores-24gb-of-a3d7e6a027a8)
+- [Enabling Network Traffic to Ubuntu Images in OCI (Oracle 公式ブログ — iptables 罠)](https://blogs.oracle.com/developers/enabling-network-traffic-to-ubuntu-images-in-oracle-cloud-infrastructure)
+- [Docker Engine on Ubuntu (公式)](https://docs.docker.com/engine/install/ubuntu/)


### PR DESCRIPTION
## 概要

本番デプロイ計画 Phase A の **doc-only PR**。Oracle Cloud Always Free (Tokyo, ARM Ampere A1 4 OCPU/24GB RAM/200GB SSD) + お名前.com DNS + Let's Encrypt SSL までの手動セットアップ手順を整備する。実機セットアップとコード変更はこの PR には含まない。

## 背景

旧 kagetra (`hokudaicarta.com` root) と並行稼働する形で、新システム kagetra_new を `new.hokudaicarta.com` サブドメインで本番運用する。Phase A-D の 4 段階構成のうちの最初。

- Phase A (本 PR): インフラ + DNS/SSL の手動セットアップ doc
- Phase B (今後): apps/web / apps/api / postgres を systemd + docker-compose で起動配線
- Phase C (今後): pg_dump → Cloudflare R2 バックアップ
- Phase D (今後): 本番初回起動 + 動作確認

## 新規ファイル

| ファイル | 行数 | 内容 |
|---|---|---|
| `docs/deploy/oracle-setup.md` | 170 | Oracle アカウント作成 → Tokyo ARM A1 起動 → Security List → **iptables 罠** (INPUT 末尾 REJECT を回避する `-I INPUT 6` 挿入) → swap 4GB → kagetra user (**`-m` 罠**) → Node 22 / corepack / Docker |
| `docs/deploy/dns-ssl.md` | 140 | お名前.com で `new.hokudaicarta.com` A レコード追加 → DNS 反映待ち → nginx → certbot で Let's Encrypt SSL + 自動更新 timer |
| `docs/deploy/README.md` | 52 | deploy doc 群 index + Phase A-D 概要 + 確定済み構成表 |

## ドメイン戦略

- **サブドメイン分離方式**: `new.hokudaicarta.com` で新システム、root `hokudaicarta.com` は旧 kagetra 継続
- **DNS は移管しない**: お名前.com のまま `new` の A レコード追加のみ (旧 kagetra への影響ゼロ)
- Cloudflare は Phase C で R2 用途のみ利用 (DNS 機能不使用)
- ドメイン cutover (`new.` → root) は Phase 4 完了 + データ移行完了後に別 PR で実施

## 罠系記述 (本 PR で明示)

- **iptables**: Oracle Ubuntu image の INPUT 末尾に REJECT 既存 → `-A` で 80/443 追加すると弾かれる → `-I INPUT 6` で挿入必須
- **ホーム region**: テナンシ作成時に Japan East (Tokyo) 必須、後変更不可
- **SSH 鍵**: "Generate a key pair for me" は秘密鍵 DL 1 回限りで詰むので "Paste public keys" + ローカル `ssh-keygen` 推奨
- **useradd**: `-m` 付けると `/etc/skel` 由来の `.bashrc` で後の `git clone /opt/kagetra` が「destination not empty」失敗 (mail-worker.md と同じ罠)
- **swap**: 8GB 以上は thrashing で逆効果、4GB + `vm.swappiness=10` 推奨
- **Always Free 維持**: 30 日無アクセス suspend / CPU < 20%/7d で idle 停止 → Pay-as-you-go 昇格で両方対象外 (枠内は課金 0)
- **certbot**: DNS 反映前に実行すると DNS-01 challenge 失敗

## テスト計画

- [x] **doc-only のため自動テストなし** (新規 doc 追加のみで既存ファイル無修正、type check / lint / vitest にリグレッションなし)
- [ ] **実機検証は Phase D** (`initial-launch-checklist.md` で消化)、Phase A 単独では「ユーザーが手順通りに Oracle + DNS + SSL をセットアップして `curl -I https://new.hokudaicarta.com` が 200 を返す」が成功基準

## ユーザー手動作業 (この PR merge 後、Phase B 着手前)

1. Oracle Cloud アカウント作成 (oracle-setup.md §1)
2. Pay-as-you-go 昇格 (§2)
3. ARM A1 4 OCPU/24GB インスタンス起動 (§3、Out of Capacity 時は数日リトライ可能)
4. Security List 80/443 開放 (§4)
5. iptables `-I INPUT 6` で 80/443 挿入 (§5、最大罠)
6. swap + user + Node + Docker (§6-§8)
7. お名前.com で `new` A レコード追加 (dns-ssl.md §1)
8. DNS 反映待ち (§2、最大 24-48h)
9. nginx + certbot (§3-§6)

## 参考

- 既存 `docs/deploy/mail-worker.md` の style (Markdown 構造 / トラブルシュート表 / コードブロック内コメント / `## N. セクション` 番号付け) を完全踏襲
- mail-worker は同じ Oracle インスタンス上で Phase B 以降に systemd timer で配線済 (既存 `apps/mail-worker/systemd/*` 流用)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>