### PR TITLE
fix(deploy): drop --no-progress from rclone opts (removed in v1.74+)

### DIFF
--- a/scripts/deploy/backup.sh
+++ b/scripts/deploy/backup.sh
@@ -76,7 +76,7 @@ export RCLONE_CONFIG_R2_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}"
 export RCLONE_CONFIG_R2_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}"
 
 RCLONE_OPTS=(
-  --no-progress
+  # --no-progress は rclone v1.74+ で削除 (no-progress が default 挙動なので明示不要)
   --log-level INFO
   --retries 3
   --low-level-retries 10


### PR DESCRIPTION
## 概要

Phase C 本番デプロイ実機検証で発覚した \`backup.sh\` の rclone フラグ非互換修正。

## 症状

\`sudo systemctl start kagetra-backup.service\` 実行時、stage=r2_upload_daily で即落ち:

\`\`\`
2026/05/22 11:57:56 NOTICE: Fatal error: unknown flag: --no-progress
[backup] ERROR: kagetra backup failed: stage=r2_upload_daily, exit=2, host=kagetra-vnc, ts=20260522-205756 JST
[notify-system] pushed  ← (LINE 通知は正常動作、これは設計通り)
\`\`\`

## 原因

rclone は v1.74+ で \`--no-progress\` フラグを削除 (no-progress が default 挙動)。Ubuntu 22.04 でも公式 \`.deb\` (\`https://downloads.rclone.org/rclone-current-linux-arm64.deb\`) を入れると v1.74.1 が落ちてくるため、\`backup.sh\` の \`RCLONE_OPTS\` が即時 exit 2 する。

## 修正

\`RCLONE_OPTS\` 配列から \`--no-progress\` を削除 (コメントで removal 経緯を残す)。他フラグ (\`--log-level INFO\`, \`--retries 3\`, \`--low-level-retries 10\`, \`--timeout 5m\`, \`--contimeout 1m\`) は v1.74+ でも有効。

## 検証

- ✅ \`bash -n scripts/deploy/backup.sh\` syntax check pass
- ✅ rclone v1.74.1 の \`--help\` で \`--no-progress\` が listing されないことを確認
- ✅ LINE 通知 (notify-system) は正常動作することは本番でこの失敗時に証明済 (`[notify-system] pushed` ログ)。fail path 自体は健全

## 影響範囲

\`scripts/deploy/backup.sh\` 1 行のみ。Phase C 本番起動を unblock する 5 個目の hot fix。

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>