### PR TITLE
fix(mail-worker): bundle @kagetra/shared in tsup build (Node ESM .ts import fix)

### DIFF
--- a/apps/mail-worker/package.json
+++ b/apps/mail-worker/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "start": "tsx src/index.ts",
     "dev": "tsx watch src/index.ts",
-    "build": "tsup src/index.ts --format esm --outDir dist --clean",
+    "build": "tsup",
     "check-types": "tsc --noEmit",
     "lint": "eslint src test scripts",
     "test": "vitest run"

--- a/apps/mail-worker/tsup.config.ts
+++ b/apps/mail-worker/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup"
+
+// @kagetra/shared は exports が .ts を直接指している (build step なし)。
+// 本番では node が .ts の relative import (拡張子なし) を解決できないため、
+// tsup でバンドルに含める。PR #36 (apps/api) と同様の対応。
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  outDir: "dist",
+  clean: true,
+  noExternal: ["@kagetra/shared"],
+})


### PR DESCRIPTION
## 概要

Phase C 本番デプロイ (mail-worker 初回起動) で発覚した本番起動失敗の修正。PR #36 (apps/api) と同 root cause。

## 症状

\`sudo systemctl start kagetra-mail-worker.service\` で即落ち:

\`\`\`
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/opt/kagetra/packages/shared/src/schema/enums' imported from /opt/kagetra/packages/shared/src/schema/index.ts
\`\`\`

## 原因

PR #36 と同じ。\`apps/mail-worker\` の build (\`tsup\`) が \`@kagetra/shared\` を external 扱いし、\`dist/index.js\` に \`import * as ... from \"@kagetra/shared/schema\"\` を残す。本番 \`node dist/index.js\` 起動時に pnpm symlink 経由で \`packages/shared/src/schema/index.ts\` (.ts) を読み、内部の \`import \"./enums\"\` (拡張子なし relative) を Node ESM が解決できず fail。

## 対応

\`apps/mail-worker/tsup.config.ts\` を新設し \`noExternal: [\"@kagetra/shared\"]\` を指定 (PR #36 と同形式、対称)。
\`package.json\` の build スクリプトを \`tsup\` に簡略化 (config 参照)。

## 検証

- ✅ \`pnpm --filter @kagetra/mail-worker build\` pass
- ✅ \`grep -c \"@kagetra/shared\" dist/index.js\` → \`0\` (external 消失)
- ✅ bundle size: 85 KB → 107 KB (shared schema 含めて期待通り)

## 影響範囲

\`apps/mail-worker\` のみ。Phase C 本番起動を unblock するための hot fix。PR #36 (apps/api) と対称。

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>