### PR TITLE
feat(deploy): Phase B — apps/web + apps/api + postgres + nginx 本番起動配線

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,35 @@
+# kagetra_new 本番 env テンプレート。実値は /opt/kagetra/.env.production (mode 0600, owner kagetra) に書く。
+# scripts/deploy/apply-migrations.sh、docker compose、systemd unit、mail-worker が EnvironmentFile として読む。
+
+# === Database (Docker postgres) ===
+POSTGRES_DB=kagetra
+POSTGRES_USER=kagetra
+POSTGRES_PASSWORD=CHANGEME_strong_password_32_or_more_chars
+DATABASE_URL=postgres://kagetra:CHANGEME_strong_password_32_or_more_chars@127.0.0.1:5432/kagetra?sslmode=disable
+
+# === Auth.js (apps/web) ===
+# AUTH_SECRET は `openssl rand -base64 32` で生成、dev の test secret は絶対流用しない
+AUTH_SECRET=CHANGEME_openssl_rand_base64_32
+NEXTAUTH_URL=https://new.hokudaicarta.com
+
+# === LINE Login (production channel、新規取得) ===
+# redirect URI: https://new.hokudaicarta.com/api/auth/callback/line
+AUTH_LINE_ID=CHANGEME
+AUTH_LINE_SECRET=CHANGEME
+LINE_LOGIN_CHANNEL_ID=CHANGEME
+LINE_LOGIN_CHANNEL_SECRET=CHANGEME
+LINE_LOGIN_CALLBACK_URL=https://new.hokudaicarta.com/api/line-link/callback
+
+# === API ===
+# NEXT_PUBLIC_API_URL は dev/prod 共通で /hono-api (Hono basePath、Phase B Option B)
+NEXT_PUBLIC_API_URL=/hono-api
+FRONTEND_URL=https://new.hokudaicarta.com
+# PORT は systemd unit 内で web=3000、api=3001 を個別設定するので、ここでは設定しない
+
+# === mail-worker (既存 docs/deploy/mail-worker.md と整合) ===
+ANTHROPIC_API_KEY=CHANGEME
+YAHOO_IMAP_USER=CHANGEME@yahoo.co.jp
+YAHOO_IMAP_APP_PASSWORD=CHANGEME
+YAHOO_IMAP_HOST=imap.mail.yahoo.co.jp
+YAHOO_IMAP_PORT=993
+MAIL_WORKER_PDF_SIZE_LIMIT_KB=800

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ coverage/
 .env
 .env.*
 !.env.example
+!.env.*.example
 *.tsbuildinfo
 scripts/migration/dump/
 test-results/

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,4 @@
+# apps/api 用 env サンプル。実値は .env (gitignored) に書く。
+PORT=3001
+DATABASE_URL=postgres://kagetra:kagetra@localhost:5432/kagetra?sslmode=disable
+FRONTEND_URL=http://localhost:3000

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -3,7 +3,8 @@ import { logger } from 'hono/logger'
 import { cors } from 'hono/cors'
 import { eventsRoute } from './routes/events'
 
-const app = new Hono().basePath('/api')
+// basePath は dev/prod 一貫で '/hono-api'。Next.js (apps/web) の Auth.js (/api/auth/*) や line-link (/api/line-link/*) との path 衝突を回避するため、Hono は別 prefix を持つ。本番 nginx は /hono-api/* を api 3001 に振り分ける (docker/nginx/kagetra.conf.example 参照)。
+const app = new Hono().basePath('/hono-api')
 
 app.use('*', logger())
 app.use('*', cors({

--- a/apps/api/systemd/kagetra-api.service
+++ b/apps/api/systemd/kagetra-api.service
@@ -1,0 +1,29 @@
+[Unit]
+Description=Kagetra api (Hono + @hono/node-server)
+After=network.target postgresql.service
+Documentation=https://github.com/poponta2020/kagetra_new/blob/main/docs/deploy/api.md
+
+[Service]
+Type=simple
+
+User=kagetra
+Group=kagetra
+
+# tsup build 後の dist/ を直接起動。@kagetra/shared workspace 依存は
+# /opt/kagetra/node_modules で解決される前提。
+WorkingDirectory=/opt/kagetra/apps/api
+
+EnvironmentFile=/opt/kagetra/.env.production
+Environment=PORT=3001
+Environment=NODE_ENV=production
+
+ExecStart=/usr/bin/node dist/index.js
+
+Restart=on-failure
+RestartSec=5
+
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/apps/web/.env.local.example
+++ b/apps/web/.env.local.example
@@ -1,0 +1,10 @@
+# apps/web 用 env サンプル。実値は .env.local (gitignored) に書く。
+NEXT_PUBLIC_API_URL=/hono-api
+NEXTAUTH_URL=http://localhost:3000
+AUTH_SECRET=e2e-test-secret-do-not-use-in-production
+AUTH_LINE_ID=dummy_dev_channel_id
+AUTH_LINE_SECRET=dummy_dev_channel_secret
+LINE_LOGIN_CHANNEL_ID=dummy_dev_channel_id
+LINE_LOGIN_CHANNEL_SECRET=dummy_dev_channel_secret
+LINE_LOGIN_CALLBACK_URL=http://localhost:3000/api/line-link/callback
+DATABASE_URL=postgres://kagetra:kagetra@localhost:5433/kagetra

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
@@ -9,6 +10,14 @@ const nextConfig: NextConfig = {
   // actions.ts → classifier.ts → ../persist/draft.js cannot be resolved.
   transpilePackages: ['@kagetra/shared', '@kagetra/mail-worker'],
   output: 'standalone',
+  // monorepo の root を明示。Next.js 15 は auto-detect するが、CI/prod 差異リスク回避のため明示 (Phase B Phase 0 Discovery 結果)。
+  outputFileTracingRoot: path.join(__dirname, '../../'),
+  // dev で Hono RPC client (apps/web/src/lib/api.ts) の相対 path '/hono-api/*' を http://localhost:3001 に転送する。本番は nginx が同じ path を api 3001 に proxy_pass するので、ここでは production=空配列。
+  async rewrites() {
+    return process.env.NODE_ENV === 'production'
+      ? []
+      : [{ source: '/hono-api/:path*', destination: 'http://localhost:3001/hono-api/:path*' }]
+  },
   webpack: (config) => {
     // Resolve `import './foo.js'` against `./foo.ts` so the `.js`-suffixed
     // relative imports inside @kagetra/mail-worker (NodeNext / TS bundler

--- a/apps/web/scripts/__tests__/seed-initial-admin.test.ts
+++ b/apps/web/scripts/__tests__/seed-initial-admin.test.ts
@@ -1,0 +1,134 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { users } from '@kagetra/shared/schema'
+import { closeTestDb, testDb, truncateAll } from '@/test-utils/db'
+import { createUser, createAdmin } from '@/test-utils/seed'
+import { seedInitialAdmin } from '../seed-initial-admin'
+
+beforeEach(async () => {
+  await truncateAll()
+})
+
+afterAll(async () => {
+  await closeTestDb()
+})
+
+describe('seedInitialAdmin', () => {
+  it('inserts a new admin row when no user with the given email exists', async () => {
+    const result = await seedInitialAdmin(testDb, {
+      name: '管理者 太郎',
+      email: 'admin1@example.com',
+    })
+
+    expect(result.kind).toBe('inserted')
+
+    const rows = await testDb
+      .select()
+      .from(users)
+      .where(eq(users.email, 'admin1@example.com'))
+    expect(rows).toHaveLength(1)
+    const inserted = rows[0]!
+    expect(inserted.name).toBe('管理者 太郎')
+    expect(inserted.role).toBe('admin')
+    expect(inserted.isInvited).toBe(true)
+    expect(inserted.grade).toBe('A')
+    expect(inserted.lineUserId).toBeNull()
+    expect(inserted.invitedAt).not.toBeNull()
+  })
+
+  it('is idempotent: a second call with the same email leaves a single admin row', async () => {
+    await seedInitialAdmin(testDb, {
+      name: '管理者 太郎',
+      email: 'admin1@example.com',
+    })
+    const second = await seedInitialAdmin(testDb, {
+      name: '管理者 太郎 (再実行)',
+      email: 'admin1@example.com',
+    })
+
+    expect(second.kind).toBe('noop')
+
+    const rows = await testDb
+      .select()
+      .from(users)
+      .where(eq(users.email, 'admin1@example.com'))
+    expect(rows).toHaveLength(1)
+    // Name is NOT overwritten by a no-op call — the original name is preserved.
+    expect(rows[0]!.name).toBe('管理者 太郎')
+  })
+
+  it('promotes an existing member to admin while preserving other fields', async () => {
+    const member = await createUser({
+      name: '一般 会員',
+      email: 'member1@example.com',
+      role: 'member',
+      grade: 'C',
+    })
+
+    const result = await seedInitialAdmin(testDb, {
+      name: 'IGNORED on promote',
+      email: 'member1@example.com',
+    })
+
+    expect(result.kind).toBe('promoted')
+    if (result.kind === 'promoted') {
+      expect(result.previousRole).toBe('member')
+      expect(result.userId).toBe(member.id)
+    }
+
+    const rows = await testDb
+      .select()
+      .from(users)
+      .where(eq(users.email, 'member1@example.com'))
+    expect(rows).toHaveLength(1)
+    const promoted = rows[0]!
+    expect(promoted.role).toBe('admin')
+    expect(promoted.isInvited).toBe(true)
+    // Other fields stay intact (only role / isInvited / updatedAt change on promote).
+    expect(promoted.name).toBe('一般 会員')
+    expect(promoted.grade).toBe('C')
+  })
+
+  it('is a no-op when the existing user is already an admin', async () => {
+    const existing = await createAdmin({
+      email: 'admin2@example.com',
+      name: 'Existing Admin',
+    })
+
+    const result = await seedInitialAdmin(testDb, {
+      name: 'IGNORED',
+      email: 'admin2@example.com',
+    })
+
+    expect(result.kind).toBe('noop')
+    if (result.kind === 'noop') {
+      expect(result.userId).toBe(existing.id)
+    }
+
+    const rows = await testDb
+      .select()
+      .from(users)
+      .where(eq(users.email, 'admin2@example.com'))
+    expect(rows[0]!.name).toBe('Existing Admin')
+    expect(rows[0]!.role).toBe('admin')
+  })
+
+  it('allows multiple admins as long as their emails differ', async () => {
+    await seedInitialAdmin(testDb, {
+      name: 'Admin A',
+      email: 'adminA@example.com',
+    })
+    await seedInitialAdmin(testDb, {
+      name: 'Admin B',
+      email: 'adminB@example.com',
+    })
+
+    const all = await testDb
+      .select()
+      .from(users)
+      .where(eq(users.role, 'admin'))
+    expect(all).toHaveLength(2)
+    const emails = all.map((u) => u.email).sort()
+    expect(emails).toEqual(['adminA@example.com', 'adminB@example.com'])
+  })
+})

--- a/apps/web/scripts/seed-initial-admin.ts
+++ b/apps/web/scripts/seed-initial-admin.ts
@@ -1,0 +1,192 @@
+#!/usr/bin/env tsx
+/**
+ * Production-only helper: seed (or idempotently promote) an initial admin user
+ * directly into the users table, bypassing LINE OAuth. This is the
+ * bootstrapping step right after `apply-migrations.sh` so a real human can log
+ * in via /api/auth/signin/line and have admin role — without it, no one can
+ * mint other admins through the UI.
+ *
+ * Usage (from repo root, on the production host):
+ *   DATABASE_URL=postgres://... pnpm --filter @kagetra/web exec tsx \
+ *     scripts/seed-initial-admin.ts --name="管理者 太郎" --email=admin@example.com
+ *
+ *   # grade is optional, defaults to 'A'
+ *   ... --name=... --email=... --grade=B
+ *
+ * Idempotency:
+ *   - email 一致行が無ければ INSERT (role='admin', isInvited=true, grade='A',
+ *     lineUserId=null, invitedAt=now)
+ *   - email 一致行があり role != 'admin' → UPDATE して admin に昇格 (name 等は不変)
+ *   - email 一致行があり既に role='admin' → no-op
+ *
+ * The script intentionally does NOT take a `--line-user-id` — the operator
+ * logs in via LINE Login first time, and self-identify (or admin-link) maps
+ * the LINE id to this seeded admin row.
+ */
+
+import { config as loadEnv } from 'dotenv'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+// Load apps/web/.env.local in dev (parity with dev-issue-cookie.ts); in
+// production the systemd unit / shell wraps DATABASE_URL into process.env so
+// the file may not exist — dotenv just no-ops in that case.
+const here = dirname(fileURLToPath(import.meta.url))
+loadEnv({ path: resolve(here, '..', '.env.local') })
+
+import { Pool } from 'pg'
+import { drizzle } from 'drizzle-orm/node-postgres'
+import { eq } from 'drizzle-orm'
+import { users } from '@kagetra/shared/schema'
+
+type Grade = 'A' | 'B' | 'C' | 'D' | 'E'
+
+const VALID_GRADES: readonly Grade[] = ['A', 'B', 'C', 'D', 'E']
+
+export interface SeedInitialAdminInput {
+  name: string
+  email: string
+  grade?: Grade
+}
+
+export type SeedInitialAdminResult =
+  | { kind: 'inserted'; userId: string }
+  | { kind: 'promoted'; userId: string; previousRole: string }
+  | { kind: 'noop'; userId: string }
+
+/**
+ * Idempotently seed (or promote) an admin user.
+ *
+ * Exported as a pure function so vitest can drive it with the test DB
+ * connection without touching process.argv / process.exit.
+ */
+export async function seedInitialAdmin(
+  db: ReturnType<typeof drizzle>,
+  input: SeedInitialAdminInput,
+): Promise<SeedInitialAdminResult> {
+  const grade: Grade = input.grade ?? 'A'
+
+  const existing = await db
+    .select()
+    .from(users)
+    .where(eq(users.email, input.email))
+    .limit(1)
+  const current = existing[0]
+
+  if (!current) {
+    const inserted = await db
+      .insert(users)
+      .values({
+        name: input.name,
+        email: input.email,
+        role: 'admin',
+        isInvited: true,
+        invitedAt: new Date(),
+        grade,
+        lineUserId: null,
+      })
+      .returning()
+    const row = inserted[0]
+    if (!row) throw new Error('Failed to insert initial admin user')
+    return { kind: 'inserted', userId: row.id }
+  }
+
+  if (current.role === 'admin') {
+    return { kind: 'noop', userId: current.id }
+  }
+
+  const previousRole = current.role
+  await db
+    .update(users)
+    .set({ role: 'admin', isInvited: true, updatedAt: new Date() })
+    .where(eq(users.id, current.id))
+  return { kind: 'promoted', userId: current.id, previousRole }
+}
+
+interface ParsedArgs {
+  name: string
+  email: string
+  grade?: Grade
+}
+
+function parseArgs(argv: readonly string[]): ParsedArgs {
+  let name: string | null = null
+  let email: string | null = null
+  let grade: Grade | undefined = undefined
+  for (const arg of argv) {
+    const m = /^--([a-z-]+)=(.*)$/.exec(arg)
+    if (!m) continue
+    const [, key, value] = m
+    if (key === 'name') {
+      name = value!
+    } else if (key === 'email') {
+      email = value!
+    } else if (key === 'grade') {
+      if (!(VALID_GRADES as readonly string[]).includes(value!)) {
+        throw new Error(
+          `--grade must be one of ${VALID_GRADES.join(', ')} (got "${value}")`,
+        )
+      }
+      grade = value as Grade
+    }
+  }
+  if (!email) {
+    throw new Error('--email is required (e.g. --email=admin@example.com)')
+  }
+  if (!name) {
+    throw new Error('--name is required (e.g. --name="管理者 太郎")')
+  }
+  return { name, email, grade }
+}
+
+export async function main(argv: readonly string[] = process.argv.slice(2)): Promise<void> {
+  const { name, email, grade } = parseArgs(argv)
+  const databaseUrl = process.env.DATABASE_URL
+  if (!databaseUrl) throw new Error('DATABASE_URL not set')
+
+  const pool = new Pool({ connectionString: databaseUrl })
+  try {
+    const db = drizzle(pool)
+    const result = await seedInitialAdmin(db, { name, email, grade })
+    if (result.kind === 'inserted') {
+      process.stdout.write(
+        `[seed-initial-admin] inserted admin ${result.userId} (${email})\n`,
+      )
+    } else if (result.kind === 'promoted') {
+      process.stdout.write(
+        `[seed-initial-admin] promoted ${result.userId} (${email}) ` +
+          `from role=${result.previousRole} to admin\n`,
+      )
+    } else {
+      process.stdout.write(
+        `[seed-initial-admin] no-op: ${result.userId} (${email}) is already admin\n`,
+      )
+    }
+  } finally {
+    await pool.end()
+  }
+}
+
+// CLI entry. When this file is imported (by vitest) `import.meta.url` won't
+// match `process.argv[1]`, so the body is skipped — tests drive `seedInitialAdmin`
+// directly with the test DB.
+const isDirectRun = (() => {
+  if (!process.argv[1]) return false
+  try {
+    return fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  } catch {
+    return false
+  }
+})()
+
+if (isDirectRun) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      process.stderr.write(
+        `[seed-initial-admin] ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`,
+      )
+      process.exit(1)
+    },
+  )
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,6 +1,7 @@
 import { hc } from 'hono/client'
 import type { AppType } from '@kagetra/api/types'
 
+// baseUrl は dev/prod 共通で '/hono-api' (相対 path)。dev は next.config.ts の rewrites が /hono-api/* を http://localhost:3001/hono-api/* に転送、prod は nginx が同じ path を api 3001 に proxy_pass する。NEXT_PUBLIC_API_URL env で上書き可。
 export const apiClient = hc<AppType>(
-  process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001'
+  process.env.NEXT_PUBLIC_API_URL ?? '/hono-api'
 )

--- a/apps/web/systemd/kagetra-web.service
+++ b/apps/web/systemd/kagetra-web.service
@@ -1,0 +1,41 @@
+[Unit]
+Description=Kagetra web (Next.js 15 standalone)
+After=network.target postgresql.service
+Documentation=https://github.com/poponta2020/kagetra_new/blob/main/docs/deploy/web.md
+
+[Service]
+# Next.js standalone build は self-contained Node サーバー、常駐 simple service。
+# graceful shutdown は Next.js が SIGTERM を内部処理 (Node http.Server.close)。
+Type=simple
+
+# 専用 system user (root 回避、docs/deploy/oracle-setup.md §7 で作成済)。
+User=kagetra
+Group=kagetra
+
+# Next.js 15 monorepo standalone の出力先。`apps/web/server.js` を起動する。
+# `cp -r apps/web/public apps/web/.next/standalone/apps/web/` +
+# `cp -r apps/web/.next/static apps/web/.next/standalone/apps/web/.next/` を
+# 事前に deploy script で実施しておく必要あり (docs/deploy/web.md §4 参照)。
+WorkingDirectory=/opt/kagetra/apps/web/.next/standalone
+
+# DATABASE_URL, AUTH_SECRET, NEXTAUTH_URL, AUTH_LINE_*, NEXT_PUBLIC_API_URL 等
+# を含む。実体は .env.production (mode 0600, owner kagetra)、commit しない。
+EnvironmentFile=/opt/kagetra/.env.production
+
+# 個別環境変数 (EnvironmentFile に書かないもの)。
+Environment=PORT=3000
+Environment=HOSTNAME=127.0.0.1
+Environment=NODE_ENV=production
+
+# server.js は monorepo path として apps/web/server.js に配置される。
+ExecStart=/usr/bin/node apps/web/server.js
+
+# 異常終了時は自動再起動 (Next.js の例外で落ちた場合に備える)。
+Restart=on-failure
+RestartSec=5
+
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -1,0 +1,24 @@
+# 本番 PostgreSQL のみ。web/api/mail-worker は systemd で別途起動。
+# localhost bind 厳守 (127.0.0.1:5432)、外部公開禁止 (Security List で 5432 開けない)。
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: kagetra-postgres
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:5432:5432"  # localhost のみ bind、絶対外部に開けない
+    volumes:
+      - kagetra-pgdata:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-kagetra}
+      POSTGRES_USER: ${POSTGRES_USER:-kagetra}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER:-kagetra}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  kagetra-pgdata:
+    name: kagetra-pgdata

--- a/docker/nginx/kagetra.conf.example
+++ b/docker/nginx/kagetra.conf.example
@@ -1,0 +1,56 @@
+# kagetra_new 本番 nginx config テンプレート (sample)。
+# /etc/nginx/sites-available/kagetra に配置 → /etc/nginx/sites-enabled/ に symlink。
+# certbot --nginx で SSL 設定済 (`docs/deploy/dns-ssl.md` §5 完了) の上から
+# location ブロックだけ上書きする想定。
+#
+# 設定方針 (Phase B Option B):
+# - /hono-api/* は Hono API (port 3001) に proxy_pass
+# - それ以外 (Next.js web、Auth.js /api/auth/*、line-link /api/line-link/*、
+#   admin /api/admin/*、静的アセット 等) は全部 Next.js web (port 3000) に
+#
+# Hono の basePath は '/hono-api' なので nginx は prefix を剥がさず転送。
+
+server {
+    listen 443 ssl http2;
+    server_name new.hokudaicarta.com;
+
+    # certbot --nginx が生成した SSL 設定をそのまま使う。
+    ssl_certificate /etc/letsencrypt/live/new.hokudaicarta.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/new.hokudaicarta.com/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    # アップロード上限 (mail-worker の PDF 添付や将来の Phase 4 アルバム用)
+    client_max_body_size 32M;
+
+    # Hono API: /hono-api/* → port 3001 に転送 (prefix 剥がさない)
+    location /hono-api/ {
+        proxy_pass http://127.0.0.1:3001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+    }
+
+    # それ以外 (Next.js web、Auth.js、line-link、静的アセット 等)
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        # WebSocket / SSE 用 (Next.js dev HMR は本番不要だが、将来の Phase で
+        # SSE 通知等を使う可能性に備えて)。
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}
+
+# HTTP -> HTTPS リダイレクト (certbot が生成した default を上書き)
+server {
+    listen 80;
+    server_name new.hokudaicarta.com;
+    return 301 https://$host$request_uri;
+}

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -9,20 +9,20 @@ Phase A-D の段階構成で進める。
 |---|---|---|
 | A | `oracle-setup.md` | Oracle Cloud アカウント作成 → Tokyo ARM A1 インスタンス起動 → iptables/swap/user/Node/Docker セットアップ |
 | A | `dns-ssl.md` | お名前.com で `new.hokudaicarta.com` A レコード追加 → nginx → Let's Encrypt SSL |
-| B | `postgres.md` (今後追加) | Docker Compose で PostgreSQL 16 起動 + migration 適用 + 接続確認 |
-| B | `web.md` (今後追加) | apps/web (Next.js standalone) を systemd service として起動 |
-| B | `api.md` (今後追加) | apps/api (Hono) を systemd service として起動 |
+| B | [postgres.md](postgres.md) | Docker Compose で PostgreSQL 16 起動 + apply-migrations.sh で migration 適用 + 接続確認 |
+| B | [web.md](web.md) | apps/web (Next.js 15 standalone) を systemd service として起動 + 静的アセット cp + nginx 配線 |
+| B | [api.md](api.md) | apps/api (Hono) を systemd service として起動、basePath は /hono-api |
 | P3-A 既存 | `mail-worker.md` | apps/mail-worker (cron 30 分) を systemd timer で起動 (既存) |
 | C | `backup-restore.md` (今後追加) | pg_dump → Cloudflare R2 日次バックアップ + 復元手順 |
 | D | `initial-launch-checklist.md` (今後追加) | 全 Phase 揃った後の初回起動・動作確認チェックリスト |
 
 ## Phase 構成
 
-- **Phase A** (現在): インフラ準備 + 手動セットアップ doc のみ (コード
-  変更なし)
-- **Phase B**: アプリケーションデプロイ配線 (systemd unit /
+- **Phase A**: インフラ準備 + 手動セットアップ doc のみ (コード変更なし)
+  — 完了 (PR #32)
+- **Phase B** (現在): アプリケーションデプロイ配線 (systemd unit /
   docker-compose.prod.yml / nginx 設定 / migration script / 初期 admin
-  seed)
+  seed) — 実装中 (本 PR)
 - **Phase C**: バックアップ配線 (pg_dump → R2 + LINE 失敗通知 + 復元手順)
 - **Phase D**: 本番初回起動 + 動作確認 + ship
 
@@ -35,8 +35,7 @@ Phase A-D の段階構成で進める。
 | ドメイン | `new.hokudaicarta.com` (サブドメイン分離、root は旧 kagetra 並行稼働) |
 | DNS | お名前.com (移管しない) |
 | SSL | Let's Encrypt (certbot, 自動更新) |
-| reverse proxy | nginx (port 80/443 → web 3000 デフォルト、Hono API は別 path prefix or 別サブドメインで分離 — Phase B で詳細設計) |
-| 認証経路の注意 | LINE Login の redirect URI は `/api/auth/callback/line` で Next.js (web 3000) の Auth.js App Router が処理する。Phase B で `/api/*` を Hono (api 3001) に全部流すと Auth.js callback が壊れるため、`/api/auth/*` は明示的に web 3000 にルートする (or Hono を `/hono-api/*` 等に分離) |
+| reverse proxy | nginx (port 80/443 → /hono-api/* は api 3001、それ以外は web 3000) |
 | DB | PostgreSQL 16 (Docker 同居、localhost bind) |
 | バックアップ | Cloudflare R2 (10GB 無料 tier, 日次 03:00 JST + GFS rotation) |
 | LINE Login (production) | 新規取得 (redirect URI: `https://new.hokudaicarta.com/api/auth/callback/line`) |

--- a/docs/deploy/api.md
+++ b/docs/deploy/api.md
@@ -1,0 +1,54 @@
+# apps/api (Hono) デプロイ手順
+
+kagetra_new バックエンド API (Hono on Node) を systemd service として
+起動する手順。tsup build で `dist/index.js` 生成、port 3001 で待ち受け、
+nginx が `/hono-api/*` を proxy_pass する。basePath は `/hono-api`
+(Phase B Option B、Phase A R3 Codex 指摘の Auth.js callback 衝突回避)。
+
+## 0. 前提
+
+- Phase A 完了 (`docs/deploy/oracle-setup.md` / `docs/deploy/dns-ssl.md`)
+- `docs/deploy/postgres.md` 完了 (PostgreSQL 起動 + migration 適用済)
+- `docs/deploy/web.md` §1〜§2 完了想定 (`git clone` + `pnpm install` は
+  monorepo 共通)
+
+## 1. build
+
+```bash
+cd /opt/kagetra
+sudo -u kagetra corepack pnpm --filter @kagetra/api build
+```
+
+- tsup で `apps/api/dist/index.js` 生成
+- `@kagetra/shared` workspace 依存は `/opt/kagetra/node_modules` で
+  resolved される (pnpm の symlink)
+
+## 2. systemd unit 配置 + enable
+
+```bash
+sudo cp /opt/kagetra/apps/api/systemd/kagetra-api.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now kagetra-api.service
+sudo systemctl status kagetra-api.service
+```
+
+## 3. 動作確認
+
+```bash
+# local の port 3001 で health endpoint が応答すること
+curl http://127.0.0.1:3001/hono-api/health
+# → {"status":"ok"} が返れば OK
+# nginx 経由 (Phase A SSL 完了後):
+curl https://new.hokudaicarta.com/hono-api/health
+# journalctl
+sudo journalctl -u kagetra-api.service -n 50 --no-pager
+```
+
+## 4. トラブルシュート
+
+| 症状 | 原因と対応 |
+|---|---|
+| curl `/hono-api/health` で 404 | basePath 設定間違い、`apps/api/src/app.ts` の `app.basePath('/hono-api')` 確認 (Stream 0 で変更済) |
+| curl で connection refused | systemd 起動失敗、`journalctl -u kagetra-api.service -n 100` で詳細 |
+| `Cannot find module '@kagetra/shared'` | pnpm workspace の symlink が壊れている、`/opt/kagetra/node_modules/@kagetra/shared` を確認、再度 `corepack pnpm install` |
+| DATABASE_URL 接続失敗 | `.env.production` の `DATABASE_URL` が正しいか + postgres container 起動済か確認 (`docker compose -f docker/docker-compose.prod.yml ps`) |

--- a/docs/deploy/postgres.md
+++ b/docs/deploy/postgres.md
@@ -1,0 +1,83 @@
+# PostgreSQL (Docker) セットアップ
+
+kagetra_new 本番の PostgreSQL 16 を Docker Compose で同居起動する手順。
+`docker/docker-compose.prod.yml` を使い、localhost (127.0.0.1:5432) bind
+厳守で外部公開しない。drizzle migration の適用は
+`scripts/deploy/apply-migrations.sh` で psql 経由実施 (drizzle-kit migrate は
+TTY 必須で本番不適、Phase 0 Discovery 結果)。
+
+## 0. 前提
+
+- Phase A 完了 (`docs/deploy/oracle-setup.md` / `docs/deploy/dns-ssl.md`)
+- Docker / Docker Compose plugin install 済 (`oracle-setup.md` §8)
+- `.env.production` が `/opt/kagetra/.env.production` に配置済 (mode 0600,
+  owner `kagetra`、`POSTGRES_PASSWORD` / `DATABASE_URL` / `AUTH_SECRET` /
+  `AUTH_LINE_*` / `ANTHROPIC_API_KEY` 等を含む)
+- `/opt/kagetra/` に git clone 済 (`docs/deploy/mail-worker.md` §1 と同じ
+  手順、`useradd -r` + `install -d` + `git clone`)
+
+## 1. docker compose 起動
+
+```bash
+cd /opt/kagetra
+sudo -u kagetra docker compose -f docker/docker-compose.prod.yml up -d
+```
+
+起動確認:
+
+```bash
+sudo -u kagetra docker compose -f docker/docker-compose.prod.yml ps
+```
+
+healthcheck が pass するまで 10〜30 秒待つ (status が `healthy` になれば OK)。
+
+## 2. DB 接続確認
+
+```bash
+sudo -u kagetra docker exec -it kagetra-postgres psql -U kagetra -d kagetra -c '\dt'
+```
+
+→ 何もテーブルがない状態 (Tables: empty) で正常 (まだ migration 未適用)。
+
+## 3. jq install (apply-migrations.sh の依存)
+
+```bash
+sudo apt install -y jq postgresql-client
+```
+
+- `jq`: apply-migrations.sh が drizzle journal (`_journal.json`) を parse
+  するのに使う
+- `postgresql-client`: host から psql を直接実行する用。docker exec 経由
+  なら不要だが、apply-migrations.sh は host で実行する想定なので入れておく
+
+## 4. migration 適用
+
+```bash
+cd /opt/kagetra
+sudo -u kagetra bash -c 'source .env.production && export DATABASE_URL="postgres://kagetra:$POSTGRES_PASSWORD@127.0.0.1:5432/kagetra?sslmode=disable" && bash scripts/deploy/apply-migrations.sh'
+```
+
+- 実値は env 経由で渡し、`POSTGRES_PASSWORD` を CLI に直接書かない
+- 0000-0011 の 12 migration が順次 APPLY、success 出力で完了
+- 再実行は SKIP メッセージ (idempotent、`__drizzle_migrations` テーブルで
+  既適用 hash を見て分岐)
+
+## 5. 接続テスト
+
+```bash
+sudo -u kagetra docker exec -it kagetra-postgres psql -U kagetra -d kagetra -c '\dt'
+```
+
+→ `users` / `events` / `event_attendances` / `mail_messages` 等
+(10+ tables) が見える。
+
+## 6. トラブルシュート
+
+| 症状 | 原因と対応 |
+|---|---|
+| `docker compose up -d` で port 5432 already in use | host の PostgreSQL が既に動いている、`sudo systemctl stop postgresql` で止める (kagetra は Docker 経由のみ使う想定) |
+| apply-migrations.sh で `psql: command not found` | postgresql-client 未 install、§3 参照 |
+| apply-migrations.sh で `jq: command not found` | jq 未 install、§3 参照 |
+| apply-migrations.sh で permission denied | `chmod +x scripts/deploy/apply-migrations.sh` |
+| migration が部分適用で失敗 | 個別 SQL の構文エラー or schema 衝突、pg_dump からの restore が必要 (Phase C `backup-restore.md` 参照、まだ未整備なので docker volume 削除 + 最初から: `docker compose -f docker/docker-compose.prod.yml down -v` で kagetra-pgdata を消す) |
+| `__drizzle_migrations` テーブルが見えない | drizzle schema (`SET search_path TO drizzle;` または `SELECT * FROM drizzle.__drizzle_migrations;`) |

--- a/docs/deploy/web.md
+++ b/docs/deploy/web.md
@@ -1,0 +1,92 @@
+# apps/web (Next.js 15 standalone) デプロイ手順
+
+kagetra_new フロントエンド (Next.js 15 App Router) を Oracle Cloud
+Ubuntu 22.04 上に systemd service として起動する手順。Next.js standalone
+output を `apps/web/.next/standalone/` から起動、port 3000 で nginx が
+reverse proxy する。
+
+## 0. 前提
+
+- Phase A 完了 (`docs/deploy/oracle-setup.md` / `docs/deploy/dns-ssl.md`)
+- `docs/deploy/postgres.md` 完了 (PostgreSQL 起動 + migration 適用済)
+- Node 22 + corepack pnpm 9.x install 済 (`oracle-setup.md` §6)
+- `kagetra` user + `/opt/kagetra` 準備済 (`mail-worker.md` §1 と同じ)
+- `.env.production` 配置済 (`postgres.md` §0 参照)
+
+## 1. git clone (まだなら)
+
+```bash
+# mail-worker と同じ /opt/kagetra に clone 済の前提。未 clone なら:
+sudo -u kagetra git clone https://github.com/poponta2020/kagetra_new.git /opt/kagetra
+```
+
+## 2. pnpm install
+
+```bash
+cd /opt/kagetra
+sudo -u kagetra corepack pnpm install --frozen-lockfile
+```
+
+## 3. build
+
+```bash
+sudo -u kagetra corepack pnpm --filter @kagetra/web build
+```
+
+- Next.js standalone は `apps/web/.next/standalone/` に出力される
+- monorepo 構造が反映され、`apps/web/.next/standalone/apps/web/server.js`
+  がエントリーポイント
+
+## 4. 静的アセット コピー (最重要、忘れると CSS/JS 全部 404)
+
+```bash
+# Next.js standalone は public/ と .next/static/ をコピーしない仕様。手動 cp 必須。
+# cp 先 path は monorepo path を踏襲: .next/standalone/apps/web/{public,.next/static}/
+sudo -u kagetra cp -r /opt/kagetra/apps/web/public /opt/kagetra/apps/web/.next/standalone/apps/web/
+sudo -u kagetra cp -r /opt/kagetra/apps/web/.next/static /opt/kagetra/apps/web/.next/standalone/apps/web/.next/
+```
+
+**これを忘れると next start は起動するが画面が全部真っ白になる**
+(server.js は port 3000 で listen するが、`/_next/static/*` と `/public/*`
+の応答が全部 404 になり、HTML だけ返って CSS/JS が読み込まれない)。
+
+## 5. systemd unit 配置 + enable
+
+```bash
+sudo cp /opt/kagetra/apps/web/systemd/kagetra-web.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now kagetra-web.service
+sudo systemctl status kagetra-web.service
+```
+
+## 6. nginx config 設置
+
+```bash
+# certbot --nginx で /etc/nginx/sites-enabled/default に SSL 設定済。これを上書き。
+sudo cp /opt/kagetra/docker/nginx/kagetra.conf.example /etc/nginx/sites-available/kagetra
+sudo ln -sf /etc/nginx/sites-available/kagetra /etc/nginx/sites-enabled/kagetra
+sudo rm -f /etc/nginx/sites-enabled/default
+sudo nginx -t  # syntax check
+sudo systemctl reload nginx
+```
+
+## 7. 動作確認
+
+```bash
+# local の port 3000 が応答すること
+curl -I http://127.0.0.1:3000
+# nginx 経由で 200 が返ること
+curl -I https://new.hokudaicarta.com
+# journalctl で web service のログ
+sudo journalctl -u kagetra-web.service -n 50 --no-pager
+```
+
+## 8. トラブルシュート
+
+| 症状 | 原因と対応 |
+|---|---|
+| curl 127.0.0.1:3000 で connection refused | systemd service 起動失敗、`journalctl -u kagetra-web.service -n 100` で詳細 |
+| 画面が真っ白、F12 で CSS/JS 404 | §4 静的アセット cp 忘れ、再度 cp して `sudo systemctl restart kagetra-web.service` |
+| `Cannot find module 'next'` | standalone build 失敗 or transpilePackages 設定不整合、build を pnpm clean 後やり直し |
+| nginx 502 Bad Gateway | apps/web (3000) が応答していない、`systemctl status kagetra-web.service` / `journalctl -u kagetra-web.service` で確認 |
+| Auth.js LINE Login で redirect URI mismatch | LINE Developers Console の callback URL が `https://new.hokudaicarta.com/api/auth/callback/line` 登録済か確認 |

--- a/scripts/deploy/apply-migrations.sh
+++ b/scripts/deploy/apply-migrations.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# kagetra_new 本番 migration 適用 script。
+# drizzle-kit migrate は TTY 必須で本番不適 (Phase A Phase 0 Discovery 結果)、
+# このため psql で SQL ファイルを順次適用 + __drizzle_migrations への hash INSERT
+# を手動実施する。
+#
+# 使い方:
+#   DATABASE_URL=postgres://... bash scripts/deploy/apply-migrations.sh
+#
+# 前提:
+#   - psql コマンド利用可能 (Docker container 内 or host install)
+#   - jq コマンド利用可能 (meta/_journal.json parse 用、apt install jq)
+#   - sha256sum コマンド利用可能 (coreutils、Ubuntu default)
+#   - packages/shared/drizzle/[0-9]*.sql が clone 済 (git clone /opt/kagetra 経由)
+#
+# 失敗時:
+#   - any 1 migration が失敗すると script は即終了 (set -e + ON_ERROR_STOP=1)
+#   - 部分適用された state からの復旧は pg_dump からの restore が確実
+
+set -euo pipefail
+
+# DATABASE_URL 必須 (未設定なら明示 fail)
+DATABASE_URL="${DATABASE_URL:?DATABASE_URL is required (postgres://user:pass@host:port/db)}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATIONS_DIR="$REPO_ROOT/packages/shared/drizzle"
+JOURNAL_FILE="$MIGRATIONS_DIR/meta/_journal.json"
+
+# dependencies チェック
+for cmd in psql jq sha256sum; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "ERROR: '$cmd' not found in PATH. Install: apt install postgresql-client jq coreutils" >&2
+    exit 1
+  fi
+done
+
+if [ ! -f "$JOURNAL_FILE" ]; then
+  echo "ERROR: journal file not found: $JOURNAL_FILE" >&2
+  exit 1
+fi
+
+# __drizzle_migrations テーブル作成 (idempotent、drizzle-kit と同じ schema)
+# drizzle 公式 internal schema:
+#   schema=drizzle, table=__drizzle_migrations, columns=(id SERIAL PK, hash text NOT NULL, created_at bigint)
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'EOSQL'
+CREATE SCHEMA IF NOT EXISTS drizzle;
+CREATE TABLE IF NOT EXISTS drizzle.__drizzle_migrations (
+  id SERIAL PRIMARY KEY,
+  hash text NOT NULL,
+  created_at bigint
+);
+EOSQL
+
+echo "Reading journal: $JOURNAL_FILE"
+
+# journal entries を iterate
+# tag (e.g. "0000_eager_kylun") + when (epoch ms) を取得
+# 対応する .sql ファイル → sha256sum で hash 計算 → 既適用なら skip、未適用なら apply + INSERT
+applied_count=0
+skipped_count=0
+
+while IFS=$'\t' read -r tag when; do
+  sql_file="$MIGRATIONS_DIR/${tag}.sql"
+
+  if [ ! -f "$sql_file" ]; then
+    echo "ERROR: SQL file not found: $sql_file (journal entry tag=$tag)" >&2
+    exit 1
+  fi
+
+  # SQL ファイル内容の SHA-256 hex 算出 (drizzle-kit と同じ計算式)
+  hash=$(sha256sum "$sql_file" | awk '{print $1}')
+
+  # 既適用 check (hash は psql 変数経由で渡して quote 注入を回避、`-v VAR=val`
+  # で psql 変数を設定 + SQL 中の `:'VAR'` で文字列 quote 込み展開)
+  is_applied=$(psql "$DATABASE_URL" -tA -v hash="$hash" -c \
+    "SELECT EXISTS (SELECT 1 FROM drizzle.__drizzle_migrations WHERE hash = :'hash')")
+
+  if [ "$is_applied" = "t" ]; then
+    echo "SKIP: $tag (already applied, hash=$hash)"
+    skipped_count=$((skipped_count + 1))
+    continue
+  fi
+
+  echo "APPLY: $tag (hash=$hash, when=$when)"
+  psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$sql_file"
+
+  # __drizzle_migrations への INSERT (drizzle-kit migrate と同じ挙動)
+  # hash は :'hash' で文字列 quote、when は :when で bigint (数値そのまま)
+  psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -v hash="$hash" -v when="$when" -c \
+    "INSERT INTO drizzle.__drizzle_migrations (hash, created_at) VALUES (:'hash', :when)"
+
+  applied_count=$((applied_count + 1))
+done < <(jq -r '.entries[] | "\(.tag)\t\(.when)"' "$JOURNAL_FILE")
+
+echo ""
+echo "Migration summary: applied=$applied_count, skipped=$skipped_count"
+echo "All migrations completed successfully."


### PR DESCRIPTION
## 概要

本番デプロイ計画 **Phase B**。apps/web (Next.js 15 standalone) + apps/api (Hono) + PostgreSQL 16 (Docker 同居) + nginx reverse proxy + migration 適用 + 初期 admin seed までを配線する。Phase A (PR #32) で整備した手動セットアップ doc の続き。実機セットアップとコード変更を伴う配線が両方含まれ、動作確認は Phase D の initial-launch-checklist で実施する。

## 背景

Phase A (PR #32) ship 時の Codex R3 で発見した「Phase B で nginx が `/api/*` を全部 Hono に流すと Auth.js callback (`/api/auth/callback/line`) が 404 して本番ログイン不能」問題を解決するため、Hono の basePath を **`/api` → `/hono-api`** に変更 (Option B 採用)。これで nginx config は `/hono-api/* → api 3001`、それ以外 → web 3000 の 2 location でシンプルに済む。

## 変更内容 (18 ファイル、+874 / -11)

### (1) Hono basePath 変更 + web env 追従 + Next.js config

| ファイル | 変更 |
|---|---|
| `apps/api/src/app.ts` | `app.basePath('/api')` → `app.basePath('/hono-api')` |
| `apps/web/src/lib/api.ts` | fallback を `'http://localhost:3001'` → `'/hono-api'` (相対 path) |
| `apps/web/next.config.ts` | `outputFileTracingRoot` + dev 専用 `rewrites()` 追加 |

### (2) 配線 file (新規 4)

| ファイル | 内容 |
|---|---|
| `apps/web/systemd/kagetra-web.service` | Type=simple, WD=.next/standalone, ExecStart=`node apps/web/server.js`, PORT=3000 |
| `apps/api/systemd/kagetra-api.service` | Type=simple, ExecStart=`node dist/index.js`, PORT=3001 |
| `docker/docker-compose.prod.yml` | postgres:16-alpine, **`127.0.0.1:5432` localhost bind 厳守**, named volume |
| `docker/nginx/kagetra.conf.example` | `/hono-api/* → 3001`、それ以外 → 3000、HTTP→HTTPS redirect、SSL = certbot 生成 path |

### (3) Operation script (新規 2)

| ファイル | 内容 |
|---|---|
| `scripts/deploy/apply-migrations.sh` | psql で 0000-0011 順次適用、`meta/_journal.json` から (tag, when) 取得、SHA-256 で hash 計算、`drizzle.__drizzle_migrations` へ idempotent INSERT (`-v VAR=val` で SQL injection 回避) |
| `apps/web/scripts/seed-initial-admin.ts` | `--name --email --grade`、SELECT-then-INSERT、3 状態 (inserted/promoted/noop)、idempotent |

### (4) Env テンプレート (新規 3 + 既存編集 1)

- `.env.production.example` (root): 本番全 env テンプレート
- `apps/api/.env.example`: dev API env
- `apps/web/.env.local.example`: dev web env
- `.gitignore`: `!.env.*.example` 例外追加 (.env.local.example 等もテンプレとして commit 可能に)

### (5) Doc (新規 3 + 既存編集 1)

- `docs/deploy/postgres.md`: Docker postgres + migration 適用 + トラブルシュート
- `docs/deploy/web.md`: build + **静的アセット cp (最大の罠、bold で強調)** + systemd + nginx
- `docs/deploy/api.md`: build + systemd + curl /hono-api/health
- `docs/deploy/README.md`: 実体リンク化、reverse proxy 行を Option B 反映、Phase A 完了表記

### (6) Test (新規 1)

- `apps/web/scripts/__tests__/seed-initial-admin.test.ts`: vitest 5 ケース (新規 admin / idempotent noop / member promote / existing admin noop / multiple admins with different emails)

## 罠系記述 (本 PR で明示)

- **Hono basePath path 衝突**: `/api/*` は Next.js (Auth.js, line-link, admin/mail/attachments) が使うため、Hono は `/hono-api/*` に分離
- **Next.js 15 standalone monorepo の `.next/standalone/apps/web/server.js`**: pnpm workspace + transpilePackages で監視 path 構造、`outputFileTracingRoot` で確定
- **静的アセット cp 忘れ**: `.next/static` と `public/` は standalone コピー対象外 → 別途 cp、忘れると画面真っ白 (最頻発罠)
- **PostgreSQL localhost bind 厳守**: `127.0.0.1:5432:5432`、外部公開禁止 (Phase A iptables / Security List とセット)
- **drizzle-kit migrate は TTY 必須で本番不適**: psql 直接 + SHA-256 hash 計算 + `__drizzle_migrations` 手動 INSERT で代替

## 検証

- ✅ Type check pass (4 packages、turbo cached、Stream 0 直後 + 最終で 2 回確認)
- ✅ 仕様 checklist 17/17 (3 並列 subagent verification)
- ✅ Anti-pattern check 35/35 (nginx / systemd / shell / TS / docker / env / doc 全網羅)
- ✅ bash syntax check (`bash -n apply-migrations.sh`)
- ✅ shell script + TS script の executable 権限確認
- ⚠️ Vitest は worktree の `vite/dist/client/client.mjs` 物理欠落で fail (Node 24 + vite 7 + Windows worktree の case-insensitive FS check)。コード起因ではない (main repo では存在、subagent verification で確認)。**Phase D 実機環境で `pnpm install` 後に再検証**

## ユーザー手動作業 (PR merge 後、Phase D 着手前)

1. Oracle Cloud + DNS/SSL (Phase A) セットアップ完了確認
2. `/opt/kagetra` に git clone + `corepack pnpm install --frozen-lockfile`
3. `/opt/kagetra/.env.production` 配置 (mode 0600, owner kagetra) + 実値編集
4. `docker compose -f docker/docker-compose.prod.yml up -d` (postgres 起動)
5. `bash scripts/deploy/apply-migrations.sh` (migration 適用)
6. `pnpm --filter @kagetra/web build && pnpm --filter @kagetra/api build`
7. **静的アセット cp** (`docs/deploy/web.md` §4): public/ と .next/static/ を standalone 配下に
8. `sudo cp apps/{web,api}/systemd/*.service /etc/systemd/system/ && sudo systemctl enable --now kagetra-{web,api}`
9. `sudo cp docker/nginx/kagetra.conf.example /etc/nginx/sites-available/kagetra && sudo ln -sf ... && sudo nginx -s reload`
10. `tsx apps/web/scripts/seed-initial-admin.ts --name="..." --email="..."`
11. ブラウザで `https://new.hokudaicarta.com` 動作確認

## 次の Phase

- **Phase C**: バックアップ配線 (pg_dump → Cloudflare R2 + LINE 失敗通知 + 復元 doc)
- **Phase D**: 本番初回起動 + 動作確認 + ship (`initial-launch-checklist.md`、ここで実機 vitest 含む全検証)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>