### PR TITLE
feat(mobile-shell): モバイルシェル固定（h-dvh + safe-area padding）

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -37,6 +37,10 @@ export const metadata: Metadata = {
 
 export const viewport: Viewport = {
   themeColor: '#ffffff',
+  // Required for env(safe-area-inset-*) to be non-zero on iOS notch/home-
+  // indicator devices; MobileShell's BottomNav relies on it to extend its
+  // background into the home indicator area.
+  viewportFit: 'cover',
 }
 
 export default function RootLayout({

--- a/apps/web/src/components/layout/bottom-nav.test.tsx
+++ b/apps/web/src/components/layout/bottom-nav.test.tsx
@@ -79,4 +79,16 @@ describe('BottomNav', () => {
     const link = screen.getByText('会員').closest('a')
     expect(link?.className).toContain('border-brand')
   })
+
+  // sticky-mobile-shell: ensure the iOS home-indicator area gets bg-surface
+  // by extending the <nav> via padding-bottom; without env(safe-area-inset-
+  // bottom) the home indicator overlaps the bottom tab row. Implemented as a
+  // Tailwind arbitrary value (not inline style) so jsdom — which silently
+  // drops `env()` when round-tripping inline styles through the CSSOM — can
+  // still verify the intent at the class-name level.
+  it('<nav> に safe-area の padding-bottom が arbitrary value で適用される', () => {
+    render(<BottomNav isAdmin />)
+    const nav = screen.getByRole('navigation')
+    expect(nav.className).toContain('pb-[env(safe-area-inset-bottom)]')
+  })
 })

--- a/apps/web/src/components/layout/bottom-nav.tsx
+++ b/apps/web/src/components/layout/bottom-nav.tsx
@@ -70,10 +70,7 @@ export function BottomNav({ isAdmin }: BottomNavProps) {
   const pathname = usePathname() ?? ''
   const visibleTabs = TABS.filter((tab) => !tab.adminOnly || isAdmin)
   return (
-    <nav
-      className="min-h-[52px] flex-shrink-0 flex items-stretch bg-surface border-t border-border"
-      style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
-    >
+    <nav className="min-h-[52px] pb-[env(safe-area-inset-bottom)] flex-shrink-0 flex items-stretch bg-surface border-t border-border">
       {visibleTabs.map((tab) => {
         const active = tab.matches.some((prefix) =>
           matchesPath(pathname, prefix),

--- a/apps/web/src/components/layout/bottom-nav.tsx
+++ b/apps/web/src/components/layout/bottom-nav.tsx
@@ -56,8 +56,11 @@ export interface BottomNavProps {
 }
 
 /**
- * Sticky mobile bottom tab bar (52px tall). Tabs per `docs/design/design.md`
- * §3 — ホーム / イベント / 予定 / 会員 (admin only until a member-facing list
+ * Sticky mobile bottom tab bar. Tabs are 52px tall; the `<nav>` itself
+ * uses `min-h-[52px]` plus `padding-bottom: env(safe-area-inset-bottom)`
+ * so the bg-surface fill extends into the iOS home-indicator area without
+ * shrinking the tap targets. Tabs per `docs/design/design.md` §3 —
+ * ホーム / イベント / 予定 / 会員 (admin only until a member-facing list
  * exists).
  *
  * Client component because it reads the current pathname via
@@ -67,7 +70,10 @@ export function BottomNav({ isAdmin }: BottomNavProps) {
   const pathname = usePathname() ?? ''
   const visibleTabs = TABS.filter((tab) => !tab.adminOnly || isAdmin)
   return (
-    <nav className="h-[52px] flex-shrink-0 flex items-stretch bg-surface border-t border-border">
+    <nav
+      className="min-h-[52px] flex-shrink-0 flex items-stretch bg-surface border-t border-border"
+      style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+    >
       {visibleTabs.map((tab) => {
         const active = tab.matches.some((prefix) =>
           matchesPath(pathname, prefix),
@@ -77,7 +83,7 @@ export function BottomNav({ isAdmin }: BottomNavProps) {
             key={tab.id}
             href={tab.href}
             className={cn(
-              'flex-1 flex items-center justify-center text-[11px] font-medium border-t-2 transition-colors',
+              'h-[52px] flex-1 flex items-center justify-center text-[11px] font-medium border-t-2 transition-colors',
               active
                 ? 'border-brand text-brand'
                 : 'border-transparent text-ink-meta',

--- a/apps/web/src/components/layout/mobile-shell.test.tsx
+++ b/apps/web/src/components/layout/mobile-shell.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MobileShell } from './mobile-shell'
+
+vi.mock('./app-bar-main', () => ({
+  AppBarMain: ({ user }: { user: string; signOutAction: () => Promise<void> }) => (
+    <div data-testid="app-bar-main">app-bar:{user}</div>
+  ),
+}))
+
+vi.mock('./bottom-nav', () => ({
+  BottomNav: ({ isAdmin }: { isAdmin: boolean }) => (
+    <div data-testid="bottom-nav">bottom-nav:{String(isAdmin)}</div>
+  ),
+}))
+
+describe('MobileShell', () => {
+  const noopSignOut = async () => {}
+
+  // Regression guard: keeps AppBar/BottomNav pinned to viewport edges by
+  // sizing the shell to the visible viewport (h-dvh with h-screen fallback)
+  // so only <main> scrolls. Reverting either class re-introduces the body-
+  // scroll bug where the bars vanish off-screen.
+  it('シェルが h-dvh + h-screen フォールバック + flex 縦並びで構成される', () => {
+    const { container } = render(
+      <MobileShell user="山田さん" isAdmin signOutAction={noopSignOut}>
+        <div>child</div>
+      </MobileShell>,
+    )
+    const shell = container.firstChild as HTMLElement
+    expect(shell.className).toContain('h-dvh')
+    expect(shell.className).toContain('h-screen')
+    expect(shell.className).toContain('flex')
+    expect(shell.className).toContain('flex-col')
+  })
+
+  it('<main> が flex-1 overflow-y-auto を持ち、children を描画する', () => {
+    render(
+      <MobileShell user="山田さん" isAdmin signOutAction={noopSignOut}>
+        <div data-testid="child">child-content</div>
+      </MobileShell>,
+    )
+    const main = screen.getByRole('main')
+    expect(main.className).toContain('flex-1')
+    expect(main.className).toContain('overflow-y-auto')
+    expect(screen.getByTestId('child').textContent).toBe('child-content')
+  })
+
+  it('AppBarMain に user prop が透過される', () => {
+    render(
+      <MobileShell user="山田さん" isAdmin={false} signOutAction={noopSignOut}>
+        <div>child</div>
+      </MobileShell>,
+    )
+    expect(screen.getByTestId('app-bar-main').textContent).toBe('app-bar:山田さん')
+  })
+
+  it('BottomNav に isAdmin=false が透過される', () => {
+    render(
+      <MobileShell user="" isAdmin={false} signOutAction={noopSignOut}>
+        <div>child</div>
+      </MobileShell>,
+    )
+    expect(screen.getByTestId('bottom-nav').textContent).toBe('bottom-nav:false')
+  })
+
+  it('BottomNav に isAdmin=true が透過される', () => {
+    render(
+      <MobileShell user="" isAdmin signOutAction={noopSignOut}>
+        <div>child</div>
+      </MobileShell>,
+    )
+    expect(screen.getByTestId('bottom-nav').textContent).toBe('bottom-nav:true')
+  })
+})

--- a/apps/web/src/components/layout/mobile-shell.tsx
+++ b/apps/web/src/components/layout/mobile-shell.tsx
@@ -19,8 +19,11 @@ export interface MobileShellProps {
 }
 
 /**
- * Mobile-first application shell: sticky 44px top bar + scrollable main +
- * sticky 52px bottom tab bar. Matches the `MobileFrame` prototype in
+ * Mobile-first application shell. Fits the visible viewport via `h-dvh`
+ * (with `h-screen` fallback for older browsers) so AppBar and BottomNav
+ * stay pinned at the flex edges and only `<main>` scrolls — keeping the
+ * 44px top bar and 52px bottom tab bar visible regardless of page length
+ * or iOS Safari URL-bar collapse. Matches the `MobileFrame` prototype in
  * `docs/design/ui_kits/kagetra-mobile/primitives.jsx` and §3 of
  * `docs/design/design.md`.
  *
@@ -37,8 +40,10 @@ export function MobileShell({
   signOutAction,
   children,
 }: MobileShellProps) {
+  // `h-screen` first as a fallback for browsers without `dvh` support; the
+  // later `h-dvh` wins where supported (iOS Safari 15.4+, Chrome 108+).
   return (
-    <div className="flex min-h-screen flex-col bg-canvas text-ink font-sans">
+    <div className="flex h-screen h-dvh flex-col bg-canvas text-ink font-sans">
       <AppBarMain user={user} signOutAction={signOutAction} />
       <main className="flex-1 overflow-y-auto">{children}</main>
       <BottomNav isAdmin={isAdmin} />

--- a/apps/web/src/components/layout/mobile-shell.tsx
+++ b/apps/web/src/components/layout/mobile-shell.tsx
@@ -40,8 +40,9 @@ export function MobileShell({
   signOutAction,
   children,
 }: MobileShellProps) {
-  // `h-screen` first as a fallback for browsers without `dvh` support; the
-  // later `h-dvh` wins where supported (iOS Safari 15.4+, Chrome 108+).
+  // `h-screen` is kept as a fallback for browsers without `dvh` support;
+  // Tailwind's generated `h-dvh` utility overrides it in the cascade where
+  // supported (iOS Safari 15.4+, Chrome 108+), not by class-attribute order.
   return (
     <div className="flex h-screen h-dvh flex-col bg-canvas text-ink font-sans">
       <AppBarMain user={user} signOutAction={signOutAction} />

--- a/docs/features/sticky-mobile-shell/implementation-plan.md
+++ b/docs/features/sticky-mobile-shell/implementation-plan.md
@@ -12,13 +12,13 @@ status: completed
 - **変更対象ファイル:**
   - `apps/web/src/app/layout.tsx` — `viewport` export に `viewportFit: 'cover'` を追加
   - `apps/web/src/components/layout/mobile-shell.tsx` — shell コンテナの `min-h-screen` を `h-screen h-dvh` に変更、コメントを実装一致に更新
-  - `apps/web/src/components/layout/bottom-nav.tsx` — `<nav>` を `min-h-[52px]` + inline style `paddingBottom: 'env(safe-area-inset-bottom)'` に変更し、各 `<Link>` に明示的に `h-[52px]` を付ける
+  - `apps/web/src/components/layout/bottom-nav.tsx` — `<nav>` を `min-h-[52px] pb-[env(safe-area-inset-bottom)]`（Tailwind arbitrary value）に変更し、各 `<Link>` に明示的に `h-[52px]` を付ける
 - **依存タスク:** なし
 - **対応Issue:** #51
 
 ### タスク2: MobileShell の構造テストを追加 + 既存テスト実行
 
-- [ ] 完了
+- [x] 完了
 - **概要:** shell の構造（`h-dvh`、main の `flex-1 overflow-y-auto`、AppBar/BottomNav の render）を Vitest で検証。既存の `bottom-nav.test.tsx` 8 ケースが壊れていないことも確認する。
 - **変更対象ファイル:**
   - `apps/web/src/components/layout/mobile-shell.test.tsx` — **新規。** AppBarMain / BottomNav を `vi.mock` で stub し、render 結果から shell コンテナ class / main 要素の class / children 描画を検証

--- a/docs/features/sticky-mobile-shell/implementation-plan.md
+++ b/docs/features/sticky-mobile-shell/implementation-plan.md
@@ -1,0 +1,51 @@
+---
+status: completed
+---
+# モバイルシェル固定（ヘッダー・ボトムナビ） 実装手順書
+
+## 実装タスク
+
+### タスク1: viewport-fit=cover を有効化 + MobileShell を h-dvh ベースに変更 + BottomNav に safe-area padding 追加
+
+- [x] 完了
+- **概要:** スクロール時に AppBar / BottomNav が画面端に固定されるよう shell を viewport にフィットさせ、safe-area-inset-bottom に対応する。3 ファイルを 1 コミットでまとめる（互いに密接に依存する変更のため）。
+- **変更対象ファイル:**
+  - `apps/web/src/app/layout.tsx` — `viewport` export に `viewportFit: 'cover'` を追加
+  - `apps/web/src/components/layout/mobile-shell.tsx` — shell コンテナの `min-h-screen` を `h-screen h-dvh` に変更、コメントを実装一致に更新
+  - `apps/web/src/components/layout/bottom-nav.tsx` — `<nav>` を `min-h-[52px]` + inline style `paddingBottom: 'env(safe-area-inset-bottom)'` に変更し、各 `<Link>` に明示的に `h-[52px]` を付ける
+- **依存タスク:** なし
+- **対応Issue:** #51
+
+### タスク2: MobileShell の構造テストを追加 + 既存テスト実行
+
+- [ ] 完了
+- **概要:** shell の構造（`h-dvh`、main の `flex-1 overflow-y-auto`、AppBar/BottomNav の render）を Vitest で検証。既存の `bottom-nav.test.tsx` 8 ケースが壊れていないことも確認する。
+- **変更対象ファイル:**
+  - `apps/web/src/components/layout/mobile-shell.test.tsx` — **新規。** AppBarMain / BottomNav を `vi.mock` で stub し、render 結果から shell コンテナ class / main 要素の class / children 描画を検証
+- **依存タスク:** タスク1
+- **対応Issue:** #52
+- **完了条件:**
+  - `pnpm --filter web test` が全件 pass
+  - 新規テストが pass し、`h-dvh` / `flex-1` / `overflow-y-auto` / `paddingBottom: env(safe-area-inset-bottom)` を検証している
+
+### タスク3: 実機確認（iPhone Safari + iPhone PWA standalone）
+
+- [ ] 完了
+- **概要:** iPhone Safari と PWA standalone モードで、コンテンツをスクロールしても AppBar と BottomNav が画面端に固定されることを目視確認する。あわせて `events/[id]/page.tsx:331` の `sticky bottom-0`（出欠ボタン）が BottomNav と重ならず main 内の下端に正しく乗ることをチェック。
+- **変更対象ファイル:** なし（実機確認のみ）
+- **依存タスク:** タスク1, タスク2
+- **対応Issue:** #53
+- **完了条件:**
+  - iPhone Safari でダッシュボード / イベント一覧 / イベント詳細 / 予定 を縦スクロールしても AppBar・BottomNav が画面端に常に表示される
+  - iPhone PWA standalone でも同様の挙動
+  - BottomNav の下に home indicator 領域がきれいに塗られている（背景色が途切れない）
+  - イベント詳細ページの出欠ボタン（sticky bottom-0）が BottomNav の上に乗り、視覚的に違和感がない
+  - `(app)` 配下の各ページ（ダッシュボード / イベント / 予定 / 会員 / メール受信箱 / 管理ページ）のいずれもリグレッションなし
+
+## 実装順序
+
+1. タスク1（実装、依存なし）
+2. タスク2（テスト追加・実行、タスク1 完了後）
+3. タスク3（実機確認、タスク1・2 完了後）
+
+実装はすべて 1 PR にまとめる（1PR=1機能の原則）。

--- a/docs/features/sticky-mobile-shell/requirements.md
+++ b/docs/features/sticky-mobile-shell/requirements.md
@@ -1,0 +1,166 @@
+---
+status: completed
+---
+# モバイルシェル固定（ヘッダー・ボトムナビ） 要件定義書（ドラフト）
+
+## 1. 概要
+
+- **目的:** モバイル（iPhone Safari / PWA standalone）でページコンテンツをスクロールしたときに、上部の AppBar（かげとら / ログアウト）と下部の BottomNav（ホーム / イベント / 予定 / 会員 / メール）が画面端に常に表示されるようにする。
+- **背景:** 現状の `MobileShell` は `min-h-screen flex flex-col` で構成されており、`<main>` に `overflow-y-auto` が付いているものの、コンテンツが viewport を超えるとシェル全体が伸びてしまい、結果として body 全体がスクロールしてヘッダー/ナビごと画面外に消える。コメントには「sticky 44px top bar」「sticky 52px bottom tab bar」と書かれているが、実装が追従していない。
+
+## 2. ユーザーストーリー
+
+- **対象ユーザー:** モバイル端末（iPhone Safari、iPhone PWA standalone）で「かげとら」を利用する全会員（一般会員・副管理者・管理者）。
+- **ユーザーの目的:** ダッシュボード / イベント詳細 / 予定一覧 / 会員管理 / メール受信箱など、縦に長いリストや本文を閲覧しているときに、スクロール位置に関係なくいつでもタブ切り替え・ログアウトができる。
+- **利用シナリオ:**
+  1. 会員がイベント詳細ページを下までスクロールして出欠ボタンを押した後、すぐに BottomNav の「ホーム」をタップしてダッシュボードに戻る。
+  2. 管理者が `/admin/members` の長いリストを下までスクロールしながら、上部のログアウトボタンに常にアクセスできる。
+  3. PWA standalone モードで利用中、画面下部のホームインジケータ領域とナビが被らず、タブが押しやすい。
+
+## 3. 機能要件
+
+### 3.1 画面挙動
+
+- **AppBar（44px）と BottomNav（52px）は常に画面端に表示される。** ページコンテンツがどれだけ縦に長くてもスクロール中に画面外に消えない。
+- **スクロールするのは `<main>` の内側のみ。** `<html>` / `<body>` 全体はスクロールしない。
+- **iPhone Safari の URL バー出現/非表示による viewport 高さ変動に追従する。** `h-dvh`（dynamic viewport height）を使い、シェルが常に「現在の見えている viewport」にフィットする。
+- **iPhone のホームインジケータ領域（safe-area-inset-bottom）にも BottomNav の背景色を伸ばす。** タップ領域は 52px のまま維持し、background だけ safe area の高さ分追加する。
+
+### 3.2 ナビゲーション挙動（変更なし）
+
+- **ページ遷移ごとに `<main>` のスクロール位置はトップに戻る。** Next.js App Router のデフォルト挙動を維持し、タブ間スクロール位置の記憶は実装しない。
+- **同じタブをタップしたときの再タップ挙動は何もしない。** `next/link` のデフォルト挙動に任せる（クライアントナビゲーションだけ走る）。
+
+### 3.3 スコープ外
+
+- **個別ページ内の横スクロール（例: `/admin/members` の `max-w-5xl` テーブル）は本 PR では触らない。** 各ページが自分の `<main>` の中で `overflow-x-auto` を持つ責務とする。
+- **`<keyboard>` 出現時の挙動最適化は本 PR では触らない。** iOS Safari は仮想キーボード出現時に visualViewport を縮める挙動があるが、入力フォーム自体が小さいため致命的ではない（必要なら別 PR）。
+- **スクロール位置の記憶やタブ再タップでのスクロールトップは別 PR。**
+
+### 3.4 ビジネスルール
+
+- 既存の BottomNav タブ構成・admin ゲーティング・active 判定ロジックは変更しない（PR #2 系・mail-tournament-import で固まった仕様を維持）。
+- 既存ページのレイアウト・スタイルを壊さない（リグレッションなし）。
+
+## 4. 技術設計
+
+### 4.1 変更ファイル一覧
+
+| ファイル | 変更内容 |
+|---|---|
+| `apps/web/src/app/layout.tsx` | `viewport` export に `viewportFit: 'cover'` を追加（safe-area-inset-* を有効化するために必須） |
+| `apps/web/src/components/layout/mobile-shell.tsx` | shell コンテナを `min-h-screen` → `h-screen h-dvh` に変更、コメントを実装と一致させる |
+| `apps/web/src/components/layout/bottom-nav.tsx` | `<nav>` に `paddingBottom: env(safe-area-inset-bottom)` を inline style で追加、高さを `h-[52px]` から `min-h-[52px]` 系に調整しタブ自体は 52px を維持 |
+| `apps/web/src/components/layout/mobile-shell.test.tsx` | **新規。** shell に `h-dvh` クラスが付くこと、main に `flex-1 overflow-y-auto` が付くこと、BottomNav が render されることを構造テスト |
+
+### 4.2 実装詳細
+
+**`apps/web/src/app/layout.tsx`**
+
+```tsx
+export const viewport: Viewport = {
+  themeColor: '#ffffff',
+  viewportFit: 'cover',  // ← 追加。safe-area-inset-* を有効化
+}
+```
+
+**`apps/web/src/components/layout/mobile-shell.tsx`**
+
+```tsx
+<div className="flex h-screen h-dvh flex-col bg-canvas text-ink font-sans">
+  <AppBarMain ... />
+  <main className="flex-1 overflow-y-auto">{children}</main>
+  <BottomNav isAdmin={isAdmin} />
+</div>
+```
+
+- `h-screen h-dvh` の順で書くことで、`h-dvh` 未サポートブラウザは `h-screen` (100vh) にフォールバック、サポートブラウザは後勝ちで `h-dvh` が適用される。
+- 既存コメントの「sticky 44px top bar + scrollable main + sticky 52px bottom tab bar」を「Fits viewport via h-dvh; AppBar/BottomNav stay at flex edges, main scrolls.」のような実装一致の記述に更新。
+
+**`apps/web/src/components/layout/bottom-nav.tsx`**
+
+```tsx
+<nav
+  className="min-h-[52px] flex-shrink-0 flex items-stretch bg-surface border-t border-border"
+  style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+>
+  {visibleTabs.map((tab) => (
+    <Link
+      ...
+      className={cn(
+        'h-[52px] flex-1 flex items-center justify-center text-[11px] font-medium border-t-2 transition-colors',
+        ...
+      )}
+    >
+      {tab.label}
+    </Link>
+  ))}
+</nav>
+```
+
+- `<nav>` 高さは `min-h-[52px]` + `paddingBottom`（safe-area 込みで 52px + α）。
+- 各 `<Link>` のタップ可能領域は明示的に `h-[52px]` で 52px 固定。
+- safe-area 部分（home indicator 領域）は `<nav>` の padding 領域として bg-surface のまま描画される。
+
+**`apps/web/src/components/layout/mobile-shell.test.tsx`**（新規）
+
+- mock `AppBarMain` / `BottomNav` を入れて MobileShell 単体の構造を検証。
+- 検証項目: shell に `h-dvh` クラスが付く / `main` 要素が `flex-1` と `overflow-y-auto` を持つ / BottomNav と AppBarMain が children と一緒に render される。
+
+### 4.3 既存テストへの影響
+
+- `bottom-nav.test.tsx` の既存 8 ケース（admin タブ表示・active 判定）は構造に依存しないので、`h-[52px]` から `min-h-[52px]` への変更でも壊れない見込み。実行して確認する。
+
+## 5. 影響範囲
+
+### 5.1 既存ページのスクロール挙動の変化
+
+修正前は `<html>`/`<body>` 全体がスクロールしていたのが、修正後は `<main>` 内だけがスクロールするようになる。これにより以下の影響が出る可能性がある:
+
+- **`apps/web/src/app/(app)/events/[id]/page.tsx:331`** — `sticky bottom-0` の出欠トグル UI。
+  - 修正前: body スクロールでの sticky → 画面下端（BottomNav と重なる懸念あり）
+  - 修正後: `<main>` 内スクロールでの sticky → main の下端、つまり BottomNav のすぐ上に乗る
+  - **想定はむしろ良い方向への変化** だが、視覚チェック必須。
+- **`apps/web/src/app/self-identify/candidate-list.tsx`** — `scrollIntoView` を使う可能性。中身を確認しスクロール container が `<main>` でも動くか検証。
+  - そもそも self-identify ページは `(app)` 配下ではないので MobileShell でラップされていない → 影響なし。
+- **その他の `(app)` 配下ページ全般** — 縦に長いページで window.scrollTo / scrollY を使っているコードがあれば壊れる。grep で `window.scroll` / `document.scrollingElement` の使用箇所を最終確認する。
+
+### 5.2 MobileShell の外のページ（影響なし）
+
+以下は `(app)` 配下ではなく MobileShell を使っていない:
+
+- `apps/web/src/app/auth/signin/page.tsx`
+- `apps/web/src/app/403/page.tsx`
+- `apps/web/src/app/self-identify/page.tsx`
+- `apps/web/src/app/settings/line-link/page.tsx`
+
+各々 `min-h-screen` を使っているがそのまま維持。
+
+### 5.3 viewport-fit=cover の副作用
+
+- `viewport-fit=cover` を入れると iOS で WebView がノッチ/ホームインジケータ領域に「広がる」。今のところ AppBar / BottomNav / main の各セクションは bg-surface / bg-canvas で塗りつぶされる前提なので、左右ノッチが目立つことはない想定。
+- 念のため `<main>` 内のページ（ダッシュボード等）の左右パディングをチェックし、ノッチ越しに切れる文字がないか実機で確認する。
+
+### 5.4 互換性
+
+- `h-dvh`: iOS Safari 15.4+ (2022-03), Android Chrome 108+ (2022-11) 対応。`h-screen` フォールバックがあるので未サポート環境でも極端な破綻はしない。
+- `env(safe-area-inset-bottom)`: iOS 11+, 主要ブラウザ全て対応。
+
+## 6. 設計判断の根拠
+
+### 6.1 なぜ `h-dvh` ベース（方針 A）にするか
+
+- 候補 B（`sticky` 化）は親の overflow が絡むと挙動が読みにくい（とくに iOS Safari）。デバッグが脱走しやすい。
+- 候補 C（`fixed` 化）は AppBar/BottomNav の位置と main の padding を分離管理する必要があり、修正コストと考慮事項が増える。
+- 候補 A は flex 一本で完結し、`<main>` の `overflow-y-auto` が確実に効くので最もシンプル。既存コメントが想定していたモデル（「sticky 44px top + scrollable main + sticky 52px bottom」）を最も低コストで実現できる。
+
+### 6.2 なぜ safe-area は BottomNav の `padding-bottom` で吸収するか
+
+- shell 全体に `padding-bottom` を入れる方法だと、BottomNav の下にできる余白が `bg-canvas` 色になり BottomNav の `bg-surface` と色違いが目立つ。
+- BottomNav 自身が padding 領域として safe-area を抱えると、`bg-surface` が home indicator 領域まで自然に伸び、視覚的に統一感が出る。Tailwind / Next.js モバイル UI の定石。
+
+### 6.3 なぜ Playwright E2E は追加しないか
+
+- スクロール挙動・safe-area・h-dvh はいずれも実機 / 実 viewport で初めて意味を持つ確認。Playwright headless は viewport を擬似的に変えるだけで実機の URL バー出現や safe-area は再現できない。
+- DoD として「iPhone Safari 実機での目視確認」を入れる方が確実で、CI コストが増えるリスクに見合わない。
+

--- a/docs/features/sticky-mobile-shell/requirements.md
+++ b/docs/features/sticky-mobile-shell/requirements.md
@@ -50,7 +50,7 @@ status: completed
 |---|---|
 | `apps/web/src/app/layout.tsx` | `viewport` export に `viewportFit: 'cover'` を追加（safe-area-inset-* を有効化するために必須） |
 | `apps/web/src/components/layout/mobile-shell.tsx` | shell コンテナを `min-h-screen` → `h-screen h-dvh` に変更、コメントを実装と一致させる |
-| `apps/web/src/components/layout/bottom-nav.tsx` | `<nav>` に `paddingBottom: env(safe-area-inset-bottom)` を inline style で追加、高さを `h-[52px]` から `min-h-[52px]` 系に調整しタブ自体は 52px を維持 |
+| `apps/web/src/components/layout/bottom-nav.tsx` | `<nav>` に Tailwind arbitrary value `pb-[env(safe-area-inset-bottom)]` を追加（jsdom CSSOM が inline `env()` を弾くため class 化）、高さを `h-[52px]` から `min-h-[52px]` 系に調整しタブ自体は 52px を維持 |
 | `apps/web/src/components/layout/mobile-shell.test.tsx` | **新規。** shell に `h-dvh` クラスが付くこと、main に `flex-1 overflow-y-auto` が付くこと、BottomNav が render されることを構造テスト |
 
 ### 4.2 実装詳細
@@ -80,10 +80,7 @@ export const viewport: Viewport = {
 **`apps/web/src/components/layout/bottom-nav.tsx`**
 
 ```tsx
-<nav
-  className="min-h-[52px] flex-shrink-0 flex items-stretch bg-surface border-t border-border"
-  style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
->
+<nav className="min-h-[52px] pb-[env(safe-area-inset-bottom)] flex-shrink-0 flex items-stretch bg-surface border-t border-border">
   {visibleTabs.map((tab) => (
     <Link
       ...
@@ -98,7 +95,8 @@ export const viewport: Viewport = {
 </nav>
 ```
 
-- `<nav>` 高さは `min-h-[52px]` + `paddingBottom`（safe-area 込みで 52px + α）。
+- `<nav>` 高さは `min-h-[52px]` + Tailwind arbitrary value `pb-[env(safe-area-inset-bottom)]`（safe-area 込みで 52px + α）。
+- 当初は inline style で `paddingBottom: 'env(...)'` を当てる方針だったが、jsdom (vitest) の CSSOM が `env()` を invalid と判定して style attribute ごと捨てるためテスト不能。Tailwind arbitrary value に切り替えて class 名で検証可能にした（実機の挙動は等価）。
 - 各 `<Link>` のタップ可能領域は明示的に `h-[52px]` で 52px 固定。
 - safe-area 部分（home indicator 領域）は `<nav>` の padding 領域として bg-surface のまま描画される。
 


### PR DESCRIPTION
## Summary

モバイル（iPhone Safari / PWA standalone）でスクロール中も AppBar (44px) と BottomNav (52px) を画面端に固定するための shell 改修。

- `layout.tsx` に `viewportFit: 'cover'` を追加し `env(safe-area-inset-*)` を有効化
- `mobile-shell.tsx` を `min-h-screen` → `h-screen h-dvh` に変更し、`<main>` の内側だけがスクロールする構造に（AppBar/BottomNav は flex 両端に固定）
- `bottom-nav.tsx` に Tailwind arbitrary value `pb-[env(safe-area-inset-bottom)]` を追加し、iPhone のホームインジケータ領域まで `bg-surface` を伸ばす（タップ可能領域は 52px 維持）
- `mobile-shell.test.tsx` 新規 5 ケース（shell 構造、main の overflow、AppBar/BottomNav の props 透過）
- `bottom-nav.test.tsx` +1 ケース（safe-area padding class の検証）

設計判断は `docs/features/sticky-mobile-shell/requirements.md`、実装手順は `docs/features/sticky-mobile-shell/implementation-plan.md` を参照。

## 補足: なぜ Tailwind arbitrary value か

当初は `style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}` の inline style 方針だったが、jsdom (vitest 環境) の CSSOM パーサーが `env()` を invalid と判定して style attribute ごと捨てるためテストで検証不能。Tailwind arbitrary value `pb-[env(safe-area-inset-bottom)]` に切り替えて class 名で検証可能にした（実機の挙動は等価）。

## Test plan

- [x] `pnpm --filter web test` — 22 ファイル / 180 ケース全 pass（既存 bottom-nav 8 ケース含む）
- [ ] iPhone Safari でダッシュボード / イベント一覧 / イベント詳細 / 予定 を縦スクロールしても AppBar・BottomNav が画面端に常に表示される
- [ ] iPhone PWA standalone でも同様の挙動
- [ ] BottomNav の下の home indicator 領域が `bg-surface` で塗られ、背景色が途切れない
- [ ] イベント詳細ページの出欠ボタン（`sticky bottom-0`）が BottomNav の上に乗り視覚的違和感なし
- [ ] `(app)` 配下の各ページにリグレッションなし

## 関連 Issue

- 親: #50
- 子: #51, #52（コミットで自動クローズ）
- 残: #53（iPhone 実機確認、本 PR マージ後に DoD として実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)