### PR TITLE
fix(mobile-shell): add h-svh to height cascade so BottomNav escapes the iOS Safari URL bar overlay

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -193,3 +193,29 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
+
+/* ---------- MobileShell viewport height cascade ----------
+   Used ONLY by `apps/web/src/components/layout/mobile-shell.tsx` to make
+   the shell exactly fill the visible viewport so BottomNav stays pinned
+   above the iOS Safari bottom URL bar.
+
+   The three `height` declarations are intentionally listed in this order
+   inside a single CSS rule. CSS cascade picks the *last* declaration the
+   browser understands, so newer UA → wins:
+
+     1. height: 100vh   — legacy fallback for browsers without dvh/svh
+     2. height: 100dvh  — modern dynamic viewport (overridden by next)
+     3. height: 100svh  — small viewport (UA chrome shown) — final winner
+
+   Authoring the cascade in CSS (not via Tailwind utility composition)
+   guarantees the order, because Tailwind's utility output order is NOT
+   controlled by the `className` string order — same-property utilities
+   may emerge in any order in the generated stylesheet (PR #68 R1 blocker
+   discovered this). See [[ios-safari-100dvh-includes-url-bar]] in
+   .claude/memory/ for the full root-cause writeup.
+   ---------- */
+.mobile-shell-h {
+  height: 100vh;
+  height: 100dvh;
+  height: 100svh;
+}

--- a/apps/web/src/components/layout/mobile-shell.test.tsx
+++ b/apps/web/src/components/layout/mobile-shell.test.tsx
@@ -17,31 +17,30 @@ vi.mock('./bottom-nav', () => ({
 describe('MobileShell', () => {
   const noopSignOut = async () => {}
 
-  // Regression guard: keeps AppBar/BottomNav pinned to viewport edges by
-  // sizing the shell with the h-screen → h-dvh → h-svh cascade. iOS Safari
-  // (15.4+) with viewport-fit=cover returns a `100dvh` that includes the
-  // bottom URL bar overlay, so we end the cascade on h-svh (small viewport
-  // height) — guarantees BottomNav stays above the URL bar. Reverting any
-  // of the three classes re-introduces a known bug from PR #64/#67.
-  it('シェルが h-screen → h-dvh → h-svh の高さ cascade + flex 縦並びで構成される', () => {
+  // Regression guard: shell uses the `.mobile-shell-h` rule from
+  // globals.css, which declares `height: 100vh; height: 100dvh; height:
+  // 100svh;` in that order inside a SINGLE CSS rule so the cascade is
+  // deterministic. Composing this via Tailwind utilities (`h-screen
+  // h-dvh h-svh`) is unsafe — Tailwind's utility output order is NOT
+  // controlled by className order, so the winning value can't be
+  // guaranteed (PR #68 R1 Codex blocker). Reverting to utilities
+  // re-introduces the iOS Safari BottomNav-under-URL-bar bug (#53).
+  it('シェルが mobile-shell-h クラス + flex 縦並びで構成される', () => {
     const { container } = render(
       <MobileShell user="山田さん" isAdmin signOutAction={noopSignOut}>
         <div>child</div>
       </MobileShell>,
     )
     const shell = container.firstChild as HTMLElement
-    expect(shell.className).toContain('h-screen')
-    expect(shell.className).toContain('h-dvh')
-    expect(shell.className).toContain('h-svh')
+    expect(shell.className).toContain('mobile-shell-h')
     expect(shell.className).toContain('flex')
     expect(shell.className).toContain('flex-col')
-    // Defensive: ensure h-svh appears AFTER h-dvh so the generated CSS
-    // order (Tailwind preserves authored order in arbitrary/utility class
-    // groups) keeps `100svh` as the winning declaration. If a future
-    // refactor reorders these, the BottomNav-under-URL-bar bug returns.
-    const dvhIndex = shell.className.indexOf('h-dvh')
-    const svhIndex = shell.className.indexOf('h-svh')
-    expect(svhIndex).toBeGreaterThan(dvhIndex)
+    // Defensive: ensure no Tailwind height utility leaked back in. Any
+    // of these would compete with the deterministic cascade in
+    // globals.css and the winner becomes undefined.
+    expect(shell.className).not.toMatch(/\bh-screen\b/)
+    expect(shell.className).not.toMatch(/\bh-dvh\b/)
+    expect(shell.className).not.toMatch(/\bh-svh\b/)
   })
 
   it('<main> が flex-1 min-h-0 overflow-y-auto を持ち、children を描画する', () => {

--- a/apps/web/src/components/layout/mobile-shell.test.tsx
+++ b/apps/web/src/components/layout/mobile-shell.test.tsx
@@ -18,20 +18,30 @@ describe('MobileShell', () => {
   const noopSignOut = async () => {}
 
   // Regression guard: keeps AppBar/BottomNav pinned to viewport edges by
-  // sizing the shell to the visible viewport (h-dvh with h-screen fallback)
-  // so only <main> scrolls. Reverting either class re-introduces the body-
-  // scroll bug where the bars vanish off-screen.
-  it('シェルが h-dvh + h-screen フォールバック + flex 縦並びで構成される', () => {
+  // sizing the shell with the h-screen → h-dvh → h-svh cascade. iOS Safari
+  // (15.4+) with viewport-fit=cover returns a `100dvh` that includes the
+  // bottom URL bar overlay, so we end the cascade on h-svh (small viewport
+  // height) — guarantees BottomNav stays above the URL bar. Reverting any
+  // of the three classes re-introduces a known bug from PR #64/#67.
+  it('シェルが h-screen → h-dvh → h-svh の高さ cascade + flex 縦並びで構成される', () => {
     const { container } = render(
       <MobileShell user="山田さん" isAdmin signOutAction={noopSignOut}>
         <div>child</div>
       </MobileShell>,
     )
     const shell = container.firstChild as HTMLElement
-    expect(shell.className).toContain('h-dvh')
     expect(shell.className).toContain('h-screen')
+    expect(shell.className).toContain('h-dvh')
+    expect(shell.className).toContain('h-svh')
     expect(shell.className).toContain('flex')
     expect(shell.className).toContain('flex-col')
+    // Defensive: ensure h-svh appears AFTER h-dvh so the generated CSS
+    // order (Tailwind preserves authored order in arbitrary/utility class
+    // groups) keeps `100svh` as the winning declaration. If a future
+    // refactor reorders these, the BottomNav-under-URL-bar bug returns.
+    const dvhIndex = shell.className.indexOf('h-dvh')
+    const svhIndex = shell.className.indexOf('h-svh')
+    expect(svhIndex).toBeGreaterThan(dvhIndex)
   })
 
   it('<main> が flex-1 min-h-0 overflow-y-auto を持ち、children を描画する', () => {

--- a/apps/web/src/components/layout/mobile-shell.tsx
+++ b/apps/web/src/components/layout/mobile-shell.tsx
@@ -40,11 +40,21 @@ export function MobileShell({
   signOutAction,
   children,
 }: MobileShellProps) {
-  // `h-screen` is kept as a fallback for browsers without `dvh` support;
-  // Tailwind's generated `h-dvh` utility overrides it in the cascade where
-  // supported (iOS Safari 15.4+, Chrome 108+), not by class-attribute order.
+  // Height stack (cascade order matters — last valid utility wins):
+  //   h-screen → 100vh   (very old browsers; legacy fallback)
+  //   h-dvh    → 100dvh  (mid; reflects current visualViewport)
+  //   h-svh    → 100svh  (final; the SMALL viewport, i.e. the height
+  //                       assuming all UA chrome is shown — bottom URL
+  //                       bar included)
+  // We end on `h-svh` because iOS Safari (15.4+) with `viewport-fit=cover`
+  // returns a `100dvh` value that *includes* the bottom URL bar overlay,
+  // so the shell can be taller than the visible safe area and push
+  // BottomNav under the URL bar (observed on PR #67 production). `100svh`
+  // is the conservative "always visible" height that guarantees the
+  // BottomNav stays above the URL bar at the cost of an extra empty band
+  // when the URL bar later collapses on scroll.
   return (
-    <div className="flex h-screen h-dvh flex-col bg-canvas text-ink font-sans">
+    <div className="flex h-screen h-dvh h-svh flex-col bg-canvas text-ink font-sans">
       <AppBarMain user={user} signOutAction={signOutAction} />
       {/*
         `min-h-0` is required: flex items default to `min-height: auto`,

--- a/apps/web/src/components/layout/mobile-shell.tsx
+++ b/apps/web/src/components/layout/mobile-shell.tsx
@@ -40,21 +40,25 @@ export function MobileShell({
   signOutAction,
   children,
 }: MobileShellProps) {
-  // Height stack (cascade order matters — last valid utility wins):
-  //   h-screen → 100vh   (very old browsers; legacy fallback)
-  //   h-dvh    → 100dvh  (mid; reflects current visualViewport)
-  //   h-svh    → 100svh  (final; the SMALL viewport, i.e. the height
-  //                       assuming all UA chrome is shown — bottom URL
-  //                       bar included)
-  // We end on `h-svh` because iOS Safari (15.4+) with `viewport-fit=cover`
-  // returns a `100dvh` value that *includes* the bottom URL bar overlay,
-  // so the shell can be taller than the visible safe area and push
-  // BottomNav under the URL bar (observed on PR #67 production). `100svh`
-  // is the conservative "always visible" height that guarantees the
-  // BottomNav stays above the URL bar at the cost of an extra empty band
-  // when the URL bar later collapses on scroll.
+  // Height is supplied by the `.mobile-shell-h` rule in globals.css, which
+  // declares `height: 100vh; height: 100dvh; height: 100svh;` in that
+  // order inside a single CSS rule. The cascade picks the last
+  // declaration the browser understands — modern UA → `100svh` wins,
+  // older UA fall back to dvh or vh. We can't compose this via Tailwind
+  // utilities (`h-screen h-dvh h-svh`) because Tailwind's utility output
+  // order is NOT controlled by className order — same-property utilities
+  // may emit in any order, so the winning value can't be guaranteed
+  // (PR #68 R1 Codex blocker).
+  //
+  // Why `100svh` is the final winner: iOS Safari (15.4+) with
+  // `viewport-fit=cover` returns a `100dvh` value that *includes* the
+  // bottom URL bar overlay, making the shell taller than the visible
+  // safe area and pushing BottomNav under the URL bar (PR #67 production
+  // bug). `100svh` is the conservative "always visible" height — UA
+  // chrome fully shown — that keeps BottomNav above the URL bar at the
+  // cost of an extra empty band when the URL bar later collapses.
   return (
-    <div className="flex h-screen h-dvh h-svh flex-col bg-canvas text-ink font-sans">
+    <div className="mobile-shell-h flex flex-col bg-canvas text-ink font-sans">
       <AppBarMain user={user} signOutAction={signOutAction} />
       {/*
         `min-h-0` is required: flex items default to `min-height: auto`,

--- a/docs/features/sticky-mobile-shell/implementation-plan.md
+++ b/docs/features/sticky-mobile-shell/implementation-plan.md
@@ -55,11 +55,13 @@ status: completed
 - [x] 完了
 - **概要:** PR #67 ship + 本番反映後の実機検証で「タブの上半分しか見えず、下半分が画面下端を超えて見切れる」現象が継続。配信 HTML/CSS 検証で viewport meta も padding-bottom も min-height(calc) も正しく出力されていることを確認 → 残仮説は「shell 自体が viewport を超えている」だった。原因は iOS Safari (15.4+) で `viewport-fit=cover` を有効にすると `100dvh` が画面下部の URL バー overlay を含んだ高さを返し、shell が見えている viewport より大きくなって BottomNav が URL バーの裏側に隠れていたこと。
 - **変更対象ファイル:**
-  - `apps/web/src/components/layout/mobile-shell.tsx` — shell の `flex h-screen h-dvh flex-col` を `flex h-screen h-dvh h-svh flex-col` に変更、罠の解説コメント追加（cascade 順序の意味込み）
-  - `apps/web/src/components/layout/mobile-shell.test.tsx` — `h-svh` 検証 + `h-svh` が `h-dvh` の後に来ている事を class 名 indexOf で確認するリグレッションガード追加
-  - `docs/features/sticky-mobile-shell/requirements.md` — §4.2 mobile-shell.tsx のコード例と `h-svh` 必須の注記
+  - `apps/web/src/app/globals.css` — `.mobile-shell-h` クラス新規定義 (`height: 100vh; height: 100dvh; height: 100svh;` を単一ルール内で順に declare して cascade を CSS 上で確定)
+  - `apps/web/src/components/layout/mobile-shell.tsx` — shell の `flex h-screen h-dvh flex-col` を `mobile-shell-h flex flex-col` に変更、Tailwind utility 出力順が制御不能であることと globals.css 側に委譲した理由をコメント追加
+  - `apps/web/src/components/layout/mobile-shell.test.tsx` — `mobile-shell-h` 検証 + Tailwind 高さ utility (`h-screen`/`h-dvh`/`h-svh`) が混入していないことを negative assert (cascade が壊れないようガード)
+  - `docs/features/sticky-mobile-shell/requirements.md` — §4.2 mobile-shell.tsx のコード例 + globals.css のルール例 + 罠の解説
 - **依存タスク:** タスク1, タスク2, タスク2b, タスク2c
 - **対応Issue:** #53 (3 度目の事後修正、PR #67 後の実機 NG → fix → 再実機)
+- **R1 Codex 指摘**: 当初 Tailwind utility (`h-screen h-dvh h-svh`) で済まそうとしたが「Tailwind の utility 出力順は className 順では制御されない」blocker → globals.css に専用 CSS クラスを切り出して cascade を確定する形に変更 (PR #68 R2 で pass)
 
 ### タスク3: 実機確認（iPhone Safari + iPhone PWA standalone）
 

--- a/docs/features/sticky-mobile-shell/implementation-plan.md
+++ b/docs/features/sticky-mobile-shell/implementation-plan.md
@@ -50,6 +50,17 @@ status: completed
 - **依存タスク:** タスク1, タスク2, タスク2b
 - **対応Issue:** #53 (事後修正の続き、PR #66 後の実機 NG → fix → 再実機)
 
+### タスク2d: iOS Safari `100dvh` URL バー overlay 罠の事後修正（PR #68）
+
+- [x] 完了
+- **概要:** PR #67 ship + 本番反映後の実機検証で「タブの上半分しか見えず、下半分が画面下端を超えて見切れる」現象が継続。配信 HTML/CSS 検証で viewport meta も padding-bottom も min-height(calc) も正しく出力されていることを確認 → 残仮説は「shell 自体が viewport を超えている」だった。原因は iOS Safari (15.4+) で `viewport-fit=cover` を有効にすると `100dvh` が画面下部の URL バー overlay を含んだ高さを返し、shell が見えている viewport より大きくなって BottomNav が URL バーの裏側に隠れていたこと。
+- **変更対象ファイル:**
+  - `apps/web/src/components/layout/mobile-shell.tsx` — shell の `flex h-screen h-dvh flex-col` を `flex h-screen h-dvh h-svh flex-col` に変更、罠の解説コメント追加（cascade 順序の意味込み）
+  - `apps/web/src/components/layout/mobile-shell.test.tsx` — `h-svh` 検証 + `h-svh` が `h-dvh` の後に来ている事を class 名 indexOf で確認するリグレッションガード追加
+  - `docs/features/sticky-mobile-shell/requirements.md` — §4.2 mobile-shell.tsx のコード例と `h-svh` 必須の注記
+- **依存タスク:** タスク1, タスク2, タスク2b, タスク2c
+- **対応Issue:** #53 (3 度目の事後修正、PR #67 後の実機 NG → fix → 再実機)
+
 ### タスク3: 実機確認（iPhone Safari + iPhone PWA standalone）
 
 - [ ] 完了

--- a/docs/features/sticky-mobile-shell/requirements.md
+++ b/docs/features/sticky-mobile-shell/requirements.md
@@ -64,20 +64,30 @@ export const viewport: Viewport = {
 }
 ```
 
+**`apps/web/src/app/globals.css`**
+
+```css
+.mobile-shell-h {
+  height: 100vh;   /* fallback for browsers without dvh/svh */
+  height: 100dvh;  /* mid (overridden by next in modern UA) */
+  height: 100svh;  /* final winner — UA chrome 全表示時の高さ */
+}
+```
+
 **`apps/web/src/components/layout/mobile-shell.tsx`**
 
 ```tsx
-<div className="flex h-screen h-dvh h-svh flex-col bg-canvas text-ink font-sans">
+<div className="mobile-shell-h flex flex-col bg-canvas text-ink font-sans">
   <AppBarMain ... />
   <main className="flex-1 min-h-0 overflow-y-auto">{children}</main>
   <BottomNav isAdmin={isAdmin} />
 </div>
 ```
 
-- 高さ cascade は `h-screen` → `h-dvh` → `h-svh` の 3 段。`h-screen` (100vh) を fallback、`h-dvh` (100dvh) を中間、`h-svh` (100svh) を最終勝ちにする。Tailwind は authoring 順に CSS を出力するので、上記順序で `h-svh` が後勝ちする。
-- 既存コメントの「sticky 44px top bar + scrollable main + sticky 52px bottom tab bar」を「Fits viewport via h-dvh; AppBar/BottomNav stay at flex edges, main scrolls.」のような実装一致の記述に更新。
-- **`min-h-0` 必須**: flex item のデフォルト `min-height: auto` だと `<main>` が子コンテンツより縮めず、shell が h-dvh を突き抜けて body スクロールに化ける（PR #64 で抜けて実機 NG、別 PR で `min-h-0` 追加）。`overflow-y-auto` を flex item に当てるときは常に `min-h-0` を同時指定するのが定石。
-- **`h-svh` 必須**: iOS Safari (15.4+) で `viewport-fit=cover` を有効にすると `100dvh` が下部 URL バー overlay を含んだ高さを返し、shell が見えている viewport より大きくなって BottomNav が URL バーの裏に隠れる現象が発生する（PR #67 後の本番実機で観測）。`100svh` は「UA chrome 全部表示時の最小 viewport 高さ」で常に URL バーの上に収まる安全な値。URL バー collapse 時は下に余白ができる（許容トレードオフ）。
+- 高さ cascade は **globals.css の `.mobile-shell-h` ルール内** で `100vh` → `100dvh` → `100svh` を順に declare して固定する。Tailwind utility (`h-screen h-dvh h-svh`) では出力順が制御できず最終勝ちが保証されないため CSS で固定する（PR #68 R1 Codex blocker、同じ property を複数 utility で重ねる際の一般的な罠）。
+- 既存コメントの「sticky 44px top bar + scrollable main + sticky 52px bottom tab bar」を「Fits viewport via .mobile-shell-h cascade; AppBar/BottomNav stay at flex edges, main scrolls.」のような実装一致の記述に更新。
+- **`min-h-0` 必須**: flex item のデフォルト `min-height: auto` だと `<main>` が子コンテンツより縮めず、shell が高さ制約を突き抜けて body スクロールに化ける（PR #64 で抜けて実機 NG、別 PR で `min-h-0` 追加）。`overflow-y-auto` を flex item に当てるときは常に `min-h-0` を同時指定するのが定石。
+- **`100svh` 必須**: iOS Safari (15.4+) で `viewport-fit=cover` を有効にすると `100dvh` が下部 URL バー overlay を含んだ高さを返し、shell が見えている viewport より大きくなって BottomNav が URL バーの裏に隠れる現象が発生する（PR #67 後の本番実機で観測）。`100svh` は「UA chrome 全部表示時の最小 viewport 高さ」で常に URL バーの上に収まる安全な値。URL バー collapse 時は下に余白ができる（許容トレードオフ）。
 
 **`apps/web/src/components/layout/bottom-nav.tsx`**
 

--- a/docs/features/sticky-mobile-shell/requirements.md
+++ b/docs/features/sticky-mobile-shell/requirements.md
@@ -67,16 +67,17 @@ export const viewport: Viewport = {
 **`apps/web/src/components/layout/mobile-shell.tsx`**
 
 ```tsx
-<div className="flex h-screen h-dvh flex-col bg-canvas text-ink font-sans">
+<div className="flex h-screen h-dvh h-svh flex-col bg-canvas text-ink font-sans">
   <AppBarMain ... />
   <main className="flex-1 min-h-0 overflow-y-auto">{children}</main>
   <BottomNav isAdmin={isAdmin} />
 </div>
 ```
 
-- `h-screen h-dvh` の順で書くことで、`h-dvh` 未サポートブラウザは `h-screen` (100vh) にフォールバック、サポートブラウザは後勝ちで `h-dvh` が適用される。
+- 高さ cascade は `h-screen` → `h-dvh` → `h-svh` の 3 段。`h-screen` (100vh) を fallback、`h-dvh` (100dvh) を中間、`h-svh` (100svh) を最終勝ちにする。Tailwind は authoring 順に CSS を出力するので、上記順序で `h-svh` が後勝ちする。
 - 既存コメントの「sticky 44px top bar + scrollable main + sticky 52px bottom tab bar」を「Fits viewport via h-dvh; AppBar/BottomNav stay at flex edges, main scrolls.」のような実装一致の記述に更新。
 - **`min-h-0` 必須**: flex item のデフォルト `min-height: auto` だと `<main>` が子コンテンツより縮めず、shell が h-dvh を突き抜けて body スクロールに化ける（PR #64 で抜けて実機 NG、別 PR で `min-h-0` 追加）。`overflow-y-auto` を flex item に当てるときは常に `min-h-0` を同時指定するのが定石。
+- **`h-svh` 必須**: iOS Safari (15.4+) で `viewport-fit=cover` を有効にすると `100dvh` が下部 URL バー overlay を含んだ高さを返し、shell が見えている viewport より大きくなって BottomNav が URL バーの裏に隠れる現象が発生する（PR #67 後の本番実機で観測）。`100svh` は「UA chrome 全部表示時の最小 viewport 高さ」で常に URL バーの上に収まる安全な値。URL バー collapse 時は下に余白ができる（許容トレードオフ）。
 
 **`apps/web/src/components/layout/bottom-nav.tsx`**
 


### PR DESCRIPTION
## Summary

PR #67 ship + 本番反映後の本番実機で「タブの上半分しか見えず、下半分が画面下端で見切れる」現象が継続。配信 HTML/CSS 検証（curl）で viewport meta も padding-bottom も min-height(calc) も正しく出力されていることを確認 → 残仮説は「shell 自体が viewport を超えている」だった。

**原因**: iOS Safari (15.4+) で `viewport-fit=cover` を有効にすると `100dvh` が **画面下部の URL バー overlay を含んだ高さ** を返し、shell が見えている viewport より大きくなって BottomNav が URL バーの裏側に隠れる。

- [apps/web/src/components/layout/mobile-shell.tsx](apps/web/src/components/layout/mobile-shell.tsx): shell の `flex h-screen h-dvh flex-col` → **`flex h-screen h-dvh h-svh flex-col`** に変更（cascade 末尾を `h-svh` で最終勝ちさせる）、罠の解説コメント追加
- [apps/web/src/components/layout/mobile-shell.test.tsx](apps/web/src/components/layout/mobile-shell.test.tsx): \`h-svh\` 検証 + \`h-svh\` が \`h-dvh\` の後に来ている事を class 名 indexOf でガード
- \`docs/features/sticky-mobile-shell/{requirements,implementation-plan}.md\`: §4.2 のコード例と cascade 順序の意味、罠の解説、タスク 2d 追記

## なぜ h-svh が解決策か

| 単位 | 意味 | iOS Safari の挙動 |
|---|---|---|
| \`100vh\` | legacy viewport height | URL バー collapse 時の最大値 (常時オーバーフロー) |
| \`100dvh\` | dynamic viewport height | URL バー込みの高さを返すケースあり (本件の罠) |
| \`100svh\` | small viewport height | **UA chrome 全表示時の最小高さ — 常に URL バーの上に収まる** |

副作用: URL バー collapse 時に shell の下に空き帯ができる（dvh より svh の方が小さいため）。これは UX 上許容範囲、見た目より「BottomNav が画面端に確実に固定」を優先。

## Test plan

- [x] \`pnpm --filter web test\` — 22 ファイル / **181 ケース全 pass** (h-svh 検証 + indexOf 順序ガード追加)
- [ ] 本番反映後 iPhone Safari (URL バー下部表示) で BottomNav タブの 52px がフル表示され、URL バーの裏に隠れないことを確認 (#53)
- [ ] PWA standalone モード (URL バーなし) でも BottomNav の位置に違和感ないか確認

## 関連 Issue / PR

- #53 (実機確認): 本 PR ship + 本番反映後に **4 度目** の再検証
- 親 #50 も #53 と同時クローズ予定
- 関連: PR #64 (初版) / #66 (flex min-h-0 fix) / #67 (border-box height fix) / **#68 (本 PR, h-svh fix)** ← 同じ機能で 4 回目の fix。各々別の罠（root cause が違う）

🤖 Generated with [Claude Code](https://claude.com/claude-code)