### PR TITLE
fix(mobile-shell): add min-h-0 to <main> so flex shell stays viewport-fit

### DIFF
--- a/apps/web/src/components/layout/mobile-shell.test.tsx
+++ b/apps/web/src/components/layout/mobile-shell.test.tsx
@@ -34,7 +34,7 @@ describe('MobileShell', () => {
     expect(shell.className).toContain('flex-col')
   })
 
-  it('<main> が flex-1 overflow-y-auto を持ち、children を描画する', () => {
+  it('<main> が flex-1 min-h-0 overflow-y-auto を持ち、children を描画する', () => {
     render(
       <MobileShell user="山田さん" isAdmin signOutAction={noopSignOut}>
         <div data-testid="child">child-content</div>
@@ -42,6 +42,12 @@ describe('MobileShell', () => {
     )
     const main = screen.getByRole('main')
     expect(main.className).toContain('flex-1')
+    // Regression guard: without `min-h-0`, flex items default to
+    // `min-height: auto` which lets <main> grow past the shell, the shell
+    // exceeds h-dvh, and body scroll carries AppBar/BottomNav off-screen
+    // on iOS Safari. Removing this class re-introduces the PR #64 followup
+    // bug (BottomNav disappears while scrolling).
+    expect(main.className).toContain('min-h-0')
     expect(main.className).toContain('overflow-y-auto')
     expect(screen.getByTestId('child').textContent).toBe('child-content')
   })

--- a/apps/web/src/components/layout/mobile-shell.tsx
+++ b/apps/web/src/components/layout/mobile-shell.tsx
@@ -46,7 +46,15 @@ export function MobileShell({
   return (
     <div className="flex h-screen h-dvh flex-col bg-canvas text-ink font-sans">
       <AppBarMain user={user} signOutAction={signOutAction} />
-      <main className="flex-1 overflow-y-auto">{children}</main>
+      {/*
+        `min-h-0` is required: flex items default to `min-height: auto`,
+        which prevents <main> from shrinking below its content height even
+        with `overflow-y-auto`. Without it the inner content pushes <main>
+        past the shell, the shell bleeds past h-dvh, and body scroll
+        carries AppBar/BottomNav off-screen — exactly the bug we are trying
+        to fix. See https://developer.mozilla.org/en-US/docs/Web/CSS/min-height#values
+      */}
+      <main className="flex-1 min-h-0 overflow-y-auto">{children}</main>
       <BottomNav isAdmin={isAdmin} />
     </div>
   )

--- a/docs/features/sticky-mobile-shell/implementation-plan.md
+++ b/docs/features/sticky-mobile-shell/implementation-plan.md
@@ -28,6 +28,17 @@ status: completed
   - `pnpm --filter web test` が全件 pass
   - 新規テストが pass し、`h-dvh` / `flex-1` / `overflow-y-auto` / `paddingBottom: env(safe-area-inset-bottom)` を検証している
 
+### タスク2b: flex `min-h-auto` 罠の事後修正（PR #65 で追加）
+
+- [x] 完了
+- **概要:** PR #64 ship + 本番反映後、ユーザー実機検証で BottomNav が下スクロールで画面外に消える現象が判明。原因は flex item デフォルト `min-height: auto` で `<main>` が子コンテンツに押されて shell の h-dvh 境界を突き抜け、body スクロールが走っていたこと。
+- **変更対象ファイル:**
+  - `apps/web/src/components/layout/mobile-shell.tsx` — `<main>` を `flex-1 overflow-y-auto` → `flex-1 min-h-0 overflow-y-auto` に修正、罠の解説コメント追加
+  - `apps/web/src/components/layout/mobile-shell.test.tsx` — main の class アサーションに `min-h-0` を追加（リグレッションガード）
+  - `docs/features/sticky-mobile-shell/requirements.md` — §4.2 mobile-shell.tsx のコード例と `min-h-0` 必須の注記
+- **依存タスク:** タスク1, タスク2
+- **対応Issue:** #53 (事後修正の一部、実機 NG → fix → 再実機)
+
 ### タスク3: 実機確認（iPhone Safari + iPhone PWA standalone）
 
 - [ ] 完了

--- a/docs/features/sticky-mobile-shell/requirements.md
+++ b/docs/features/sticky-mobile-shell/requirements.md
@@ -69,13 +69,14 @@ export const viewport: Viewport = {
 ```tsx
 <div className="flex h-screen h-dvh flex-col bg-canvas text-ink font-sans">
   <AppBarMain ... />
-  <main className="flex-1 overflow-y-auto">{children}</main>
+  <main className="flex-1 min-h-0 overflow-y-auto">{children}</main>
   <BottomNav isAdmin={isAdmin} />
 </div>
 ```
 
 - `h-screen h-dvh` の順で書くことで、`h-dvh` 未サポートブラウザは `h-screen` (100vh) にフォールバック、サポートブラウザは後勝ちで `h-dvh` が適用される。
 - 既存コメントの「sticky 44px top bar + scrollable main + sticky 52px bottom tab bar」を「Fits viewport via h-dvh; AppBar/BottomNav stay at flex edges, main scrolls.」のような実装一致の記述に更新。
+- **`min-h-0` 必須**: flex item のデフォルト `min-height: auto` だと `<main>` が子コンテンツより縮めず、shell が h-dvh を突き抜けて body スクロールに化ける（PR #64 で抜けて実機 NG、別 PR で `min-h-0` 追加）。`overflow-y-auto` を flex item に当てるときは常に `min-h-0` を同時指定するのが定石。
 
 **`apps/web/src/components/layout/bottom-nav.tsx`**
 


### PR DESCRIPTION
## Summary

PR #64 (sticky-mobile-shell) 後の本番実機検証で、下スクロール時に AppBar/BottomNav が画面外へ消える現象が判明。原因は flex item デフォルト \`min-height: auto\` で \`<main>\` が子コンテンツに押されて shell の h-dvh 境界を突き抜け、結果として body スクロールが走っていたこと。

- [apps/web/src/components/layout/mobile-shell.tsx](apps/web/src/components/layout/mobile-shell.tsx): \`<main>\` を \`flex-1 overflow-y-auto\` → \`flex-1 min-h-0 overflow-y-auto\` に変更、罠の解説コメント追加
- [apps/web/src/components/layout/mobile-shell.test.tsx](apps/web/src/components/layout/mobile-shell.test.tsx): main の class アサーションに \`min-h-0\` を追加（リグレッションガード）
- \`docs/features/sticky-mobile-shell/{requirements,implementation-plan}.md\`: §4.2 のコード例を min-h-0 入りに更新 + 罠の解説追加、事後修正タスク 2b を plan に追記

## 補足: なぜ vitest で検知できなかったか

jsdom はレイアウト計算をしない (display:flex も計算しない) ため、\`min-height: auto\` で main が伸びる現象は class アサーション以外では捉えられない。実機/Playwright headful でしか再現しない種類のバグ。今回は class レベルでリグレッションガードを追加 + requirements に罠を明記して再発防止する。

\`<body>\` 側に \`h-dvh overflow-hidden\` を当てる二重防御も検討したが、\`(app)\` 配下以外のページ (auth/signin / 403 / self-identify / settings/line-link) は \`min-h-screen\` で body スクロール許容前提のため副作用リスクあり。\`min-h-0\` だけで罠は解消するので最小限の修正とした。

## Test plan

- [x] \`pnpm --filter web test\` — 22 ファイル / 180 ケース全 pass (\`bottom-nav.test.tsx\` 9 ケース含む)
- [ ] 本番反映後 iPhone Safari + PWA standalone で下スクロール時に AppBar/BottomNav が画面端に固定されることを確認 (#53)
- [ ] イベント詳細ページの出欠ボタン (\`sticky bottom-0\`) が BottomNav の上に乗ることを確認

## 関連 Issue

- #53 (実機確認): 本 PR ship + 本番反映後に再検証
- 親 #50 も #53 と同時クローズ

🤖 Generated with [Claude Code](https://claude.com/claude-code)