### PR TITLE
fix(event-line-broadcast): wrap subject in 【】 (no label text)

### DIFF
--- a/apps/web/src/lib/mail-body-cleaner.test.ts
+++ b/apps/web/src/lib/mail-body-cleaner.test.ts
@@ -69,16 +69,16 @@ describe('stripMailFooter', () => {
 })
 
 describe('buildBroadcastBody', () => {
-  it('prepends 【メール件名】 prefix when subject is present', () => {
+  it('wraps subject in 【】 brackets when subject is present', () => {
     const result = buildBroadcastBody({
       rawBody: '本文です',
       subject: '第48回大会のお知らせ',
       isCorrection: false,
     })
-    expect(result).toBe('【メール件名】第48回大会のお知らせ\n\n本文です')
+    expect(result).toBe('【第48回大会のお知らせ】\n\n本文です')
   })
 
-  it('omits subject prefix when subject is empty/null', () => {
+  it('omits subject bracket when subject is empty/null', () => {
     expect(
       buildBroadcastBody({ rawBody: '本文だけ', subject: '', isCorrection: false }),
     ).toBe('本文だけ')
@@ -87,14 +87,14 @@ describe('buildBroadcastBody', () => {
     ).toBe('本文だけ')
   })
 
-  it('prepends 【訂正】「<件名>」 + subject prefix for corrections', () => {
+  it('prepends 【訂正】 + 【件名】 for corrections', () => {
     const result = buildBroadcastBody({
       rawBody: '訂正後本文',
       subject: '第48回大会のお知らせ(訂正版)',
       isCorrection: true,
     })
     expect(result).toBe(
-      '【訂正】「第48回大会のお知らせ(訂正版)」\n【メール件名】第48回大会のお知らせ(訂正版)\n\n訂正後本文',
+      '【訂正】【第48回大会のお知らせ(訂正版)】\n\n訂正後本文',
     )
   })
 
@@ -110,7 +110,7 @@ describe('buildBroadcastBody', () => {
       subject: 'テスト',
       isCorrection: false,
     })
-    expect(result).toBe('【メール件名】テスト\n\n本文')
+    expect(result).toBe('【テスト】\n\n本文')
   })
 
   it('falls back to placeholder body when rawBody is empty', () => {
@@ -119,7 +119,7 @@ describe('buildBroadcastBody', () => {
       subject: 'タイトル',
       isCorrection: false,
     })
-    expect(result).toBe('【メール件名】タイトル\n\n(本文なし)')
+    expect(result).toBe('【タイトル】\n\n(本文なし)')
   })
 
   it('trims surrounding whitespace from subject', () => {
@@ -128,6 +128,6 @@ describe('buildBroadcastBody', () => {
       subject: '  前後空白  ',
       isCorrection: false,
     })
-    expect(result).toBe('【メール件名】前後空白\n\n本文')
+    expect(result).toBe('【前後空白】\n\n本文')
   })
 })

--- a/apps/web/src/lib/mail-body-cleaner.ts
+++ b/apps/web/src/lib/mail-body-cleaner.ts
@@ -10,7 +10,6 @@
  */
 
 const CORRECTION_PREFIX = '【訂正】'
-const SUBJECT_PREFIX = '【メール件名】'
 
 /**
  * Google Groups の典型フッター検出パターン。
@@ -52,9 +51,13 @@ export interface BuildBroadcastBodyInput {
  * LINE に push する最終的なテキストを組み立てる。
  *
  * 構成:
- *   1. (訂正版のみ) `【訂正】「<元件名>」\n`
- *   2. `【メール件名】<件名>\n\n`  (件名が空のときはスキップ)
+ *   1. (訂正版のみ) `【訂正】`
+ *   2. `【<件名>】\n\n` (件名が空のときはスキップ)
  *   3. footer を除去した本文
+ *
+ * 例:
+ *   通常配信: 「【第48回大会のお知らせ】\n\n本文...」
+ *   訂正版:   「【訂正】【第48回大会のお知らせ(訂正版)】\n\n本文...」
  *
  * 全部結合した文字列は呼び出し側で `splitForLine` に渡して 5000 字
  * 上限に分割する前提なので、ここでは結合だけ。
@@ -65,11 +68,17 @@ export function buildBroadcastBody(input: BuildBroadcastBodyInput): string {
   const parts: string[] = []
 
   if (input.isCorrection) {
-    // 元件名を「」で囲むことで、LINE で太字/装飾できない環境でも視覚的に区切れる。
-    parts.push(subject ? `${CORRECTION_PREFIX}「${subject}」\n` : `${CORRECTION_PREFIX}\n`)
+    // 訂正版マーカー。件名がある場合は次の `【件名】` と並んで `【訂正】【...】`
+    // という二重括弧表記になる (視認性最優先)。
+    parts.push(CORRECTION_PREFIX)
   }
   if (subject) {
-    parts.push(`${SUBJECT_PREFIX}${subject}\n\n`)
+    // 件名そのものを `【...】` で囲んで本文と視覚的に分離する。
+    // ラベル文字 (例:「メール件名」) は付けない。
+    parts.push(`【${subject}】\n\n`)
+  } else if (input.isCorrection) {
+    // 訂正版で件名が空の場合は `【訂正】` 単独でその後に改行を入れる。
+    parts.push('\n')
   }
   parts.push(cleanedBody)
   return parts.join('')
@@ -77,6 +86,5 @@ export function buildBroadcastBody(input: BuildBroadcastBodyInput): string {
 
 export const _internal = {
   CORRECTION_PREFIX,
-  SUBJECT_PREFIX,
   GOOGLE_GROUPS_FOOTER_PATTERNS,
 }


### PR DESCRIPTION
## 背景
PR #71 で導入した件名 prefix のフォーマットがユーザーの意図と違っていた。

- 旧 (誤): \`【メール件名】第48回大会のお知らせ\` (ラベル文字 + 件名)
- 新 (正): \`【第48回大会のお知らせ】\` (件名を括弧で囲む)

訂正版:
- 旧: \`【訂正】「<件名>」\n【メール件名】<件名>\`
- 新: \`【訂正】【<件名>】\` (シンプルな二重括弧)

## Test plan
- [x] Vitest 14 ケース pass (mail-body-cleaner.test.ts)
- [x] 型チェック 4 packages green
- [ ] 本番反映後、次回配信メッセージで \`【件名】\` 形式を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)