### PR TITLE
fix(deploy): use stdin for psql :'VAR' substitution (psql 14 quirk)

### DIFF
--- a/scripts/deploy/apply-migrations.sh
+++ b/scripts/deploy/apply-migrations.sh
@@ -72,9 +72,12 @@ while IFS=$'\t' read -r tag when; do
   hash=$(sha256sum "$sql_file" | awk '{print $1}')
 
   # 既適用 check (hash は psql 変数経由で渡して quote 注入を回避、`-v VAR=val`
-  # で psql 変数を設定 + SQL 中の `:'VAR'` で文字列 quote 込み展開)
-  is_applied=$(psql "$DATABASE_URL" -tA -v hash="$hash" -c \
-    "SELECT EXISTS (SELECT 1 FROM drizzle.__drizzle_migrations WHERE hash = :'hash')")
+  # で psql 変数を設定 + SQL 中の `:'VAR'` で文字列 quote 込み展開)。
+  # psql 14 では `-c` モードで `:'VAR'` substitution が効かないため stdin 経由で渡す。
+  is_applied=$(psql "$DATABASE_URL" -tA -v hash="$hash" <<'EOSQL'
+SELECT EXISTS (SELECT 1 FROM drizzle.__drizzle_migrations WHERE hash = :'hash')
+EOSQL
+)
 
   if [ "$is_applied" = "t" ]; then
     echo "SKIP: $tag (already applied, hash=$hash)"
@@ -86,9 +89,11 @@ while IFS=$'\t' read -r tag when; do
   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$sql_file"
 
   # __drizzle_migrations への INSERT (drizzle-kit migrate と同じ挙動)
-  # hash は :'hash' で文字列 quote、when は :when で bigint (数値そのまま)
-  psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -v hash="$hash" -v when="$when" -c \
-    "INSERT INTO drizzle.__drizzle_migrations (hash, created_at) VALUES (:'hash', :when)"
+  # hash は :'hash' で文字列 quote、when は :when で bigint (数値そのまま)。
+  # psql 14 では `-c` モードで `:'VAR'` substitution が効かないため stdin 経由で渡す。
+  psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -v hash="$hash" -v when="$when" <<'EOSQL'
+INSERT INTO drizzle.__drizzle_migrations (hash, created_at) VALUES (:'hash', :when)
+EOSQL
 
   applied_count=$((applied_count + 1))
 done < <(jq -r '.entries[] | "\(.tag)\t\(.when)"' "$JOURNAL_FILE")


### PR DESCRIPTION
## 概要

Phase D 初回デプロイ (Oracle Cloud / Ubuntu 22.04 / psql 14.22) で発覚した `scripts/deploy/apply-migrations.sh` の不具合修正。

## 症状

`bash scripts/deploy/apply-migrations.sh` 実行時、最初の migration 判定 (既適用 check) で:

\`\`\`
ERROR:  syntax error at or near \":\"
LINE 1: ...CT 1 FROM drizzle.__drizzle_migrations WHERE hash = :'hash')
                                                               ^
\`\`\`

## 原因

psql 14.22 (Ubuntu 22.04 default `postgresql-client-14`) は \`-c \"SQL\"\` モードで \`:'VAR'\` 形式の variable substitution を展開しない。サーバ側に文字列 \`:'hash'\` がそのまま送られる。

確認:

\`\`\`bash
# 動かない (psql 14)
psql ... -v hash=abc -c \"SELECT :'hash'\"
# → ERROR: syntax error at or near \":\"

# 動く (stdin 経由)
echo \"SELECT :'hash'\" | psql ... -v hash=abc
# → 'abc'
\`\`\`

## 修正

2 箇所の \`-c \"SQL\"\` を \`<<'EOSQL'\n...\nEOSQL\` (here-doc) に置換:
- L74-79: 既適用 check
- L88-94: \`__drizzle_migrations\` への INSERT

## 検証

- ✅ \`bash -n scripts/deploy/apply-migrations.sh\` syntax check pass
- ✅ 本番 Oracle インスタンス (Ubuntu 22.04 / psql 14.22) で stdin 経由の \`:'VAR'\` substitution 動作確認済

## 影響範囲

\`scripts/deploy/apply-migrations.sh\` のみ。他ファイルに影響なし。
Phase D 本番初回起動を unblock するための hot fix。

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>