### PR TITLE
fix(api): bundle @kagetra/shared in tsup build (Node ESM .ts import fix)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "tsup src/index.ts --format esm --outDir dist --clean",
+    "build": "tsup",
     "start": "node dist/index.js",
     "check-types": "tsc --noEmit",
     "lint": "echo 'no lint configured yet'",

--- a/apps/api/tsup.config.ts
+++ b/apps/api/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup"
+
+// @kagetra/shared は exports が .ts を直接指している (build step なし)。
+// 本番では node が .ts の relative import (拡張子なし) を解決できないため、
+// tsup でバンドルに含める。
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  outDir: "dist",
+  clean: true,
+  noExternal: ["@kagetra/shared"],
+})


### PR DESCRIPTION
## 概要

Phase D 初回デプロイ (Oracle Cloud / Node 22.22.2) で発覚した \`apps/api\` 本番起動失敗の修正。

## 症状

\`apps/api/dist/index.js\` を \`node dist/index.js\` で起動すると以下のエラーで即落ちて systemd が restart loop:

\`\`\`
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/opt/kagetra/packages/shared/src/schema/enums' imported from /opt/kagetra/packages/shared/src/schema/index.ts
\`\`\`

## 原因

\`apps/api\` の build (\`tsup\`) は \`@kagetra/shared\` を external 扱いし、\`dist/index.js\` に以下のような import を残す:

\`\`\`js
import * as schema from \"@kagetra/shared/schema\"
\`\`\`

本番 \`node dist/index.js\` 起動時、pnpm symlink (\`node_modules/@kagetra/shared/\`) 経由で \`packages/shared/package.json\` の exports が引かれ:

\`\`\`json
\"./schema\": \"./src/schema/index.ts\"
\`\`\`

→ Node が \`.ts\` ファイルを直接読みに行き、その中の \`import { ... } from \"./enums\"\` (拡張子なし relative import) を Node ESM が解決できず \`ERR_MODULE_NOT_FOUND\` で fail。

dev では \`tsx watch\` が透過的に変換するため発覚しない。

## 対応

\`apps/api/tsup.config.ts\` を新設し \`noExternal: [\"@kagetra/shared\"]\` を指定。
\`@kagetra/shared\` の TS ソースが apps/api の bundle に inline される → 本番 \`node dist/index.js\` だけで完結。
\`package.json\` の build スクリプトは \`tsup src/index.ts --format esm --outDir dist --clean\` → \`tsup\` に簡略化 (config 参照)。

## 検証

- ✅ \`pnpm --filter @kagetra/api build\` pass
- ✅ \`grep -c \"@kagetra/shared\" apps/api/dist/index.js\` → \`0\` (external import 消失)
- ✅ bundle size: 3.39 KB → 25.25 KB (shared schema 含めて期待通りの増加)
- ✅ tsup 既定オプション (\`format=esm / outDir=dist / clean=true\`) を config に移植のみで等価

## 影響範囲

\`apps/api\` のみ。\`apps/web\` (Next.js standalone) は \`transpilePackages\` で別経路、影響なし。
Phase D 本番初回起動を unblock するための hot fix。PR #35 と同列の deploy 修正。

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>