### PR TITLE
fix(bottom-nav): bake safe-area into min-h so border-box keeps content 52px

### DIFF
--- a/apps/web/src/components/layout/bottom-nav.test.tsx
+++ b/apps/web/src/components/layout/bottom-nav.test.tsx
@@ -102,7 +102,7 @@ describe('BottomNav', () => {
     render(<BottomNav isAdmin />)
     const nav = screen.getByRole('navigation')
     expect(nav.className).toContain(
-      'min-h-[calc(52px+env(safe-area-inset-bottom))]',
+      'min-h-[calc(52px_+_env(safe-area-inset-bottom))]',
     )
     // Plain `min-h-[52px]` reintroduces the clipping bug — guard against
     // an accidental revert.

--- a/apps/web/src/components/layout/bottom-nav.test.tsx
+++ b/apps/web/src/components/layout/bottom-nav.test.tsx
@@ -91,4 +91,21 @@ describe('BottomNav', () => {
     const nav = screen.getByRole('navigation')
     expect(nav.className).toContain('pb-[env(safe-area-inset-bottom)]')
   })
+
+  // Regression guard for the iPhone home-indicator clipping bug (PR #67):
+  // Tailwind's default box-sizing: border-box meant `min-h-[52px]` plus
+  // `pb-[env(safe-area-inset-bottom)]` (~34px) collapsed the content area
+  // to ~18px, letting the 52px <Link> children overflow off-screen. The
+  // min-h MUST be `calc(52px + env(safe-area-inset-bottom))` so the
+  // content area stays a full 52px after the safe-area padding is removed.
+  it('<nav> の min-height が calc(52px + safe-area) で確保される', () => {
+    render(<BottomNav isAdmin />)
+    const nav = screen.getByRole('navigation')
+    expect(nav.className).toContain(
+      'min-h-[calc(52px+env(safe-area-inset-bottom))]',
+    )
+    // Plain `min-h-[52px]` reintroduces the clipping bug — guard against
+    // an accidental revert.
+    expect(nav.className).not.toMatch(/(?<!\+)min-h-\[52px\]/)
+  })
 })

--- a/apps/web/src/components/layout/bottom-nav.tsx
+++ b/apps/web/src/components/layout/bottom-nav.tsx
@@ -57,11 +57,19 @@ export interface BottomNavProps {
 
 /**
  * Sticky mobile bottom tab bar. Tabs are 52px tall; the `<nav>` itself
- * uses `min-h-[52px]` plus `padding-bottom: env(safe-area-inset-bottom)`
- * so the bg-surface fill extends into the iOS home-indicator area without
- * shrinking the tap targets. Tabs per `docs/design/design.md` §3 —
- * ホーム / イベント / 予定 / 会員 (admin only until a member-facing list
- * exists).
+ * reserves `52px + env(safe-area-inset-bottom)` so the bg-surface fill
+ * extends into the iOS home-indicator area without compressing the tap
+ * targets. Tabs per `docs/design/design.md` §3 — ホーム / イベント /
+ * 予定 / 会員 (admin only until a member-facing list exists).
+ *
+ * IMPORTANT — border-box trap: Tailwind defaults to `box-sizing: border-
+ * box`, so `min-h-[52px]` measures the **outer** box (border + padding +
+ * content). With `pb-[env(safe-area-inset-bottom)]` (~34px on iPhones
+ * with a home indicator) the content area collapses to ~18px and the
+ * 52px <Link> children overflow visibly below the viewport. We therefore
+ * size the min-height as `52px + env(safe-area-inset-bottom)` so the
+ * content area always has its full 52px after the safe-area padding is
+ * deducted.
  *
  * Client component because it reads the current pathname via
  * `usePathname()` to highlight the active tab.
@@ -70,7 +78,7 @@ export function BottomNav({ isAdmin }: BottomNavProps) {
   const pathname = usePathname() ?? ''
   const visibleTabs = TABS.filter((tab) => !tab.adminOnly || isAdmin)
   return (
-    <nav className="min-h-[52px] pb-[env(safe-area-inset-bottom)] flex-shrink-0 flex items-stretch bg-surface border-t border-border">
+    <nav className="min-h-[calc(52px+env(safe-area-inset-bottom))] pb-[env(safe-area-inset-bottom)] flex-shrink-0 flex items-stretch bg-surface border-t border-border">
       {visibleTabs.map((tab) => {
         const active = tab.matches.some((prefix) =>
           matchesPath(pathname, prefix),

--- a/apps/web/src/components/layout/bottom-nav.tsx
+++ b/apps/web/src/components/layout/bottom-nav.tsx
@@ -78,7 +78,7 @@ export function BottomNav({ isAdmin }: BottomNavProps) {
   const pathname = usePathname() ?? ''
   const visibleTabs = TABS.filter((tab) => !tab.adminOnly || isAdmin)
   return (
-    <nav className="min-h-[calc(52px+env(safe-area-inset-bottom))] pb-[env(safe-area-inset-bottom)] flex-shrink-0 flex items-stretch bg-surface border-t border-border">
+    <nav className="min-h-[calc(52px_+_env(safe-area-inset-bottom))] pb-[env(safe-area-inset-bottom)] flex-shrink-0 flex items-stretch bg-surface border-t border-border">
       {visibleTabs.map((tab) => {
         const active = tab.matches.some((prefix) =>
           matchesPath(pathname, prefix),

--- a/docs/features/sticky-mobile-shell/implementation-plan.md
+++ b/docs/features/sticky-mobile-shell/implementation-plan.md
@@ -28,7 +28,7 @@ status: completed
   - `pnpm --filter web test` が全件 pass
   - 新規テストが pass し、`h-dvh` / `flex-1` / `overflow-y-auto` / `paddingBottom: env(safe-area-inset-bottom)` を検証している
 
-### タスク2b: flex `min-h-auto` 罠の事後修正（PR #65 で追加）
+### タスク2b: flex `min-h-auto` 罠の事後修正（PR #66）
 
 - [x] 完了
 - **概要:** PR #64 ship + 本番反映後、ユーザー実機検証で BottomNav が下スクロールで画面外に消える現象が判明。原因は flex item デフォルト `min-height: auto` で `<main>` が子コンテンツに押されて shell の h-dvh 境界を突き抜け、body スクロールが走っていたこと。
@@ -38,6 +38,17 @@ status: completed
   - `docs/features/sticky-mobile-shell/requirements.md` — §4.2 mobile-shell.tsx のコード例と `min-h-0` 必須の注記
 - **依存タスク:** タスク1, タスク2
 - **対応Issue:** #53 (事後修正の一部、実機 NG → fix → 再実機)
+
+### タスク2c: BottomNav の border-box 高さ罠の事後修正（PR #67）
+
+- [x] 完了
+- **概要:** PR #66 ship + 本番反映後、固定挙動は OK になったがユーザー実機検証で「BottomNav タブが画面下端からだいぶ下に見切れる」現象が判明。原因は Tailwind default `box-sizing: border-box` で `min-h-[52px]` の中に `pb-[env(safe-area-inset-bottom)]` (~34px) が含まれ、コンテンツ領域が 18px に圧縮、`<Link h-[52px]>` が viewport 外にはみ出していたこと。
+- **変更対象ファイル:**
+  - `apps/web/src/components/layout/bottom-nav.tsx` — `<nav>` の `min-h-[52px]` を `min-h-[calc(52px+env(safe-area-inset-bottom))]` に修正、罠の解説コメント追加
+  - `apps/web/src/components/layout/bottom-nav.test.tsx` — `<nav>` の `min-h-[calc(52px+env(safe-area-inset-bottom))]` 検証 + 素の `min-h-[52px]` への退行ガード追加
+  - `docs/features/sticky-mobile-shell/requirements.md` — §4.2 bottom-nav.tsx のコード例と border-box 罠の注記
+- **依存タスク:** タスク1, タスク2, タスク2b
+- **対応Issue:** #53 (事後修正の続き、PR #66 後の実機 NG → fix → 再実機)
 
 ### タスク3: 実機確認（iPhone Safari + iPhone PWA standalone）
 

--- a/docs/features/sticky-mobile-shell/requirements.md
+++ b/docs/features/sticky-mobile-shell/requirements.md
@@ -81,7 +81,7 @@ export const viewport: Viewport = {
 **`apps/web/src/components/layout/bottom-nav.tsx`**
 
 ```tsx
-<nav className="min-h-[calc(52px+env(safe-area-inset-bottom))] pb-[env(safe-area-inset-bottom)] flex-shrink-0 flex items-stretch bg-surface border-t border-border">
+<nav className="min-h-[calc(52px_+_env(safe-area-inset-bottom))] pb-[env(safe-area-inset-bottom)] flex-shrink-0 flex items-stretch bg-surface border-t border-border">
   {visibleTabs.map((tab) => (
     <Link
       ...

--- a/docs/features/sticky-mobile-shell/requirements.md
+++ b/docs/features/sticky-mobile-shell/requirements.md
@@ -81,7 +81,7 @@ export const viewport: Viewport = {
 **`apps/web/src/components/layout/bottom-nav.tsx`**
 
 ```tsx
-<nav className="min-h-[52px] pb-[env(safe-area-inset-bottom)] flex-shrink-0 flex items-stretch bg-surface border-t border-border">
+<nav className="min-h-[calc(52px+env(safe-area-inset-bottom))] pb-[env(safe-area-inset-bottom)] flex-shrink-0 flex items-stretch bg-surface border-t border-border">
   {visibleTabs.map((tab) => (
     <Link
       ...
@@ -96,10 +96,11 @@ export const viewport: Viewport = {
 </nav>
 ```
 
-- `<nav>` 高さは `min-h-[52px]` + Tailwind arbitrary value `pb-[env(safe-area-inset-bottom)]`（safe-area 込みで 52px + α）。
+- `<nav>` 高さは `min-h-[calc(52px + env(safe-area-inset-bottom))]` + `pb-[env(safe-area-inset-bottom)]`（safe-area 込みで 52px + α）。
 - 当初は inline style で `paddingBottom: 'env(...)'` を当てる方針だったが、jsdom (vitest) の CSSOM が `env()` を invalid と判定して style attribute ごと捨てるためテスト不能。Tailwind arbitrary value に切り替えて class 名で検証可能にした（実機の挙動は等価）。
 - 各 `<Link>` のタップ可能領域は明示的に `h-[52px]` で 52px 固定。
 - safe-area 部分（home indicator 領域）は `<nav>` の padding 領域として bg-surface のまま描画される。
+- **min-h は `calc(52px + safe-area)` で確保必須**: Tailwind は default `box-sizing: border-box` なので `min-h-[52px]` だと padding-bottom (~34px) が min-h の中に含まれ、コンテンツ領域が 18px に圧縮されて `<Link h-[52px]>` がはみ出して画面外に切れる。PR #67 で `calc()` 版に修正（PR #66 後の実機でホームインジケータ近くまでタブが見切れる事象として発覚）。
 
 **`apps/web/src/components/layout/mobile-shell.test.tsx`**（新規）
 


### PR DESCRIPTION
## Summary

PR #66 後の本番実機検証で「固定はされるようになったが BottomNav タブが画面下端からだいぶ下に見切れる」現象が判明。原因は Tailwind default \`box-sizing: border-box\` で \`min-h-[52px]\` が外側ボックス基準のため、\`pb-[env(safe-area-inset-bottom)]\` (~34px) が min-h の中に含まれて**コンテンツ領域が 52 − 34 = 18px に圧縮**されていたこと。子の \`<Link h-[52px]>\` は 52px のまま下に overflow して画面外に切れていた。

- [apps/web/src/components/layout/bottom-nav.tsx](apps/web/src/components/layout/bottom-nav.tsx): \`<nav>\` の \`min-h-[52px]\` → \`min-h-[calc(52px+env(safe-area-inset-bottom))]\` に修正、border-box 罠の解説コメント追加
- [apps/web/src/components/layout/bottom-nav.test.tsx](apps/web/src/components/layout/bottom-nav.test.tsx): 新 calc クラスの検証ケース追加 + 素の \`min-h-[52px]\` への退行ガード
- \`docs/features/sticky-mobile-shell/{requirements,implementation-plan}.md\`: §4.2 のコード例と border-box 罠の注記、タスク 2c (PR #67) を plan に追記

## 補足: なぜ vitest で検知できなかったか

jsdom はレイアウト計算しない (display:flex / box-sizing / env() 全て計算しない) ため、border-box で padding が min-h に算入されてコンテンツが圧縮される現象は class アサーション以外では捉えられない。実機/Playwright headful + 実 iPhone viewport でしか再現しない種類のバグ。class レベルでリグレッションガードを追加 + requirements に罠を明記して再発防止する。

汎用知見として memory に [feedback_tailwind_min_h_border_box.md](.claude/memory/feedback_tailwind_min_h_border_box.md) を追加。

## Test plan

- [x] \`pnpm --filter web test\` — 22 ファイル / **181 ケース全 pass** (前回 180 → +1 = calc 検証ケース追加)
- [ ] 本番反映後 iPhone Safari + PWA standalone で BottomNav が画面下端ピッタリに表示され、タブの 52px がフル表示されることを確認 (#53)
- [ ] BottomNav の下の home indicator 領域が \`bg-surface\` で塗られていることを確認

## 関連 Issue

- #53 (実機確認): 本 PR ship + 本番反映後に再々検証
- 親 #50 も #53 と同時クローズ予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)