### PR TITLE
fix(mail-worker): bump TimeoutStartSec to 25min for backfill processing

### DIFF
--- a/apps/mail-worker/systemd/kagetra-mail-worker.service
+++ b/apps/mail-worker/systemd/kagetra-mail-worker.service
@@ -31,9 +31,13 @@ ExecStart=/usr/bin/corepack pnpm --filter @kagetra/mail-worker exec node dist/in
 StandardOutput=journal
 StandardError=journal
 
-# 1 サイクル上限 5 分 (IMAP 取得 + AI 分類 + DB write の合計)。超えたら
-# kill して次回 timer 発火に任せる (途中まで処理した分は idempotent)。
-TimeoutStartSec=300
+# 1 サイクル上限 25 分 (IMAP 取得 + AI 分類 + DB write の合計)。
+# 初回デプロイ時のバックフィル (~数十-数百件) では 1 件あたり 7-15 秒
+# (IMAP fetch + AI 分類 + DB write) かかり 5 分上限を超えやすいため、
+# 30 分 timer 間隔の手前を上限とする (= timer 多重起動回避)。
+# 通常運用 (30 分毎 1-10 件) では 1-2 分で完了、上限到達はバックフィル時のみ。
+# 超えたら kill して次回 timer 発火に任せる (途中まで処理した分は idempotent)。
+TimeoutStartSec=1500
 
 # 安全ネット: 子プロセスが暴走したら 30 秒で SIGKILL。
 TimeoutStopSec=30


### PR DESCRIPTION
## 概要

Phase C 本番デプロイで発覚した mail-worker 初回起動時の SIGKILL 修正。

## 症状

\`sudo systemctl start kagetra-mail-worker.service\` 実行時、IMAP backfill (~27 件) 処理中の 5 分時点で systemd によって SIGKILL される:

\`\`\`
May 22 11:29:51 systemd[1]: kagetra-mail-worker.service: start operation timed out. Terminating.
May 22 11:29:51 systemd[1]: kagetra-mail-worker.service: Main process exited, code=killed, status=15/TERM
\`\`\`

journal を確認すると、kill 直前まで以下が出力されており、worker 自体は正常動作中 (途中で死んだだけ):

\`\`\`
[mail-worker] persisted mail {\"id\":27,\"messageId\":\"<...>\",\"duplicated\":false,...}
\`\`\`

## 原因

unit の \`TimeoutStartSec=300\` (5 分) が backfill サイズに対して短すぎる。1 件あたり 7-15 秒 (IMAP fetch + Claude AI 分類 + DB write + 添付 PDF 抽出 if any) かかるため、20-30 件規模のバックフィルを 1 サイクルで処理しきれない。

通常運用 (30 分毎 1-10 件着信) では問題にならないが、デプロイ直後やオフ期間明けで未処理メールが溜まっている場合に踏む。

## 修正

\`TimeoutStartSec=300\` → \`TimeoutStartSec=1500\` (5 分 → 25 分)。

選定理由:
- 30 分 timer 間隔の手前を上限とすることで timer 多重起動を回避
- 通常運用 (1-10 件/30min) では 1-2 分で完了、上限到達はバックフィル時のみ
- 25 分あれば ~100-200 件の backfill を 1 サイクルで処理可能

## 検証

- ✅ 既存 \`TimeoutStartSec=300\` の 5 分 kill タイミングは journal で確認済 (\`11:24:51 開始 → 11:29:51 kill\`)
- ✅ idempotent (`mail_worker_runs` テーブル + IMAP UID 追跡で重複処理回避済)
- ✅ unit 単体変更のため code 変更なし、その他 service 影響なし

## 影響範囲

\`apps/mail-worker/systemd/kagetra-mail-worker.service\` のみ。Phase C 本番起動を unblock する 4 個目の hot fix (PR #35 / #36 / #38 / 本 PR)。

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>