### PR TITLE
feat(event-line-broadcast): strip Google Groups footer + prepend mail subject

### DIFF
--- a/apps/web/src/lib/line-broadcast.ts
+++ b/apps/web/src/lib/line-broadcast.ts
@@ -16,6 +16,7 @@ import {
 } from '@/lib/attachment-image-render'
 import { setCachedImage } from '@/lib/image-cache'
 import { splitForLine } from '@/lib/text-splitter'
+import { buildBroadcastBody } from '@/lib/mail-body-cleaner'
 
 /**
  * 5-message LINE batch limit + 1.5s sleep between batches (requirements
@@ -25,8 +26,6 @@ const LINE_BATCH_SIZE = 5
 const LINE_BATCH_SLEEP_MS = Number(process.env.LINE_BROADCAST_BATCH_SLEEP_MS ?? 1500)
 
 const LINE_PUSH_ENDPOINT = 'https://api.line.me/v2/bot/message/push'
-
-const CORRECTION_PREFIX = '【訂正】'
 
 /**
  * r-final-15 should_fix: 公開 URL は LINE からアクセス可能な HTTPS で
@@ -743,15 +742,17 @@ export async function broadcastMailToEvent(
 
   try {
     // Build text messages: split the mail body at 5000-char boundaries.
-    // For corrections, prefix the body with 「【訂正】「件名」\n」 BEFORE
-    // splitting so each resulting chunk is guaranteed to fit under the
-    // 5000-character LINE limit (rr2 review blocker: prefixing after split
-    // can push the first chunk over the limit).
-    const rawBody = mail.bodyText ?? '(本文なし)'
-    const prefix = args.isCorrection
-      ? `${CORRECTION_PREFIX}${mail.subject ? `「${mail.subject}」\n` : ''}`
-      : ''
-    const bodyText = prefix + rawBody
+    // buildBroadcastBody が
+    //   - Google Groups footer の除去
+    //   - 件名 prefix `【メール件名】<subject>` の付与
+    //   - 訂正版なら `【訂正】「<subject>」` の前置
+    // をまとめて行う。prefix を結合してから splitForLine に渡すことで、
+    // 5000 字制限を超えるリスクを完全に消す (rr2 review blocker)。
+    const bodyText = buildBroadcastBody({
+      rawBody: mail.bodyText,
+      subject: mail.subject,
+      isCorrection: args.isCorrection,
+    })
     const chunks = splitForLine(bodyText)
     const textMessages: LineMessage[] = chunks.map((chunk) => ({
       type: 'text',

--- a/apps/web/src/lib/mail-body-cleaner.test.ts
+++ b/apps/web/src/lib/mail-body-cleaner.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest'
+import { buildBroadcastBody, stripMailFooter } from './mail-body-cleaner'
+
+describe('stripMailFooter', () => {
+  it('returns body unchanged when no Google Groups footer is present', () => {
+    const body = 'こんにちは\n本文本文\n署名 太郎'
+    expect(stripMailFooter(body)).toBe('こんにちは\n本文本文\n署名 太郎')
+  })
+
+  it('strips Japanese Google Groups footer after `-- \\n`', () => {
+    const body = [
+      'こんにちは',
+      '本文本文',
+      '署名 太郎',
+      '',
+      '-- ',
+      'このメールは Google グループ「xxxxx」に登録しているユーザーに送られています。',
+      'このグループから退会するには xxxxx+unsubscribe@googlegroups.com にメールを送信してください。',
+      'https://groups.google.com/d/msgid/xxxxx/yyyyy にアクセス',
+    ].join('\n')
+    expect(stripMailFooter(body)).toBe('こんにちは\n本文本文\n署名 太郎')
+  })
+
+  it('strips English Google Groups footer after `-- \\n`', () => {
+    const body = [
+      'Hello',
+      'Some body',
+      '-- ',
+      'You received this message because you are subscribed to the Google Groups "xxx" group.',
+      'To unsubscribe...',
+    ].join('\n')
+    expect(stripMailFooter(body)).toBe('Hello\nSome body')
+  })
+
+  it('strips Google Groups footer that appears after a blank line (no `-- `)', () => {
+    const body = [
+      'こんにちは',
+      '本文本文',
+      '',
+      'このメールは Google グループ「xxx」に登録しているユーザーに送られています。',
+      'unsubscribe URL...',
+    ].join('\n')
+    expect(stripMailFooter(body)).toBe('こんにちは\n本文本文')
+  })
+
+  it('keeps a manual signoff that contains `-- ` but is not Google Groups', () => {
+    const body = [
+      'こんにちは',
+      '本文本文',
+      '',
+      '-- ',
+      '主催者 山田太郎',
+      'メール: yamada@example.com',
+    ].join('\n')
+    // Google Groups パターンに一致しないので削除されない
+    expect(stripMailFooter(body)).toBe(body)
+  })
+
+  it('trims trailing whitespace even when no footer matched', () => {
+    const body = 'こんにちは\n本文本文\n\n\n'
+    expect(stripMailFooter(body)).toBe('こんにちは\n本文本文')
+  })
+
+  it('handles CRLF line endings', () => {
+    const body =
+      'こんにちは\r\n本文本文\r\n\r\n-- \r\nこのメールは Google グループ「x」に登録しているユーザーに送られています。\r\nfooter'
+    expect(stripMailFooter(body)).toBe('こんにちは\r\n本文本文')
+  })
+})
+
+describe('buildBroadcastBody', () => {
+  it('prepends 【メール件名】 prefix when subject is present', () => {
+    const result = buildBroadcastBody({
+      rawBody: '本文です',
+      subject: '第48回大会のお知らせ',
+      isCorrection: false,
+    })
+    expect(result).toBe('【メール件名】第48回大会のお知らせ\n\n本文です')
+  })
+
+  it('omits subject prefix when subject is empty/null', () => {
+    expect(
+      buildBroadcastBody({ rawBody: '本文だけ', subject: '', isCorrection: false }),
+    ).toBe('本文だけ')
+    expect(
+      buildBroadcastBody({ rawBody: '本文だけ', subject: null, isCorrection: false }),
+    ).toBe('本文だけ')
+  })
+
+  it('prepends 【訂正】「<件名>」 + subject prefix for corrections', () => {
+    const result = buildBroadcastBody({
+      rawBody: '訂正後本文',
+      subject: '第48回大会のお知らせ(訂正版)',
+      isCorrection: true,
+    })
+    expect(result).toBe(
+      '【訂正】「第48回大会のお知らせ(訂正版)」\n【メール件名】第48回大会のお知らせ(訂正版)\n\n訂正後本文',
+    )
+  })
+
+  it('correction without subject still shows 【訂正】 alone', () => {
+    expect(
+      buildBroadcastBody({ rawBody: '本文', subject: null, isCorrection: true }),
+    ).toBe('【訂正】\n本文')
+  })
+
+  it('cleans Google Groups footer before composing', () => {
+    const result = buildBroadcastBody({
+      rawBody: '本文\n\n-- \nこのメールは Google グループ「x」に登録しているユーザーに送られています。\nfooter',
+      subject: 'テスト',
+      isCorrection: false,
+    })
+    expect(result).toBe('【メール件名】テスト\n\n本文')
+  })
+
+  it('falls back to placeholder body when rawBody is empty', () => {
+    const result = buildBroadcastBody({
+      rawBody: null,
+      subject: 'タイトル',
+      isCorrection: false,
+    })
+    expect(result).toBe('【メール件名】タイトル\n\n(本文なし)')
+  })
+
+  it('trims surrounding whitespace from subject', () => {
+    const result = buildBroadcastBody({
+      rawBody: '本文',
+      subject: '  前後空白  ',
+      isCorrection: false,
+    })
+    expect(result).toBe('【メール件名】前後空白\n\n本文')
+  })
+})

--- a/apps/web/src/lib/mail-body-cleaner.ts
+++ b/apps/web/src/lib/mail-body-cleaner.ts
@@ -1,0 +1,82 @@
+/**
+ * 配信前のメール本文を LINE 用にクリーンアップするヘルパー。
+ *
+ * 現状の責務は 2 つ:
+ *   1. Google Groups などの ML ソフトウェアが自動付与するフッターを除去
+ *   2. 件名と訂正フラグを本文先頭に prefix として埋め込む
+ *
+ * 主催者の手書き署名は触らない (--  以降全削除は副作用が大きいので、
+ * "Google Groups であることを明示しているブロック" だけを保守的に切る)。
+ */
+
+const CORRECTION_PREFIX = '【訂正】'
+const SUBJECT_PREFIX = '【メール件名】'
+
+/**
+ * Google Groups の典型フッター検出パターン。
+ *
+ * 検出条件: `-- ` 直後 (RFC 3676 のシグネチャ区切り) もしくは空行直後に、
+ * 「このメールは Google グループ」「You received this message because you
+ * are subscribed to the Google Groups」のいずれかが現れる。
+ *
+ * `[\s\S]*$` でその位置から末尾までを丸ごと除去する (Groups footer は
+ * 通常メール本文の末尾固定で、複数行に渡る)。
+ */
+const GOOGLE_GROUPS_FOOTER_PATTERNS = [
+  /(?:^|\r?\n)(?:-- ?\r?\n|\r?\n)このメールは Google グループ[\s\S]*$/,
+  /(?:^|\r?\n)(?:-- ?\r?\n|\r?\n)You received this message because you are subscribed to the Google Groups[\s\S]*$/,
+]
+
+/**
+ * 本文末尾の Google Groups footer を除去して trim する。
+ * 該当しないメールでは末尾の余分な空白だけ落として返す。
+ */
+export function stripMailFooter(body: string): string {
+  let result = body
+  for (const pattern of GOOGLE_GROUPS_FOOTER_PATTERNS) {
+    result = result.replace(pattern, '')
+  }
+  return result.trimEnd()
+}
+
+export interface BuildBroadcastBodyInput {
+  /** 元のメール本文 (`mail_messages.body_text`) */
+  rawBody: string | null | undefined
+  /** メール件名 (`mail_messages.subject`)。null なら subject prefix は付かない */
+  subject: string | null | undefined
+  /** 訂正版かどうか (`tournament_drafts.is_correction`) */
+  isCorrection: boolean
+}
+
+/**
+ * LINE に push する最終的なテキストを組み立てる。
+ *
+ * 構成:
+ *   1. (訂正版のみ) `【訂正】「<元件名>」\n`
+ *   2. `【メール件名】<件名>\n\n`  (件名が空のときはスキップ)
+ *   3. footer を除去した本文
+ *
+ * 全部結合した文字列は呼び出し側で `splitForLine` に渡して 5000 字
+ * 上限に分割する前提なので、ここでは結合だけ。
+ */
+export function buildBroadcastBody(input: BuildBroadcastBodyInput): string {
+  const cleanedBody = stripMailFooter(input.rawBody ?? '(本文なし)')
+  const subject = input.subject?.trim() ?? ''
+  const parts: string[] = []
+
+  if (input.isCorrection) {
+    // 元件名を「」で囲むことで、LINE で太字/装飾できない環境でも視覚的に区切れる。
+    parts.push(subject ? `${CORRECTION_PREFIX}「${subject}」\n` : `${CORRECTION_PREFIX}\n`)
+  }
+  if (subject) {
+    parts.push(`${SUBJECT_PREFIX}${subject}\n\n`)
+  }
+  parts.push(cleanedBody)
+  return parts.join('')
+}
+
+export const _internal = {
+  CORRECTION_PREFIX,
+  SUBJECT_PREFIX,
+  GOOGLE_GROUPS_FOOTER_PATTERNS,
+}


### PR DESCRIPTION
## 背景
本番運用フィードバック (2026-05-31):
- 配信されたメールに「このメールは Google グループ ...」フッターがそのまま入っていて読みづらい
- メール件名が本文に含まれていないので、訂正版以外でも何のメールか分かりにくい

## 変更
新規ヘルパー `apps/web/src/lib/mail-body-cleaner.ts`:
1. **stripMailFooter**: Google Groups フッター (日英) を保守的なパターンで除去。手書き署名 (主催者情報) は残す
2. **buildBroadcastBody**: 件名 prefix `【メール件名】<subject>` を常時付与、訂正版なら `【訂正】「<subject>」` を最初に追加

`line-broadcast.ts` の prefix 組み立てロジックを buildBroadcastBody に集約。

## 例
### 通常配信
```
【メール件名】第48回全国選手権 個人戦参加要項

(本文)
...
```

### 訂正版
```
【訂正】「第48回大会のお知らせ(訂正版)」
【メール件名】第48回大会のお知らせ(訂正版)

(本文)
...
```

### Google Groups footer 除去
配信前:
```
本文本文
主催者 山田太郎

--
このメールは Google グループ「xxx」に登録しているユーザーに送られています。
unsubscribe URL...
```
↓
配信後:
```
本文本文
主催者 山田太郎
```

## Test plan
- [x] Vitest: mail-body-cleaner.test.ts 14 ケース + 既存 line-broadcast 6 ケース pass
- [x] 型チェック 4 packages green
- [ ] 本番反映後、次回配信メールで Google Groups footer 削除 + 件名 prefix 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)