### PR TITLE
fix(docs/deploy): align with Phase B real-world deploy findings

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -11,6 +11,11 @@ DATABASE_URL=postgres://kagetra:CHANGEME_strong_password_32_or_more_chars@127.0.
 # AUTH_SECRET は `openssl rand -base64 32` で生成、dev の test secret は絶対流用しない
 AUTH_SECRET=CHANGEME_openssl_rand_base64_32
 NEXTAUTH_URL=https://new.hokudaicarta.com
+# reverse proxy (nginx) 配下では Auth.js v5 が X-Forwarded-* を信頼するため必須。
+# 設定し忘れると `/` → `/auth/signin` → `/` の無限 redirect ループに陥り
+# ブラウザに ERR_TOO_MANY_REDIRECTS が出る (本番初回デプロイで踏んだ罠)。
+# dev (localhost) では auto-trust されるため不要。
+AUTH_TRUST_HOST=true
 
 # === LINE Login (production channel、新規取得) ===
 # redirect URI: https://new.hokudaicarta.com/api/auth/callback/line

--- a/docs/deploy/dns-ssl.md
+++ b/docs/deploy/dns-ssl.md
@@ -1,4 +1,4 @@
-# DNS (お名前.com) + nginx + Let's Encrypt SSL
+# DNS (AWS Lightsail DNS zone) + nginx + Let's Encrypt SSL
 
 kagetra_new の本番ドメイン `new.hokudaicarta.com` を Oracle Cloud
 インスタンスに向け、nginx + Let's Encrypt で HTTPS 化するまでの手順。
@@ -10,39 +10,55 @@ kagetra_new の本番ドメイン `new.hokudaicarta.com` を Oracle Cloud
 - ドメイン: `hokudaicarta.com` (お名前.com 取得済)
 - 旧 kagetra: root `hokudaicarta.com` で稼働中 → **一切触らない**
 - 新システム: `new.hokudaicarta.com` でサブドメイン分離
-- DNS 管理: **お名前.com のまま** (移管しない、`new` の A レコードを
-  追加するだけ)
+- **DNS 解決の実態**: 旧 kagetra は **AWS Lightsail** で稼働しており、
+  お名前.com 側のネームサーバー設定で `awsdns-*` (Route 53) に委任済。
+  Lightsail コンソールの「**DNS ゾーン (DNS zones)**」機能で管理する形態
+  になっているため、お名前.com Navi の「DNS 設定/転送設定」で
+  レコード追加しても**反映されない**。
+- DNS 管理: **AWS Lightsail コンソール → ネットワーキング → DNS ゾーン**
+  で `new` の A レコードを追加する (Route 53 コンソールから直接でも可だが、
+  既存運用が Lightsail なら Lightsail UI が正)
 - 前提: Oracle インスタンス起動済 + 80/443 が外部から到達可能
   (`oracle-setup.md` §1-§5 完了)
 - インスタンス Public IP: Oracle Cloud Console → Instances → 詳細画面で
   確認
 
-## 1. お名前.com で A レコード追加
+## 1. Lightsail DNS ゾーンで A レコード追加
 
-1. お名前.com Navi にログイン
-2. ドメイン → DNS 関連機能 → DNS 設定/転送設定 → `hokudaicarta.com` 選択
-3. DNS レコード設定 → 追加で以下を入力:
-   - ホスト名: `new`
-   - TYPE: `A`
-   - VALUE: Oracle インスタンスの Public IP
-   - TTL: `3600` (1 時間、変更時の反映時間トレードオフ)
-   - 優先度: 空欄
-4. 確認画面で「DNS レコード設定用ネームサーバー変更不要」が選択されている
-   ことを確認 → 設定
-5. 旧 kagetra の root レコード (`hokudaicarta.com` の A) は触らない
+1. AWS Lightsail Console (`https://lightsail.aws.amazon.com/`) にログイン
+2. 上部メニュー **ネットワーキング (Networking)** タブ
+3. **DNS ゾーン (DNS zones)** リストに `hokudaicarta.com` があるはず → クリック
+4. **DNS レコード** タブ → **+ レコードを追加 (Add record)** ボタン
+5. 以下を入力:
+   - レコードタイプ: **A レコード**
+   - サブドメイン: `new` (右側に `.hokudaicarta.com` が自動表示)
+   - 解決先 (Resolves to): Oracle インスタンスの Public IP (例: `140.238.51.41`)
+   - TTL: `300` (5 分、セットアップ初期は短く iteration、安定後 3600 へ変更可)
+6. 右側の **✓ (緑のチェック)** または「保存」をクリック
+7. 一覧に `A new.hokudaicarta.com → <IP>` が追加表示されることを確認
+8. 旧 kagetra の root レコード (`hokudaicarta.com` の A) は触らない
 
 ## 2. DNS 反映待ち
 
-- お名前.com の DNS 反映は通常 5 分〜数時間、最大 24-48h
+- Lightsail DNS の反映は通常 **数十秒〜数分**で完了 (Route 53 経由のため
+  比較的速い。お名前.com Navi 直管理の typical 5 分〜24h より短い)
 - 確認 (ローカル PC から):
 
   ```bash
+  # dig がない Windows なら nslookup new.hokudaicarta.com 8.8.8.8 でも可
   dig new.hokudaicarta.com +short
   ```
 
   → Oracle インスタンスの Public IP が返れば反映完了
-- 反映前は次の §5 certbot が HTTP-01 challenge (port 80 経由で `new.
-  hokudaicarta.com` への到達性検証) で失敗するので、必ず DNS 反映後に進む
+- 反映前は次の §5 certbot が HTTP-01 challenge (port 80 経由で
+  `new.hokudaicarta.com` への到達性検証) で失敗するので、必ず DNS 反映後に
+  進む
+- 反映確認のもうひとつの方法 (権威 NS に直接問い合わせ):
+
+  ```bash
+  dig new.hokudaicarta.com @ns-643.awsdns-16.net +short
+  # ns-* のドメイン名は `dig -type=NS hokudaicarta.com` で確認できる
+  ```
 
 ## 3. nginx インストール
 
@@ -91,6 +107,11 @@ kagetra_new の本番ドメイン `new.hokudaicarta.com` を Oracle Cloud
   ping を受ける):
 
   ```bash
+  # 対話なし版 (一括):
+  sudo certbot --nginx -d new.hokudaicarta.com \
+    --non-interactive --agree-tos -m <あなたのメール> --redirect
+
+  # 対話版 (個別確認したい場合):
   # メールアドレス入力 (証明書失効通知用)、利用規約同意 (Y)、
   # HTTPS リダイレクト設定で `2` (Redirect, HTTP → HTTPS 自動) を選択。
   sudo certbot --nginx -d new.hokudaicarta.com
@@ -128,15 +149,16 @@ kagetra_new の本番ドメイン `new.hokudaicarta.com` を Oracle Cloud
 
 | 症状 | 原因と対応 |
 |---|---|
-| `dig` が IP を返さない | DNS 反映待ち (最大 24-48h)、お名前.com の DNS 設定画面で A レコード追加されていることを再確認 |
-| `curl http://new.hokudaicarta.com` connection refused | iptables で 80/443 が ACCEPT されていない、`sudo iptables -L INPUT --line-numbers` で INPUT 6 行目に 80/443 ACCEPT があることを確認 (`oracle-setup.md` §5) |
-| `curl` is timeout | Security List で 80/443 ingress が開いていない、Oracle Cloud Console で確認 (`oracle-setup.md` §4) |
+| `dig` が IP を返さない | DNS 反映待ち (Lightsail DNS なら通常数分以内)、Lightsail コンソールで A レコードが保存されていることを再確認。お名前.com Navi で追加していた場合は無効 (§1 参照、Lightsail で再登録) |
+| `curl http://new.hokudaicarta.com` connection refused | iptables で 80/443 が ACCEPT されていない、`sudo iptables -L INPUT --line-numbers` で INPUT の REJECT より前に 80/443 ACCEPT があることを確認 (`oracle-setup.md` §5) |
+| `curl` が timeout | Security List で 80/443 ingress が開いていない、Oracle Cloud Console で確認 (`oracle-setup.md` §4) |
 | certbot が `Connection refused` で失敗 | port 80 が外部から到達可能でない、§3 の `curl -I http://new.hokudaicarta.com` で 200 が返ることを先に確認 |
 | certbot が `DNS problem: NXDOMAIN` | DNS 反映完了前に certbot 実行、§2 の `dig` で IP が返ってから再実行 |
 | certbot 自動更新 timer が動かない | `sudo systemctl enable --now certbot.timer` で有効化、`sudo certbot renew --dry-run` で更新 simulation 実行 |
 
 ## 参考リンク
 
+- [AWS Lightsail DNS Zones (公式 doc)](https://docs.aws.amazon.com/lightsail/latest/userguide/amazon-lightsail-dns.html)
 - [Let's Encrypt 公式](https://letsencrypt.org/)
 - [certbot User Guide (nginx)](https://eff-certbot.readthedocs.io/en/latest/using.html)
-- [お名前.com Navi (DNS 設定)](https://navi.onamae.com/)
+- [お名前.com Navi (DNS 設定)](https://navi.onamae.com/) — registrar のみ、DNS 解決は Lightsail/Route 53

--- a/docs/deploy/oracle-setup.md
+++ b/docs/deploy/oracle-setup.md
@@ -73,20 +73,34 @@ LTS aarch64 image を使う前提。
   末尾に `REJECT all` が入っている** → Security List で 80/443 開けても
   弾かれる
 - 80/443 を INPUT の早い位置に挿入する必要あり
-- コマンド (順序重要、`-I INPUT 6` で REJECT より前に挿入):
+- 事前確認 (REJECT の行番号を特定):
 
   ```bash
-  # `-I INPUT 6` で 6 行目に挿入 (末尾の REJECT より前に来るのが肝)。
+  sudo iptables -L INPUT --line-numbers
+  # 例 (2026-05 時点の Ubuntu 22.04 aarch64 fresh image):
+  #   1  ACCEPT  all  -- ... state RELATED,ESTABLISHED
+  #   2  ACCEPT  icmp -- ...
+  #   3  ACCEPT  all  -- ...
+  #   4  ACCEPT  tcp  -- ... state NEW tcp dpt:22
+  #   5  REJECT  all  -- ... reject-with icmp-host-prohibited   ← この行番号 N を控える
+  ```
+
+- コマンド (順序重要、REJECT の行番号 `N` の **直前** に 80/443 を挿入):
+
+  ```bash
+  # `-I INPUT N` で N 行目に挿入 (REJECT を N+1, N+2 に押し下げる)。
+  # Ubuntu 22.04 fresh image なら N=5。doc の例は N=5 を想定するが、
+  # `iptables -L INPUT --line-numbers` で実際の N を確認すること。
   # `-A INPUT` (append) では REJECT に先に当たって弾かれる。
-  sudo iptables -I INPUT 6 -m state --state NEW -p tcp --dport 80 -j ACCEPT
-  sudo iptables -I INPUT 6 -m state --state NEW -p tcp --dport 443 -j ACCEPT
+  sudo iptables -I INPUT 5 -m state --state NEW -p tcp --dport 80 -j ACCEPT
+  sudo iptables -I INPUT 5 -m state --state NEW -p tcp --dport 443 -j ACCEPT
   sudo netfilter-persistent save
   ```
 
 - 検証: `sudo iptables -L INPUT --line-numbers` で **INPUT の REJECT より
-  前に 80 と 443 の ACCEPT 両方** が並んでいること (`-I INPUT 6` を 2 回
-  実行すると後から挿入した 443 が 6 行目に、80 は 7 行目に押し下がる。
-  どちらも REJECT より前にあれば OK)
+  前に 80 と 443 の ACCEPT 両方** が並んでいること (`-I INPUT 5` を 2 回
+  実行すると後から挿入した 443 が 5 行目に、80 は 6 行目に押し下がる。
+  REJECT は元の 5 から 7 に押し下がる。どちらも REJECT より前にあれば OK)
 - ufw は使わない (iptables-persistent と競合、Oracle image にはデフォルト
   未インストール)
 

--- a/docs/deploy/web.md
+++ b/docs/deploy/web.md
@@ -41,14 +41,21 @@ sudo -u kagetra corepack pnpm --filter @kagetra/web build
 
 ```bash
 # Next.js standalone は public/ と .next/static/ をコピーしない仕様。手動 cp 必須。
-# cp 先 path は monorepo path を踏襲: .next/standalone/apps/web/{public,.next/static}/
-sudo -u kagetra cp -r /opt/kagetra/apps/web/public /opt/kagetra/apps/web/.next/standalone/apps/web/
+# cp 先 path は monorepo path を踏襲: .next/standalone/apps/web/.next/static/
+# (apps/web に public/ ディレクトリが存在しない場合は public/ の cp は不要)
 sudo -u kagetra cp -r /opt/kagetra/apps/web/.next/static /opt/kagetra/apps/web/.next/standalone/apps/web/.next/
+
+# public/ がある場合は追加で:
+# sudo -u kagetra cp -r /opt/kagetra/apps/web/public /opt/kagetra/apps/web/.next/standalone/apps/web/
 ```
 
 **これを忘れると next start は起動するが画面が全部真っ白になる**
 (server.js は port 3000 で listen するが、`/_next/static/*` と `/public/*`
 の応答が全部 404 になり、HTML だけ返って CSS/JS が読み込まれない)。
+
+> 2026-05-21 初回デプロイ時点では `apps/web/public/` ディレクトリは存在しない
+> (favicon 等の静的ファイルは `src/app` 配下 or `.next/static` 経由で配信)。
+> 将来 public/ を追加した場合は上記コマンド行の comment-out を外す。
 
 ## 5. systemd unit 配置 + enable
 
@@ -89,4 +96,5 @@ sudo journalctl -u kagetra-web.service -n 50 --no-pager
 | 画面が真っ白、F12 で CSS/JS 404 | §4 静的アセット cp 忘れ、再度 cp して `sudo systemctl restart kagetra-web.service` |
 | `Cannot find module 'next'` | standalone build 失敗 or transpilePackages 設定不整合、build を pnpm clean 後やり直し |
 | nginx 502 Bad Gateway | apps/web (3000) が応答していない、`systemctl status kagetra-web.service` / `journalctl -u kagetra-web.service` で確認 |
-| Auth.js LINE Login で redirect URI mismatch | LINE Developers Console の callback URL が `https://new.hokudaicarta.com/api/auth/callback/line` 登録済か確認 |
+| Auth.js LINE Login で redirect URI mismatch | LINE Developers Console の callback URL が `https://new.hokudaicarta.com/api/auth/callback/line` (Auth.js login) + `https://new.hokudaicarta.com/api/line-link/callback` (self-identify) の **両方** 登録済か確認 |
+| `https://new.hokudaicarta.com/` → `/auth/signin` → `/` の無限 redirect ループ (ブラウザで `ERR_TOO_MANY_REDIRECTS`) | `.env.production` に `AUTH_TRUST_HOST=true` が設定されていない。Auth.js v5 は nginx 等の reverse proxy 配下では `AUTH_TRUST_HOST` を明示しないと `X-Forwarded-Proto` を信頼せず redirect logic が崩壊する。`.env.production.example` を参照し、追記後 `sudo systemctl restart kagetra-web.service` |


### PR DESCRIPTION
## 概要

2026-05-21 本番初回デプロイで発覚した deploy doc とテンプレの不整合 4 件を 1 PR にまとめて修正。いずれも実際に踏んだ罠で、今回のデプロイで動作確認済の手順だけ残す。

## 修正内容

### 1. \`docs/deploy/oracle-setup.md\` §5 iptables

- 旧: \`-I INPUT 6\` 固定だが、Ubuntu 22.04 aarch64 fresh image は REJECT が line 5 → 6 行目に挿入すると **REJECT より後ろ**になって弾かれる
- 新: 事前に \`iptables -L INPUT --line-numbers\` で REJECT 行番号 \`N\` を特定し、\`-I INPUT N\` で挿入。例として N=5 を提示

### 2. \`docs/deploy/dns-ssl.md\` 全面書き換え

- 旧: お名前.com Navi の「DNS 設定/転送設定」で A レコード追加
- 実態: \`hokudaicarta.com\` の権威 NS は AWS Route 53 (\`awsdns-*\`)。旧 kagetra 運用で **AWS Lightsail DNS zones** にて管理されており、お名前.com Navi 側で追加しても無効 (今回 NXDOMAIN で 30 分浪費)
- 新: AWS Lightsail Console → ネットワーキング → DNS zones ベースの手順に置換。反映時間 (5-15 分 → 数十秒-数分) も Lightsail/Route 53 実態に修正。罠表も更新。certbot コマンドは対話なし版 (\`--non-interactive --agree-tos -m <mail> --redirect\`) を主に

### 3. \`docs/deploy/web.md\` §4 静的アセット cp

- 旧: \`cp -r apps/web/public ...\` を必須として記載
- 実態: 現状 \`apps/web/public/\` ディレクトリ自体が存在しない (favicon 等は \`src/app\` or \`.next/static\` 経由)
- 新: public/ cp を comment-out 化、public/ がある場合の手順だけ残す。\`§8\` トラブルシュート表に **AUTH_TRUST_HOST 未設定の redirect loop** 行を追加

### 4. \`.env.production.example\`

- \`AUTH_TRUST_HOST=true\` を Auth.js セクションに追記
- 罠コメント (reverse proxy 配下で必須、\`/\` → \`/auth/signin\` → ERR_TOO_MANY_REDIRECTS の症状) を併記
- 今回 sign-in ループに陥り、追加してログイン成功

## 影響範囲

doc + テンプレのみ。コード変更なし。Phase D 着手前の整合性確保が目的。

## 検証

- ✅ 本番デプロイで実際に踏んだ罠 4 件 (iptables N、Lightsail DNS、public/ なし、AUTH_TRUST_HOST) の対応
- ✅ いずれも今回 (PR #33-#36 配下) の本番起動で動作確認済の手順
- ✅ \`bash -n\` 系のコード変更なし (\`bash\` script は無変更、doc/yaml/md のみ)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>