### PR TITLE
feat(mail-body-as-image): メール本文を画像で LINE 配信 + 添付を URL リンクに統一

### DIFF
--- a/apps/web/src/lib/attachment-image-render.ts
+++ b/apps/web/src/lib/attachment-image-render.ts
@@ -154,40 +154,27 @@ export async function renderPdfToJpegs(
 }
 
 /**
- * Render a `.docx` (or anything libreoffice can read) to JPEG pages by
- * converting through PDF. The intermediate PDF lives only in the tmpdir.
+ * Convert any libreoffice-readable input file (`.docx`, `.html`, `.odt`, …)
+ * to a PDF written into `outDir` with the same basename (e.g. `body.html` →
+ * `body.pdf`). `libreoffice --headless --convert-to pdf` is the documented
+ * one-shot conversion; it spawns a fresh `soffice` process per call and exits
+ * when done, so we don't manage a long-running daemon.
  *
- * `libreoffice --headless --convert-to pdf` is the documented one-shot
- * conversion; it spawns a fresh `soffice` process per call and exits when
- * done, so we don't need to manage a long-running daemon.
+ * Shared by the mail-body image-render path (mail-body-image-render.ts) so the
+ * libreoffice invocation — flags, timeout, stdout-drain, stderr surfacing —
+ * lives in one place. libreoffice cold-start on the production ARM box has
+ * been observed up to ~6s; the 120s timeout gives ample headroom for a chunky
+ * multi-page document.
  */
-export async function renderDocxToJpegs(
-  docxBuffer: Buffer,
-  options: { maxPages?: number } = {},
-): Promise<ImageRenderResult> {
-  const workDir = await mkdtemp(join(tmpdir(), 'kagetra-docx-'))
-  try {
-    const inputPath = join(workDir, 'input.docx')
-    await writeFile(inputPath, docxBuffer)
-    await runCommand(
-      'libreoffice',
-      [
-        '--headless',
-        '--convert-to',
-        'pdf',
-        '--outdir',
-        workDir,
-        inputPath,
-      ],
-      // libreoffice cold-start can be slow; give it more headroom than
-      // pdftoppm which usually runs in milliseconds.
-      { timeoutMs: 120_000 },
-    )
-    const pdfBuffer = await readFile(join(workDir, 'input.pdf'))
-    return await renderPdfToJpegs(pdfBuffer, options)
-  } finally {
-    await rm(workDir, { recursive: true, force: true }).catch(() => {})
-  }
+export async function runLibreofficeConvertToPdf(
+  inputPath: string,
+  outDir: string,
+): Promise<void> {
+  await runCommand(
+    'libreoffice',
+    ['--headless', '--convert-to', 'pdf', '--outdir', outDir, inputPath],
+    { timeoutMs: 120_000 },
+  )
 }
 
 /**

--- a/apps/web/src/lib/line-broadcast.test.ts
+++ b/apps/web/src/lib/line-broadcast.test.ts
@@ -1,6 +1,15 @@
-import { describe, it, expect, beforeEach, beforeAll, afterAll } from 'vitest'
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  beforeAll,
+  afterAll,
+  vi,
+} from 'vitest'
 import { eq } from 'drizzle-orm'
 import { broadcastMailToEvent } from './line-broadcast'
+import { renderBodyImageToJpegs } from '@/lib/mail-body-image-render'
 import {
   attachmentShareTokens,
   eventBroadcastMessages,
@@ -13,6 +22,17 @@ import {
   users,
 } from '@kagetra/shared/schema'
 import { db } from './db'
+
+// 本文画像化 (libreoffice spawn) はこのユニットテストの対象外。配信
+// オーケストレーション (本文 image / 添付 link / text fallback の role 別
+// カウント) を環境非依存で検証するため、renderBodyImageToJpegs をモジュール
+// レベルでモックする。実際の libreoffice 描画は mail-body-image-render.test.ts
+// の統合テストが (libreoffice 搭載環境でのみ) カバーする。
+vi.mock('@/lib/mail-body-image-render', () => ({
+  renderBodyImageToJpegs: vi.fn(),
+}))
+
+const renderBodyImageMock = vi.mocked(renderBodyImageToJpegs)
 
 async function resetDb() {
   await db.delete(eventBroadcastMessages)
@@ -28,14 +48,29 @@ async function resetDb() {
 
 let originalDryRun: string | undefined
 let originalBaseUrl: string | undefined
+// 本文画像化の成功ケースで使う有効な JPEG。buildBodyImageMessages は sharp で
+// リサイズするので、実バイト列でないと happy path を通らない。
+let jpegFixture: Buffer
 
-beforeAll(() => {
+beforeAll(async () => {
   originalDryRun = process.env.LINE_NOTIFY_DRY_RUN
   process.env.LINE_NOTIFY_DRY_RUN = '1'
   // r-final-15: resolveBaseUrl は PUBLIC_BASE_URL が必須なのでテスト
   // 時にダミーをセット。実際の push は LINE_NOTIFY_DRY_RUN=1 で skip。
   originalBaseUrl = process.env.PUBLIC_BASE_URL
   process.env.PUBLIC_BASE_URL = 'https://test.example.com'
+
+  const { default: sharp } = await import('sharp')
+  jpegFixture = await sharp({
+    create: {
+      width: 120,
+      height: 160,
+      channels: 3,
+      background: { r: 255, g: 255, b: 255 },
+    },
+  })
+    .jpeg()
+    .toBuffer()
 })
 
 afterAll(() => {
@@ -112,9 +147,31 @@ async function buildLinkedFixture(): Promise<Fixtures> {
   return { eventId, channelId: channel.id, broadcastId, mailMessageId }
 }
 
+async function addAttachment(
+  mailMessageId: number,
+  filename: string,
+  contentType: string,
+): Promise<number> {
+  const data = Buffer.from('fake-attachment-bytes')
+  const inserted = await db
+    .insert(mailAttachments)
+    .values({
+      mailMessageId,
+      filename,
+      contentType,
+      sizeBytes: data.length,
+      data,
+    })
+    .returning({ id: mailAttachments.id })
+  return inserted[0]!.id
+}
+
 describe('broadcastMailToEvent', () => {
   beforeEach(async () => {
     await resetDb()
+    // 既定は本文画像化成功 (1 ページ)。各テストで Once override する。
+    renderBodyImageMock.mockReset()
+    renderBodyImageMock.mockResolvedValue({ pages: [jpegFixture], truncated: false })
   })
 
   it('returns skipped when there is no linked binding', async () => {
@@ -161,8 +218,51 @@ describe('broadcastMailToEvent', () => {
     expect(result.reason).toBe('no_active_binding')
   })
 
-  it('marks broadcast row sent for an attachment-less mail', async () => {
+  it('renders the mail body as image messages for an attachment-less mail', async () => {
     const fx = await buildLinkedFixture()
+    const result = await broadcastMailToEvent(db, {
+      eventId: fx.eventId,
+      mailMessageId: fx.mailMessageId,
+      isCorrection: false,
+    })
+    expect(result.status).toBe('sent')
+    // 本文 1 ページが image として配信され、text / link は 0。
+    expect(result.sentImageCount).toBe(1)
+    expect(result.sentTextCount).toBe(0)
+    expect(result.fallbackLinkCount).toBe(0)
+    expect(renderBodyImageMock).toHaveBeenCalledTimes(1)
+
+    const row = await db.query.eventBroadcastMessages.findFirst({
+      where: eq(eventBroadcastMessages.mailMessageId, fx.mailMessageId),
+    })
+    expect(row?.status).toBe('sent')
+    expect(row?.isCorrection).toBe(false)
+    expect(row?.sentAt).not.toBeNull()
+  })
+
+  it('falls back to text messages when body image rendering fails', async () => {
+    const fx = await buildLinkedFixture()
+    renderBodyImageMock.mockRejectedValueOnce(new Error('libreoffice crashed'))
+
+    const result = await broadcastMailToEvent(db, {
+      eventId: fx.eventId,
+      mailMessageId: fx.mailMessageId,
+      isCorrection: false,
+    })
+    expect(result.status).toBe('sent')
+    // 画像化失敗 → buildBroadcastBody + splitForLine の text に降格。
+    expect(result.sentTextCount).toBe(1)
+    expect(result.sentImageCount).toBe(0)
+    expect(result.fallbackLinkCount).toBe(0)
+  })
+
+  it('falls back to text messages when the body exceeds the render page limit', async () => {
+    const fx = await buildLinkedFixture()
+    renderBodyImageMock.mockResolvedValueOnce({
+      pages: [jpegFixture, jpegFixture],
+      truncated: true,
+    })
+
     const result = await broadcastMailToEvent(db, {
       eventId: fx.eventId,
       mailMessageId: fx.mailMessageId,
@@ -171,14 +271,26 @@ describe('broadcastMailToEvent', () => {
     expect(result.status).toBe('sent')
     expect(result.sentTextCount).toBe(1)
     expect(result.sentImageCount).toBe(0)
-    expect(result.fallbackLinkCount).toBe(0)
+  })
 
-    const row = await db.query.eventBroadcastMessages.findFirst({
-      where: eq(eventBroadcastMessages.mailMessageId, fx.mailMessageId),
+  it('sends every attachment as a fallback link (no image rendering)', async () => {
+    const fx = await buildLinkedFixture()
+    await addAttachment(fx.mailMessageId, 'shiori.pdf', 'application/pdf')
+
+    const result = await broadcastMailToEvent(db, {
+      eventId: fx.eventId,
+      mailMessageId: fx.mailMessageId,
+      isCorrection: false,
     })
-    expect(row?.status).toBe('sent')
-    expect(row?.isCorrection).toBe(false)
-    expect(row?.sentAt).not.toBeNull()
+    expect(result.status).toBe('sent')
+    // 本文画像 1 + 添付リンク 1。添付は形式問わず image にはならない。
+    expect(result.sentImageCount).toBe(1)
+    expect(result.fallbackLinkCount).toBe(1)
+    expect(result.sentTextCount).toBe(0)
+
+    // 添付の署名 URL token が 1 件発行されている。
+    const tokens = await db.select().from(attachmentShareTokens)
+    expect(tokens).toHaveLength(1)
   })
 
   it('does not create duplicate rows on retry', async () => {
@@ -254,20 +366,24 @@ describe('broadcastMailToEvent', () => {
     expect(rows).toHaveLength(1)
   })
 
-  it('prefixes correction-mails with 【訂正】 + subject', async () => {
+  it('passes subject + correction flag through to the body image renderer', async () => {
     const fx = await buildLinkedFixture()
-    // Sanity: capture the mail subject so we can compare it back.
-    const mail = await db.query.mailMessages.findFirst({
-      where: eq(mailMessages.id, fx.mailMessageId),
-    })
-    expect(mail?.subject).toBe('〇〇杯 大会案内')
-
     const result = await broadcastMailToEvent(db, {
       eventId: fx.eventId,
       mailMessageId: fx.mailMessageId,
       isCorrection: true,
     })
     expect(result.status).toBe('sent')
+    // 訂正フラグ・件名・本文が renderBodyImageToJpegs に渡る (画像ヘッダーで
+    // 【訂正】【件名】を描画する素材になる)。
+    expect(renderBodyImageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: '〇〇杯 大会案内',
+        rawBody: '大会案内本文 本文 本文。',
+        isCorrection: true,
+      }),
+    )
+
     const row = await db.query.eventBroadcastMessages.findFirst({
       where: eq(eventBroadcastMessages.mailMessageId, fx.mailMessageId),
     })

--- a/apps/web/src/lib/line-broadcast.ts
+++ b/apps/web/src/lib/line-broadcast.ts
@@ -8,12 +8,8 @@ import {
   mailMessages,
 } from '@kagetra/shared/schema'
 import type { db as appDb } from '@/lib/db'
-import {
-  RENDER_PAGE_LIMIT,
-  getOrCreateShareToken,
-  renderDocxToJpegs,
-  renderPdfToJpegs,
-} from '@/lib/attachment-image-render'
+import { getOrCreateShareToken } from '@/lib/attachment-image-render'
+import { renderBodyImageToJpegs } from '@/lib/mail-body-image-render'
 import { setCachedImage } from '@/lib/image-cache'
 import { splitForLine } from '@/lib/text-splitter'
 import { buildBroadcastBody } from '@/lib/mail-body-cleaner'
@@ -257,24 +253,31 @@ const LINE_IMAGE_JPEG_QUALITY = 85
 const LINE_PREVIEW_MAX_DIMENSION = 240
 const LINE_PREVIEW_JPEG_QUALITY = 70
 
-async function buildRenderedImageMessages(
+/**
+ * 本文画像 (renderBodyImageToJpegs の JPEG ページ群) を LINE image message に
+ * 変換する。各ページを sharp で 4096px 上限に正規化し、preview を別 token で
+ * 配信する。本文画像は専用 share token を持たない (添付と違いダウンロード経路が
+ * 無い) ため、10 MB 超のページが出たら `oversize: true` を返し、呼び出し側で
+ * text fallback に倒す (要件 §3.5)。
+ *
+ * NOTE: 添付は全て URL リンク化された (要件 §3.4) ので、image message を作るのは
+ * 本文だけになった。旧 buildRenderedImageMessages から attachment / db / 署名 URL
+ * fallback への依存を落とした軽量版。
+ */
+async function buildBodyImageMessages(
   pages: Buffer[],
   baseUrl: string,
-  attachment: AttachmentRow,
-  db: typeof appDb,
   logger: NonNullable<BroadcastMailOptions['logger']>,
-): Promise<{ messages: LineMessage[]; oversizeFallback: LineMessage | null }> {
+): Promise<{ messages: LineMessage[]; oversize: boolean }> {
   const messages: LineMessage[] = []
   // Defer the sharp import to actual use — sharp is heavy (~30 MB native
-  // module) and not all broadcast paths take attachments.
+  // module) and the text-fallback path never touches it.
   const { default: sharp } = await import('sharp')
 
   for (const buffer of pages) {
-    // r-final-19 should_fix: LINE image は 4096x4096 上限もある。
-    // 150 DPI の大判ページ (A2 / 横長) は寸法超過で 400 を返す。
-    // original を sharp で 4096px 上限にリサイズしてから byteLength と
-    // 寸法を判定する。リサイズ失敗時は元 buffer に fallback (logger 警告
-    // 付き)。
+    // LINE image は 4096x4096 上限もある。A4 150 DPI の本文は収まるが、
+    // 念のため original を 4096px 上限に正規化してから byteLength を判定する。
+    // リサイズ失敗時は元 buffer に fallback (logger 警告付き)。
     let normalizedOriginal: Buffer = buffer
     try {
       normalizedOriginal = await sharp(buffer)
@@ -287,28 +290,19 @@ async function buildRenderedImageMessages(
         .jpeg({ quality: LINE_IMAGE_JPEG_QUALITY })
         .toBuffer()
     } catch (err) {
-      logger.warn('original resize failed; using raw buffer', {
-        attachmentId: attachment.id,
+      logger.warn('body image original resize failed; using raw buffer', {
         message: err instanceof Error ? err.message : String(err),
       })
       normalizedOriginal = buffer
     }
 
-    // 正規化後でも 10 MB を超えるページは画像化を諦め、ページ単位で
-    // fallback link 1 本に縮約する。
+    // 正規化後でも 10 MB を超えるページが出たら、本文画像化を諦めて text
+    // fallback に倒す (本文には署名 URL ダウンロード経路が無いため)。
     if (normalizedOriginal.byteLength > LINE_IMAGE_MAX_BYTES) {
-      const fallback = await buildFallbackTextMessage(
-        db,
-        attachment,
-        baseUrl,
-        `📎 ${attachment.filename} (サイズ超過のため Web で閲覧)`,
-      )
-      logger.warn('attachment page exceeds LINE 10 MB limit; falling back to link', {
-        attachmentId: attachment.id,
-        filename: attachment.filename,
+      logger.warn('body image page exceeds LINE 10 MB limit; falling back to text', {
         byteLength: normalizedOriginal.byteLength,
       })
-      return { messages: [], oversizeFallback: fallback }
+      return { messages: [], oversize: true }
     }
 
     let previewBuffer: Buffer
@@ -326,8 +320,7 @@ async function buildRenderedImageMessages(
       // Preview 生成失敗時は original をそのまま preview にも使う
       // (LINE 側で 1 MB を超えると失敗する可能性は残るが、画像表示
       // 機能自体は維持できる)。
-      logger.warn('preview resize failed; reusing original buffer', {
-        attachmentId: attachment.id,
+      logger.warn('body image preview resize failed; reusing original buffer', {
         message: err instanceof Error ? err.message : String(err),
       })
       previewBuffer = normalizedOriginal
@@ -343,7 +336,7 @@ async function buildRenderedImageMessages(
       previewImageUrl: attachmentImageUrl(previewToken, baseUrl),
     })
   }
-  return { messages, oversizeFallback: null }
+  return { messages, oversize: false }
 }
 
 interface AttachmentRow {
@@ -354,85 +347,19 @@ interface AttachmentRow {
 }
 
 /**
- * Convert one attachment into the LINE messages we'll send. Returns either
- * a list of `image` messages (PDF / DOCX successfully rendered) or a
- * `text` message linking to the signed-URL download (Excel, render failure,
- * 30+ page cap).
+ * 1 添付を LINE メッセージに変換する。
  *
- * The "fallback" boolean accompanying the message list lets the caller
- * track `fallback_link_count` on `event_broadcast_messages`.
+ * 要件 §3.4: PDF / Word / Excel / その他を問わず **全形式を署名 URL リンクに
+ * 統一** する。以前あった PDF/Word の画像化分岐は撤廃し、添付は常に
+ * 「📎 filename + ダウンロード URL」の text 1 本になった。本文だけが画像化
+ * 対象 (buildBodyImageMessages) で、添付は明示的に開く運用に整えた。
  */
 async function renderAttachment(
   db: typeof appDb,
   attachment: AttachmentRow,
   baseUrl: string,
-  logger: NonNullable<BroadcastMailOptions['logger']>,
-): Promise<{ messages: LineMessage[]; usedFallback: boolean }> {
-  const mime = attachment.contentType.toLowerCase()
-  // Excel-by-design: image rendering of a spreadsheet is unusable on a
-  // phone (horizontal scrolling, tiny cells); always link.
-  if (
-    mime.includes('spreadsheet') ||
-    mime === 'application/vnd.ms-excel' ||
-    attachment.filename.toLowerCase().endsWith('.xlsx') ||
-    attachment.filename.toLowerCase().endsWith('.xls')
-  ) {
-    return {
-      messages: [await buildFallbackTextMessage(db, attachment, baseUrl)],
-      usedFallback: true,
-    }
-  }
-
-  let rendered: { pages: Buffer[]; truncated: boolean } | null = null
-  try {
-    if (mime === 'application/pdf' || attachment.filename.toLowerCase().endsWith('.pdf')) {
-      rendered = await renderPdfToJpegs(attachment.data)
-    } else if (
-      mime.includes('officedocument.wordprocessingml.document') ||
-      attachment.filename.toLowerCase().endsWith('.docx') ||
-      mime === 'application/msword'
-    ) {
-      rendered = await renderDocxToJpegs(attachment.data)
-    } else {
-      // Unknown type — surface as a link rather than guess.
-      return {
-        messages: [await buildFallbackTextMessage(db, attachment, baseUrl)],
-        usedFallback: true,
-      }
-    }
-  } catch (err) {
-    logger.warn('attachment render failed; falling back to link', {
-      attachmentId: attachment.id,
-      filename: attachment.filename,
-      message: err instanceof Error ? err.message : String(err),
-    })
-    return { messages: [await buildFallbackTextMessage(db, attachment, baseUrl)], usedFallback: true }
-  }
-
-  if (rendered.pages.length === 0) {
-    return { messages: [await buildFallbackTextMessage(db, attachment, baseUrl)], usedFallback: true }
-  }
-
-  const { messages: imageMessages, oversizeFallback } =
-    await buildRenderedImageMessages(rendered.pages, baseUrl, attachment, db, logger)
-
-  // r-final-15: LINE の 10 MB 上限を超えるページがあれば、その attachment
-  // 全体を画像化諦めて fallback link 1 本に縮約する。
-  if (oversizeFallback) {
-    return { messages: [oversizeFallback], usedFallback: true }
-  }
-
-  if (rendered.truncated) {
-    // Append a "see full file on web" link after the first N rendered pages.
-    const link = await buildFallbackTextMessage(
-      db,
-      attachment,
-      baseUrl,
-      `📎 ${attachment.filename} は ${RENDER_PAGE_LIMIT} ページ以降を省略しました。Web で全体を見る`,
-    )
-    return { messages: [...imageMessages, link], usedFallback: true }
-  }
-  return { messages: imageMessages, usedFallback: false }
+): Promise<LineMessage> {
+  return await buildFallbackTextMessage(db, attachment, baseUrl)
 }
 
 async function buildFallbackTextMessage(
@@ -595,9 +522,9 @@ export async function broadcastMailToEvent(
   // sentImageCount / fallbackLinkCount) は role 別の排他カウンタで、
   // 同じ LineMessage が 2 カラムに入ることはない (role アサインを参照)。
   // 従って合計はそのまま「配信済みメッセージ件数」と等しい。
-  //   - sentTextCount: 本文 splitForLine の chunk (role='body_text')
-  //   - sentImageCount: 添付画像 (role='attachment_image')
-  //   - fallbackLinkCount: 添付の代替 text リンク (role='attachment_link')
+  //   - sentTextCount: 本文 text fallback の chunk (role='body_text')
+  //   - sentImageCount: 本文画像のページ (role='body_image')
+  //   - fallbackLinkCount: 添付の URL リンク (role='attachment_link')
   const existingAudit = await db
     .select({
       sentTextCount: eventBroadcastMessages.sentTextCount,
@@ -741,52 +668,84 @@ export async function broadcastMailToEvent(
   const broadcastMessageId = inserted[0].id
 
   try {
-    // Build text messages: split the mail body at 5000-char boundaries.
-    // buildBroadcastBody が
-    //   - Google Groups footer の除去
-    //   - 件名 prefix `【メール件名】<subject>` の付与
-    //   - 訂正版なら `【訂正】「<subject>」` の前置
-    // をまとめて行う。prefix を結合してから splitForLine に渡すことで、
-    // 5000 字制限を超えるリスクを完全に消す (rr2 review blocker)。
-    const bodyText = buildBroadcastBody({
-      rawBody: mail.bodyText,
-      subject: mail.subject,
-      isCorrection: args.isCorrection,
-    })
-    const chunks = splitForLine(bodyText)
-    const textMessages: LineMessage[] = chunks.map((chunk) => ({
-      type: 'text',
-      text: chunk,
-    }))
-
-    // rr1 review should_fix: 添付の出力は image / fallback link が交互に
-    // 並ぶことがある (Excel リンクの後に PDF 画像、など)。実際の送信順を
-    // そのまま追える metadata を message と並走させ、deliveredCount に
-    // 対応する metadata だけを数えることで partial 行のカウントを正しく
-    // 残す。
-    type MessageRole = 'body_text' | 'attachment_image' | 'attachment_link'
+    // mail-body-as-image: 本文は text ではなく画像で配信する (要件 §3.1)。
+    // renderBodyImageToJpegs が件名・本文・訂正フラグを A4 縦 JPEG に描画する。
+    // 以下のいずれかで text fallback (splitForLine) に倒す:
+    //   - 画像化が throw (libreoffice クラッシュ / フォント欠落等, §3.5)
+    //   - 30 ページ超 (truncated=true, §3.5)
+    //   - ページ 0 枚 (異常な空 PDF)
+    //   - 10 MB 超のページ (oversize, 本文には DL 経路が無いため)
+    //   - baseUrl 未設定 (画像 URL を組めない → getBaseUrl が throw)
+    // text fallback でも buildBroadcastBody が footer 除去 + 件名/訂正 prefix
+    // を行うので、可読性は劣るが連絡内容は届く。
+    //
+    // roles は実際の送信順 metadata。partial 再送時に deliveredCount 分だけ
+    // role 別カウントを正しく残すために message と並走させる (rr1 review)。
+    type MessageRole = 'body_image' | 'body_text' | 'attachment_link'
     const messages: LineMessage[] = []
     const roles: MessageRole[] = []
 
-    for (const m of textMessages) {
-      messages.push(m)
-      roles.push('body_text')
+    let bodyImageMessages: LineMessage[] = []
+    try {
+      const rendered = await renderBodyImageToJpegs({
+        subject: mail.subject,
+        rawBody: mail.bodyText,
+        isCorrection: args.isCorrection,
+      })
+      if (rendered.truncated) {
+        logger.warn('mail body exceeds render page limit; falling back to text', {
+          eventId: args.eventId,
+          mailMessageId: args.mailMessageId,
+        })
+      } else if (rendered.pages.length === 0) {
+        logger.warn('mail body rendered to 0 pages; falling back to text', {
+          eventId: args.eventId,
+          mailMessageId: args.mailMessageId,
+        })
+      } else {
+        // 本文画像は image URL が必要 → ここで baseUrl を検証する (未設定なら
+        // throw → 下の catch で text fallback に倒れる)。
+        const built = await buildBodyImageMessages(
+          rendered.pages,
+          getBaseUrl(),
+          logger,
+        )
+        if (!built.oversize) bodyImageMessages = built.messages
+      }
+    } catch (err) {
+      logger.warn('mail body image render failed; falling back to text', {
+        eventId: args.eventId,
+        mailMessageId: args.mailMessageId,
+        message: err instanceof Error ? err.message : String(err),
+      })
     }
 
-    for (const attachment of attachments) {
-      // r-final-16 blocker: 添付があるときだけ baseUrl が必要。lazy
-      // resolver で初回呼出時に検証する (PUBLIC_BASE_URL が未設定なら
-      // ここで例外 → 既存の catch (err) が failed audit に倒す)。
-      const result = await renderAttachment(
-        db,
-        attachment,
-        getBaseUrl(),
-        logger,
-      )
-      for (const m of result.messages) {
+    if (bodyImageMessages.length > 0) {
+      for (const m of bodyImageMessages) {
         messages.push(m)
-        roles.push(m.type === 'image' ? 'attachment_image' : 'attachment_link')
+        roles.push('body_image')
       }
+    } else {
+      const bodyText = buildBroadcastBody({
+        rawBody: mail.bodyText,
+        subject: mail.subject,
+        isCorrection: args.isCorrection,
+      })
+      for (const chunk of splitForLine(bodyText)) {
+        messages.push({ type: 'text', text: chunk })
+        roles.push('body_text')
+      }
+    }
+
+    // 添付は全形式 (PDF / Word / Excel / その他) を署名 URL リンクに統一する
+    // (要件 §3.4)。
+    for (const attachment of attachments) {
+      // r-final-16 blocker: baseUrl は添付/画像で必要。lazy resolver が初回
+      // 呼出で検証する (PUBLIC_BASE_URL 未設定ならここで例外 → 下の catch が
+      // failed audit に倒す)。
+      const message = await renderAttachment(db, attachment, getBaseUrl())
+      messages.push(message)
+      roles.push('attachment_link')
     }
 
     if (messages.length === 0) {
@@ -809,7 +768,7 @@ export async function broadcastMailToEvent(
     if (previouslyDelivered > 0 && existingAudit[0]) {
       const currentTextCount = roles.filter((r) => r === 'body_text').length
       const currentImageCount = roles.filter(
-        (r) => r === 'attachment_image',
+        (r) => r === 'body_image',
       ).length
       const currentLinkCount = roles.filter(
         (r) => r === 'attachment_link',
@@ -913,7 +872,7 @@ export async function broadcastMailToEvent(
         case 'body_text':
           deliveredText++
           break
-        case 'attachment_image':
+        case 'body_image':
           deliveredImage++
           break
         case 'attachment_link':

--- a/apps/web/src/lib/mail-body-image-render.test.ts
+++ b/apps/web/src/lib/mail-body-image-render.test.ts
@@ -1,0 +1,145 @@
+import { execFileSync } from 'node:child_process'
+import { describe, it, expect } from 'vitest'
+import {
+  buildBodyImageHtml,
+  renderBodyImageToJpegs,
+} from './mail-body-image-render'
+
+describe('buildBodyImageHtml', () => {
+  it('renders the subject header + body for a normal mail', () => {
+    const html = buildBodyImageHtml({
+      subject: '第48回大会のお知らせ',
+      rawBody: '本文1行目\n本文2行目',
+      isCorrection: false,
+    })
+    expect(html).toMatchInlineSnapshot(`
+      "<!DOCTYPE html>
+      <html lang="ja">
+      <head>
+        <meta charset="UTF-8">
+        <style>
+          @page { size: A4 portrait; margin: 25mm 20mm; }
+          body { font-family: 'Noto Sans CJK JP', sans-serif; font-size: 11pt; line-height: 1.7; color: #000; }
+          h1 { font-size: 14pt; font-weight: bold; margin: 0 0 1em 0; border-bottom: 1px solid #888; padding-bottom: 0.5em; }
+          pre { font-family: 'Noto Sans CJK JP', sans-serif; white-space: pre-wrap; word-break: break-word; margin: 0; }
+        </style>
+      </head>
+      <body>
+        <h1>【第48回大会のお知らせ】</h1>
+        <pre>本文1行目
+      本文2行目</pre>
+      </body>
+      </html>
+      "
+    `)
+  })
+
+  it('prepends 【訂正】 before 【件名】 for corrections', () => {
+    const html = buildBodyImageHtml({
+      subject: '第48回大会のお知らせ(訂正版)',
+      rawBody: '訂正後本文',
+      isCorrection: true,
+    })
+    expect(html).toContain(
+      '<h1>【訂正】【第48回大会のお知らせ(訂正版)】</h1>',
+    )
+    expect(html).toContain('<pre>訂正後本文</pre>')
+  })
+
+  it('omits the header entirely when subject is empty and not a correction', () => {
+    const html = buildBodyImageHtml({
+      subject: '',
+      rawBody: '本文だけ',
+      isCorrection: false,
+    })
+    expect(html).not.toContain('<h1>')
+    expect(html).toContain('<pre>本文だけ</pre>')
+  })
+
+  it('shows 【訂正】 alone when a correction has no subject', () => {
+    const html = buildBodyImageHtml({
+      subject: null,
+      rawBody: '本文',
+      isCorrection: true,
+    })
+    expect(html).toContain('<h1>【訂正】</h1>')
+  })
+
+  it('strips the Google Groups footer before rendering the body', () => {
+    const html = buildBodyImageHtml({
+      subject: 'テスト',
+      rawBody:
+        '本文\n\n-- \nこのメールは Google グループ「x」に登録しているユーザーに送られています。\nfooter',
+      isCorrection: false,
+    })
+    expect(html).toContain('<pre>本文</pre>')
+    expect(html).not.toContain('Google グループ')
+  })
+
+  it('falls back to the (本文なし) placeholder when the body is empty', () => {
+    const html = buildBodyImageHtml({
+      subject: 'タイトル',
+      rawBody: null,
+      isCorrection: false,
+    })
+    expect(html).toContain('<pre>(本文なし)</pre>')
+  })
+
+  it('escapes HTML-special characters in subject and body', () => {
+    const html = buildBodyImageHtml({
+      subject: '<script> & "危険"',
+      rawBody: 'a < b && c > d',
+      isCorrection: false,
+    })
+    expect(html).toContain(
+      '【&lt;script&gt; &amp; &quot;危険&quot;】',
+    )
+    expect(html).toContain('<pre>a &lt; b &amp;&amp; c &gt; d</pre>')
+    expect(html).not.toContain('<script>')
+  })
+
+  it('trims surrounding whitespace from the subject', () => {
+    const html = buildBodyImageHtml({
+      subject: '  前後空白  ',
+      rawBody: '本文',
+      isCorrection: false,
+    })
+    expect(html).toContain('【前後空白】')
+  })
+})
+
+/**
+ * 要件 §4.4: libreoffice を spawn する子プロセスは mock しない (本番と同じ
+ * 環境前提)。CI / 本番には libreoffice があるので走り、Windows ローカル等で
+ * 無い環境では skip する。
+ */
+function libreofficeAvailable(): boolean {
+  try {
+    execFileSync('libreoffice', ['--version'], { stdio: 'ignore' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+const describeIfLibreoffice = libreofficeAvailable() ? describe : describe.skip
+
+describeIfLibreoffice(
+  'renderBodyImageToJpegs (integration: requires libreoffice)',
+  () => {
+    it('renders a short body to at least one JPEG page', async () => {
+      const result = await renderBodyImageToJpegs({
+        subject: 'スモークテスト',
+        rawBody: 'これは本文画像化のスモークテストです。',
+        isCorrection: false,
+      })
+      expect(result.pages.length).toBeGreaterThanOrEqual(1)
+      expect(result.truncated).toBe(false)
+      // JPEG magic bytes: FF D8 FF
+      const first = result.pages[0]!
+      expect(first[0]).toBe(0xff)
+      expect(first[1]).toBe(0xd8)
+      expect(first[2]).toBe(0xff)
+    }, 120_000)
+  },
+)

--- a/apps/web/src/lib/mail-body-image-render.ts
+++ b/apps/web/src/lib/mail-body-image-render.ts
@@ -1,10 +1,10 @@
-import { spawn } from 'node:child_process'
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { stripMailFooter } from '@/lib/mail-body-cleaner'
 import {
   renderPdfToJpegs,
+  runLibreofficeConvertToPdf,
   type ImageRenderResult,
 } from '@/lib/attachment-image-render'
 
@@ -29,12 +29,6 @@ const CORRECTION_MARKER = '【訂正】'
 
 /** 本文が空 (null / 空文字 / footer のみ) のときに描画するプレースホルダ (要件 §3.7)。 */
 const EMPTY_BODY_PLACEHOLDER = '(本文なし)'
-
-/**
- * libreoffice cold-start は本番 ARM 機で ~6s 観測。120s で十分な headroom を
- * 取る。attachment-image-render.ts の renderDocxToJpegs と同じ値。
- */
-const LIBREOFFICE_TIMEOUT_MS = 120_000
 
 export interface BuildBodyImageInput {
   /** メール件名 (`mail_messages.subject`)。空ならヘッダーを出さない。 */
@@ -100,58 +94,6 @@ ${headerHtml}  <pre>${escapeHtml(body)}</pre>
 </body>
 </html>
 `
-}
-
-/**
- * 生成 HTML を libreoffice で PDF 化し `outDir` に同名 (basename) で書き出す。
- * `--headless --convert-to pdf` は 1 回ごとに soffice を起動して終了する
- * one-shot 変換なので、常駐 daemon の管理は不要。
- *
- * NOTE(task3 / #76): attachment-image-render.ts の renderDocxToJpegs にほぼ
- * 同じ libreoffice 呼び出しがある。cleanup タスクで共通 helper
- * (`runLibreofficeConvertToPdf`) に集約する予定。それまでは本文画像化パスを
- * cross-file 依存なしで自己完結させるため、意図的にローカルに置く。
- */
-async function runLibreofficeConvertToPdf(
-  inputPath: string,
-  outDir: string,
-): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const proc = spawn(
-      'libreoffice',
-      ['--headless', '--convert-to', 'pdf', '--outdir', outDir, inputPath],
-      { stdio: ['ignore', 'pipe', 'pipe'] },
-    )
-    const stderrChunks: Buffer[] = []
-    proc.stderr.on('data', (chunk: Buffer) => stderrChunks.push(chunk))
-    // stdout を drain しないと、libreoffice が多めに吐いたとき OS パイプ
-    // バッファが埋まって子プロセスが write でブロック → timeout まで
-    // 進まなくなる (attachment-image-render.ts と同じ対策)。内容は使わない。
-    proc.stdout.resume()
-    const timeout = setTimeout(() => {
-      proc.kill('SIGKILL')
-      reject(
-        new Error(`libreoffice timed out after ${LIBREOFFICE_TIMEOUT_MS}ms`),
-      )
-    }, LIBREOFFICE_TIMEOUT_MS)
-    proc.on('error', (err) => {
-      clearTimeout(timeout)
-      reject(err)
-    })
-    proc.on('exit', (code) => {
-      clearTimeout(timeout)
-      if (code === 0) {
-        resolve()
-        return
-      }
-      const stderr = Buffer.concat(stderrChunks).toString('utf8').trim()
-      reject(
-        new Error(
-          `libreoffice exited with code ${code}${stderr ? `: ${stderr.slice(0, 500)}` : ''}`,
-        ),
-      )
-    })
-  })
 }
 
 /**

--- a/apps/web/src/lib/mail-body-image-render.ts
+++ b/apps/web/src/lib/mail-body-image-render.ts
@@ -1,0 +1,184 @@
+import { spawn } from 'node:child_process'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { stripMailFooter } from '@/lib/mail-body-cleaner'
+import {
+  renderPdfToJpegs,
+  type ImageRenderResult,
+} from '@/lib/attachment-image-render'
+
+/**
+ * メール本文を「画像」として LINE に配信するためのレンダラ。
+ *
+ * 件名・本文・訂正フラグを A4 縦の HTML テンプレートに流し込み、libreoffice
+ * 経由で PDF を生成、既存 {@link renderPdfToJpegs} で JPEG 配列に変換する。
+ * スマホ LINE 上でテキストが縦に伸びて読みづらい問題を、スクショ相当の
+ * 1 枚絵で置き換えるのが目的 (要件 §3.1)。
+ *
+ * 失敗時 (libreoffice クラッシュ / フォント欠落 / ディスク不足等) は throw し、
+ * 呼び出し側 (line-broadcast.ts) の text fallback パスに委ねる (要件 §3.5)。
+ */
+
+/**
+ * 訂正版マーカー。mail-body-cleaner.ts の CORRECTION_PREFIX と同一表記にして、
+ * text fallback 経路 (buildBroadcastBody) と画像ヘッダーで `【訂正】` の見た目を
+ * 揃える (要件 §3.2)。
+ */
+const CORRECTION_MARKER = '【訂正】'
+
+/** 本文が空 (null / 空文字 / footer のみ) のときに描画するプレースホルダ (要件 §3.7)。 */
+const EMPTY_BODY_PLACEHOLDER = '(本文なし)'
+
+/**
+ * libreoffice cold-start は本番 ARM 機で ~6s 観測。120s で十分な headroom を
+ * 取る。attachment-image-render.ts の renderDocxToJpegs と同じ値。
+ */
+const LIBREOFFICE_TIMEOUT_MS = 120_000
+
+export interface BuildBodyImageInput {
+  /** メール件名 (`mail_messages.subject`)。空ならヘッダーを出さない。 */
+  subject: string | null | undefined
+  /** 元のメール本文 (`mail_messages.body_text`)。footer 除去前の生テキスト。 */
+  rawBody: string | null | undefined
+  /** 訂正版かどうか (`tournament_drafts.is_correction`)。 */
+  isCorrection: boolean
+}
+
+/**
+ * HTML のテキストコンテンツに安全に埋め込めるようエスケープする。件名・本文は
+ * `<h1>` / `<pre>` のテキストノードに入る (属性には入らない) が、`"` / `'` も
+ * 含めた標準セットを潰しておき、メール由来文字列によるマークアップ崩れ・
+ * インジェクションを確実に防ぐ。
+ */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+/**
+ * 件名・本文・訂正フラグを A4 縦の HTML 文字列に組み立てる純関数。
+ *
+ * ヘッダー (`<h1>`) の分岐:
+ *   - 件名あり / 訂正なし → `【件名】`
+ *   - 件名あり / 訂正あり → `【訂正】【件名】`
+ *   - 件名なし / 訂正あり → `【訂正】` 単独
+ *   - 件名なし / 訂正なし → `<h1>` ごと省略
+ *
+ * 本文は text 経路と同じく Google Groups footer を除去 (要件 §3.3) し、空なら
+ * `(本文なし)` に倒す。件名・本文はともに HTML エスケープして埋め込む。
+ */
+export function buildBodyImageHtml(input: BuildBodyImageInput): string {
+  const subject = input.subject?.trim() ?? ''
+  const cleanedBody = stripMailFooter(input.rawBody ?? '')
+  const body =
+    cleanedBody.trim() === '' ? EMPTY_BODY_PLACEHOLDER : cleanedBody
+
+  const headerParts: string[] = []
+  if (input.isCorrection) headerParts.push(CORRECTION_MARKER)
+  if (subject) headerParts.push(`【${escapeHtml(subject)}】`)
+  const headerHtml =
+    headerParts.length > 0 ? `  <h1>${headerParts.join('')}</h1>\n` : ''
+
+  return `<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <style>
+    @page { size: A4 portrait; margin: 25mm 20mm; }
+    body { font-family: 'Noto Sans CJK JP', sans-serif; font-size: 11pt; line-height: 1.7; color: #000; }
+    h1 { font-size: 14pt; font-weight: bold; margin: 0 0 1em 0; border-bottom: 1px solid #888; padding-bottom: 0.5em; }
+    pre { font-family: 'Noto Sans CJK JP', sans-serif; white-space: pre-wrap; word-break: break-word; margin: 0; }
+  </style>
+</head>
+<body>
+${headerHtml}  <pre>${escapeHtml(body)}</pre>
+</body>
+</html>
+`
+}
+
+/**
+ * 生成 HTML を libreoffice で PDF 化し `outDir` に同名 (basename) で書き出す。
+ * `--headless --convert-to pdf` は 1 回ごとに soffice を起動して終了する
+ * one-shot 変換なので、常駐 daemon の管理は不要。
+ *
+ * NOTE(task3 / #76): attachment-image-render.ts の renderDocxToJpegs にほぼ
+ * 同じ libreoffice 呼び出しがある。cleanup タスクで共通 helper
+ * (`runLibreofficeConvertToPdf`) に集約する予定。それまでは本文画像化パスを
+ * cross-file 依存なしで自己完結させるため、意図的にローカルに置く。
+ */
+async function runLibreofficeConvertToPdf(
+  inputPath: string,
+  outDir: string,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const proc = spawn(
+      'libreoffice',
+      ['--headless', '--convert-to', 'pdf', '--outdir', outDir, inputPath],
+      { stdio: ['ignore', 'pipe', 'pipe'] },
+    )
+    const stderrChunks: Buffer[] = []
+    proc.stderr.on('data', (chunk: Buffer) => stderrChunks.push(chunk))
+    // stdout を drain しないと、libreoffice が多めに吐いたとき OS パイプ
+    // バッファが埋まって子プロセスが write でブロック → timeout まで
+    // 進まなくなる (attachment-image-render.ts と同じ対策)。内容は使わない。
+    proc.stdout.resume()
+    const timeout = setTimeout(() => {
+      proc.kill('SIGKILL')
+      reject(
+        new Error(`libreoffice timed out after ${LIBREOFFICE_TIMEOUT_MS}ms`),
+      )
+    }, LIBREOFFICE_TIMEOUT_MS)
+    proc.on('error', (err) => {
+      clearTimeout(timeout)
+      reject(err)
+    })
+    proc.on('exit', (code) => {
+      clearTimeout(timeout)
+      if (code === 0) {
+        resolve()
+        return
+      }
+      const stderr = Buffer.concat(stderrChunks).toString('utf8').trim()
+      reject(
+        new Error(
+          `libreoffice exited with code ${code}${stderr ? `: ${stderr.slice(0, 500)}` : ''}`,
+        ),
+      )
+    })
+  })
+}
+
+/**
+ * 本文 + 件名 + 訂正フラグを JPEG ページ配列に描画する。
+ *
+ * 1. {@link buildBodyImageHtml} で HTML を組み立て tmpdir に書き出し
+ * 2. libreoffice で PDF 化
+ * 3. 既存 {@link renderPdfToJpegs} で JPEG 化 (30 ページ超は `truncated: true`)
+ * 4. tmpdir を best-effort でクリーンアップ
+ *
+ * 失敗時は throw する。呼び出し側が text fallback に倒す。
+ */
+export async function renderBodyImageToJpegs(
+  input: BuildBodyImageInput,
+): Promise<ImageRenderResult> {
+  const html = buildBodyImageHtml(input)
+  const workDir = await mkdtemp(join(tmpdir(), 'kagetra-mailbody-'))
+  try {
+    const inputPath = join(workDir, 'body.html')
+    await writeFile(inputPath, html, 'utf8')
+    await runLibreofficeConvertToPdf(inputPath, workDir)
+    const pdfBuffer = await readFile(join(workDir, 'body.pdf'))
+    return await renderPdfToJpegs(pdfBuffer)
+  } finally {
+    await rm(workDir, { recursive: true, force: true }).catch(() => {
+      // Best-effort cleanup. A leftover tmpdir is preferable to crashing the
+      // render path; the system tmp reaper will sweep it eventually.
+    })
+  }
+}

--- a/docs/features/mail-body-as-image/implementation-plan.md
+++ b/docs/features/mail-body-as-image/implementation-plan.md
@@ -1,0 +1,111 @@
+---
+status: completed
+---
+
+# mail-body-as-image 実装手順書
+
+## 前提
+- 要件定義書: `docs/features/mail-body-as-image/requirements.md`
+- ブランチ: `feat/mail-body-as-image`
+- 1 PR で全タスク完了
+- worktree: `C:/tmp/impl-mail-body-as-image`
+
+## 実装タスク
+
+### タスク1: HTML テンプレート + 本文画像化 helper の新規実装
+
+- [x] 完了
+- **概要:** 件名・本文・訂正フラグを HTML に流し込み、libreoffice → pdftoppm パイプラインで JPEG 配列を返す helper を新規作成する。`renderPdfToJpegs` を内部再利用する。
+- **変更対象ファイル:**
+  - `apps/web/src/lib/mail-body-image-render.ts` (新規) — HTML テンプレート、`buildBodyImageHtml()`、`renderBodyImageToJpegs()`
+  - `apps/web/src/lib/mail-body-image-render.test.ts` (新規) — `buildBodyImageHtml` のスナップショット (件名あり/なし/訂正版/footer 除去)
+- **テンプレート要件:**
+  - A4 縦 / margin 25mm × 20mm / Noto Sans CJK JP / 11pt / line-height 1.7
+  - ヘッダー (件名): 14pt bold, border-bottom 1px solid #888, 訂正版は `【訂正】【件名】`
+  - 本文: `<pre>` で改行・空白保持、`white-space: pre-wrap; word-break: break-word`
+  - 件名が空の場合はヘッダーごと省略
+  - 訂正版で件名なしの場合は `<h1>【訂正】</h1>` のみ
+- **依存タスク:** なし
+- **対応Issue:** #74
+
+### タスク2: line-broadcast.ts の本文画像化 + 添付リンク統一
+
+- [ ] 完了
+- **概要:** `broadcastMailToEvent` 内の本文構築を text → image に切り替え、`renderAttachment` の PDF/Word 画像化分岐を削除して全添付 URL リンク統一にする。画像化失敗時の text fallback パスを追加。
+- **変更対象ファイル:**
+  - `apps/web/src/lib/line-broadcast.ts`:
+    - import 整理: `renderBodyImageToJpegs` を追加。`renderDocxToJpegs` の import 削除
+    - `broadcastMailToEvent`:
+      - 本文 text 構築 (`splitForLine`) を撤去し、まず `renderBodyImageToJpegs` を try で呼ぶ
+      - 成功: 既存 `buildRenderedImageMessages` を本文画像用に再利用 (attachment 引数を持たないバリエーション、または共通化) して image message を作る
+      - 失敗 (catch): `buildBroadcastBody` + `splitForLine` で text message に降格、`logger.warn` で失敗理由を記録
+      - 30 ページ超: image render の `truncated=true` を受け取り、本文 text fallback に切り替え (専用 share token は導入しない)
+      - `roles` 配列に `body_image` を追加 (sent_image_count にカウント)
+    - `renderAttachment`:
+      - PDF / Word 分岐を削除
+      - 全添付を `buildFallbackTextMessage` で URL リンク 1 本に統一
+      - `usedFallback: true` を常に返す
+  - 共通 image messages 構築の関数化: `buildRenderedImageMessages` を本文 + 添付両方で使えるよう、 attachment 引数を optional にするか、本文用に「filename を持たない」軽量版を切り出す
+- **依存タスク:** タスク1
+- **対応Issue:** #75
+
+### タスク3: attachment-image-render.ts の整理
+
+- [ ] 完了
+- **概要:** 本文画像化から内部呼び出しする `renderPdfToJpegs` はそのまま残す。添付経路で唯一使われていた `renderDocxToJpegs` は外部から不要になるが、本文画像化が libreoffice → renderPdfToJpegs 経由なので **export は維持** (PDF 化 helper として再利用)。
+- **変更対象ファイル:**
+  - `apps/web/src/lib/attachment-image-render.ts`:
+    - `renderDocxToJpegs` の export 自体は残す (libreoffice 呼び出し helper として `mail-body-image-render` から呼ばれる可能性がある場合)。最終的に未使用なら削除
+    - 既存テスト (もしあれば) で削除対象を判断
+  - libreoffice 呼び出し部分を `mail-body-image-render.ts` から再利用しやすくするため、private helper `runLibreofficeConvertToPdf(inputPath, workDir)` を抽出して export する選択肢を検討
+- **依存タスク:** タスク1, タスク2
+- **対応Issue:** #76
+
+### タスク4: テスト更新
+
+- [ ] 完了
+- **概要:** `line-broadcast.test.ts` を本文 image / 添付 link の新挙動に合わせて更新。
+- **変更対象ファイル:**
+  - `apps/web/src/lib/line-broadcast.test.ts`:
+    - 既存「本文 text message」を期待しているケースを「本文 image message」に変更
+    - 添付 PDF / Word が image を返すケースを「fallback link」に変更
+    - 画像化失敗 → text fallback の新規ケースを 1 つ追加 (libreoffice mock を spawn-level で reject)
+    - role 別カウント (`sent_text_count` / `sent_image_count` / `fallback_link_count`) の期待値を更新
+  - `apps/web/src/lib/mail-body-cleaner.test.ts`: 変更なし (fallback パスで継続使用)
+- **依存タスク:** タスク1, タスク2
+- **対応Issue:** #77
+
+### タスク5: ローカル検証 + worklog 記入 + PR 作成準備
+
+- [ ] 完了
+- **概要:** worktree でユニットテスト・型チェック・lint を通し、worklog.md に進捗を追記、`/prepare-pr` で PR を作る準備をする。
+- **検証コマンド:**
+  - `pnpm --filter @kagetra/web vitest run src/lib/mail-body-image-render.test.ts`
+  - `pnpm --filter @kagetra/web vitest run src/lib/line-broadcast.test.ts`
+  - `pnpm --filter @kagetra/web typecheck`
+  - `pnpm --filter @kagetra/web lint`
+- **依存タスク:** タスク1〜4
+- **対応Issue:** #78
+
+## 実装順序
+
+1. **タスク1** (HTML テンプレート + helper): 依存なし。完全に独立で着手可能
+2. **タスク2** (line-broadcast 改修): タスク1 完了後。`renderBodyImageToJpegs` の signature が固まってから
+3. **タスク3** (attachment-image-render 整理): タスク2 で削除が必要か確定してから (実は変更不要のケースもある)
+4. **タスク4** (テスト更新): タスク2 と並行可能 (テスト ファースト寄りに進めても可)
+5. **タスク5** (検証 + PR): タスク1〜4 完了後
+
+## 完了条件
+
+- 全タスクのチェックボックスが完了
+- ユニットテスト全 green
+- 型チェック・lint pass
+- ローカル (Linux/Windows) で `LINE_NOTIFY_DRY_RUN=1` 配信が正常完了し、画像生成パスが logger に出ること (本番投入前の煙テスト)
+- PR 作成、`/auto-review-loop` で Codex 構造化レビュー passing
+- 本番デプロイ後、実機 (LINE グループ) で本文画像が表示されることを目視確認
+
+## スコープ外 (将来課題)
+
+- 本文専用 share token テーブル `mail_body_share_tokens` の新設 (30 ページ超メールが頻発するなら検討)
+- 画像 fonts/レイアウトの細かいカスタマイズ (主催者ロゴ挿入、配色テーマ等)
+- 既存配信のリトライ UI から本機能の image render を再試行する機能

--- a/docs/features/mail-body-as-image/implementation-plan.md
+++ b/docs/features/mail-body-as-image/implementation-plan.md
@@ -30,7 +30,7 @@ status: completed
 
 ### タスク2: line-broadcast.ts の本文画像化 + 添付リンク統一
 
-- [ ] 完了
+- [x] 完了
 - **概要:** `broadcastMailToEvent` 内の本文構築を text → image に切り替え、`renderAttachment` の PDF/Word 画像化分岐を削除して全添付 URL リンク統一にする。画像化失敗時の text fallback パスを追加。
 - **変更対象ファイル:**
   - `apps/web/src/lib/line-broadcast.ts`:
@@ -51,7 +51,7 @@ status: completed
 
 ### タスク3: attachment-image-render.ts の整理
 
-- [ ] 完了
+- [x] 完了
 - **概要:** 本文画像化から内部呼び出しする `renderPdfToJpegs` はそのまま残す。添付経路で唯一使われていた `renderDocxToJpegs` は外部から不要になるが、本文画像化が libreoffice → renderPdfToJpegs 経由なので **export は維持** (PDF 化 helper として再利用)。
 - **変更対象ファイル:**
   - `apps/web/src/lib/attachment-image-render.ts`:
@@ -63,7 +63,7 @@ status: completed
 
 ### タスク4: テスト更新
 
-- [ ] 完了
+- [x] 完了
 - **概要:** `line-broadcast.test.ts` を本文 image / 添付 link の新挙動に合わせて更新。
 - **変更対象ファイル:**
   - `apps/web/src/lib/line-broadcast.test.ts`:
@@ -77,7 +77,7 @@ status: completed
 
 ### タスク5: ローカル検証 + worklog 記入 + PR 作成準備
 
-- [ ] 完了
+- [x] 完了
 - **概要:** worktree でユニットテスト・型チェック・lint を通し、worklog.md に進捗を追記、`/prepare-pr` で PR を作る準備をする。
 - **検証コマンド:**
   - `pnpm --filter @kagetra/web vitest run src/lib/mail-body-image-render.test.ts`

--- a/docs/features/mail-body-as-image/requirements.md
+++ b/docs/features/mail-body-as-image/requirements.md
@@ -1,0 +1,298 @@
+---
+status: completed
+---
+
+# mail-body-as-image 要件定義書
+
+## 1. 概要
+
+### 目的
+LINE 配信される大会連絡メールを、本文テキストではなく **画像** として送信し、
+スマホ LINE 上での可読性を向上させる。あわせて添付ファイルの取り扱いを統一する。
+
+### 背景・動機
+- 現状: メール本文を `splitForLine` で 5000 文字単位に分割した text message として送信
+- 問題: LINE のテキストメッセージは縦方向に長く伸び、スマホで非常に読みづらい
+- 既存ワークアラウンド: ユーザー(管理者)が PDF / Word の添付画像で代用、もしくは手動でスクショを送る運用
+- 解決策: 本文を A4 縦 × 150 DPI の JPEG として描画して image message で送ることで、
+  スクショと同等の可読性を Web 側で機械的に再現する
+
+あわせて、現状「添付の Excel だけ URL リンク・PDF/Word は画像化」と分岐していた取り扱いを、
+**全添付 URL リンク統一** にし、本文のみ画像表示・添付は明示的にリンクから開く運用に整える。
+
+---
+
+## 2. ユーザーストーリー
+
+### 対象ユーザー
+- **管理者**: 承認したメールを LINE グループに自動配信し、参加者からの参照効率を上げたい
+- **参加者 (LINE グループ閲覧者)**: 連絡内容を縦長スクロールせず一目で把握したい
+
+### 利用シナリオ
+1. 管理者がメール下書きを承認 (`approveDraft`)
+2. システムが該当メールを本文画像 + 添付リンクで LINE グループに自動配信
+3. 参加者は LINE のトーク画面で、本文を 1〜数枚の画像として閲覧
+4. 添付が必要なときは、添付ごとに送られる URL リンクを開いて Web ブラウザで取得
+
+---
+
+## 3. 機能要件
+
+### 3.1 メール本文の画像化
+
+- **対象**: `broadcastMailToEvent` で送信される全メール (新規・訂正版)
+- **画像レイアウト**:
+  - 用紙: A4 縦 / 150 DPI / 1240 × 1754 px / 1 ページあたり
+  - 背景: 白 / テキスト: 黒
+  - フォント: Noto Sans CJK JP (本番に既に導入済み)
+  - パディング: 全周囲 80 px 程度の余白
+  - ヘッダー領域に件名を表示 (件名前置きラベル `件名:` などは付けない)
+  - 訂正版マーカーは現状踏襲: ヘッダーに `【訂正】【件名】` を並べる
+- **ページ分割**: 本文が長く 1 ページに収まらない場合、libreoffice の自動改ページに従って複数 JPEG を生成
+- **上限**: 30 ページ超は `fallback link` 1 本 (本文を Web で見るリンク) に縮約 (既存 `RENDER_PAGE_LIMIT` と同じ運用)
+
+### 3.2 件名の取り扱い
+
+- 件名は画像ヘッダーに **必ず** 含める
+- 別途 text message としては送信しない (text message 経路は完全廃止)
+- 訂正版の場合は `【訂正】【件名】` の二重括弧表記をヘッダーに反映
+
+### 3.3 Google Groups フッター除去
+
+- 既存 `stripMailFooter` の挙動を画像化前にも継続適用
+- 画像化対象本文 = `stripMailFooter(mail.bodyText)` の結果
+
+### 3.4 添付ファイル
+
+- **全形式 (PDF / Word / Excel / その他) を URL リンク方式に統一**
+- 画像化処理を廃止 (`renderPdfToJpegs` / `renderDocxToJpegs` は呼び出されなくなる)
+- 添付メッセージは現状の Excel と同じフォーマット:
+  ```
+  📎 <filename>
+  https://<base>/api/line-broadcast/attachments/<token>
+  ```
+- 添付の `getOrCreateShareToken` ロジックは変更なし (60 日 TTL)
+
+### 3.5 フォールバック
+
+- **画像化失敗時** (libreoffice クラッシュ / ディスク不足 / Noto フォント欠落等)
+  - 既存の text message 送信に自動的にフォールバック
+  - `buildBroadcastBody` で構築した本文を `splitForLine` で分割し、text message として送信
+  - logger.warn で失敗理由を記録 (運用側で気付ける)
+- **30 ページ超** (極端に長い本文)
+  - 「本文を Web で見る」リンクの text message 1 本に縮約
+  - 添付の `fallback link` と同じ仕組み (本文専用の share token を新設するか、別エンドポイントを使う — 4.4 参照)
+
+### 3.6 配信メッセージ構成
+
+通常配信の最終構成:
+
+| 順序 | 種別 | 内容 |
+|------|------|------|
+| 1〜N | image | 本文画像 (1〜30 ページ) |
+| (失敗時) | text | 本文 text (splitForLine の chunks) |
+| (30 ページ超時) | text | 本文を Web で見るリンク 1 本 |
+| 次〜 | text | 添付ごとの URL リンク (📎 filename + URL) |
+
+LINE のバッチサイズ制約 (5 message / push, 1.5 秒間隔) は既存の `pushMessages` がそのまま処理。
+
+### 3.7 エラーケース・境界条件
+
+| ケース | 挙動 |
+|--------|------|
+| 本文が空 | `(本文なし)` プレースホルダで画像化 (1 ページ) |
+| 件名が空 | ヘッダーに件名行を出さず、本文だけ画像化 |
+| 画像化失敗 | text fallback (3.5) |
+| 30 ページ超 | fallback link (3.5) |
+| 添付処理失敗 | 既存挙動を維持 (link 1 本に縮約) |
+| baseUrl 未設定 | 添付があるとき・本文の link fallback を使うときに例外で `failed` |
+
+---
+
+## 4. 技術設計
+
+### 4.1 新規ファイル
+
+#### `apps/web/src/lib/mail-body-image-render.ts`
+
+```typescript
+/**
+ * 本文 + 件名 + 訂正フラグを HTML テンプレートに流し込み、libreoffice
+ * 経由で PDF を生成し pdftoppm で JPEG 化する。失敗時は throw して
+ * 呼び出し側 (line-broadcast.ts) の text fallback パスに任せる。
+ */
+export interface BuildBodyImageInput {
+  subject: string | null | undefined
+  rawBody: string | null | undefined
+  isCorrection: boolean
+}
+
+export function buildBodyImageHtml(input: BuildBodyImageInput): string
+export async function renderBodyImageToJpegs(input: BuildBodyImageInput): Promise<ImageRenderResult>
+```
+
+HTML テンプレート:
+```html
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <style>
+    @page { size: A4 portrait; margin: 25mm 20mm; }
+    body { font-family: 'Noto Sans CJK JP', sans-serif; font-size: 11pt; line-height: 1.7; color: #000; }
+    h1 { font-size: 14pt; font-weight: bold; margin: 0 0 1em 0; border-bottom: 1px solid #888; padding-bottom: 0.5em; }
+    pre { font-family: 'Noto Sans CJK JP', sans-serif; white-space: pre-wrap; word-break: break-word; margin: 0; }
+  </style>
+</head>
+<body>
+  <h1>{{訂正マーカー}}【{{件名}}】</h1>
+  <pre>{{本文}}</pre>
+</body>
+</html>
+```
+
+実装内部:
+1. HTML を tempdir に書き出し
+2. `libreoffice --headless --convert-to pdf` で PDF 化
+3. 既存 `renderPdfToJpegs` を呼んで JPEG 配列を取得
+4. tempdir をクリーンアップ
+
+### 4.2 既存ファイルの変更
+
+#### `apps/web/src/lib/attachment-image-render.ts`
+- `renderDocxToJpegs` を **export 解除** (line-broadcast から不要になる)。一旦残しておき、未使用 export なら次の cleanup で削除
+- `renderPdfToJpegs` は `mail-body-image-render` 側で内部呼び出しする
+- それ以外の変更なし
+
+#### `apps/web/src/lib/line-broadcast.ts`
+- import 変更: `splitForLine` / `buildBroadcastBody` / `renderPdfToJpegs` / `renderDocxToJpegs` の依存を整理
+- `broadcastMailToEvent` 内:
+  - 本文 text message 構築 (`splitForLine`) を **撤去** し、`renderBodyImageToJpegs` で画像化に置換
+  - 画像化結果 → `buildRenderedImageMessages` 相当で `image` message に変換 (本文画像用は attachment 無関係なので新規 helper か既存リファクタ)
+  - 画像化失敗時の catch → `buildBroadcastBody` + `splitForLine` で text fallback
+  - role の追加: `body_image` (sent_image_count にカウント) と既存 `body_text` (fallback 時のみ使用)
+- `renderAttachment` 内:
+  - PDF / Word の分岐をすべて削除
+  - 添付は **全て** `buildFallbackTextMessage` で URL リンクを返すように単純化
+  - 結果として `renderAttachment` は filename / contentType に関わらず 1 text message を返す関数になる
+- DB スキーマは変更なし (既存 3 カラム `sent_text_count` / `sent_image_count` / `fallback_link_count` で role 集計可能)
+
+#### `apps/web/src/lib/mail-body-cleaner.ts`
+- 既存 `buildBroadcastBody` / `stripMailFooter` はそのまま (text fallback パスで使う)
+- 画像化 HTML テンプレートが直接参照する用途で `stripMailFooter` を再利用
+
+### 4.3 本文 fallback link 用エンドポイント
+
+30 ページ超で「本文を Web で見る」リンクを送るとき、どこに飛ばすか:
+
+**選択肢 A**: 既存 `/api/line-broadcast/attachments/[token]` を再利用
+  - 本文を「擬似添付」として `mail_attachments` に保存し、共通 token で配信
+  - スキーマ変更不要だが、本来の添付と区別が付かなくなる
+
+**選択肢 B (推奨)**: 新規 `/api/line-broadcast/mail-bodies/[token]` を作る
+  - `mail_body_share_tokens` テーブルを新設 (mail_message_id + token + expires_at)
+  - 既存 `getOrCreateShareToken` のパターンを踏襲
+  - LINE 上は `📧 本文を Web で見る\nhttps://.../mail-bodies/<token>` の text 1 本
+
+→ 選択肢 B を採用。30 ページ超のメールは現状ほぼ存在しないので、テーブル作成のコストよりも経路分離の方が運用上分かりやすい。
+   **ただし**, 初期実装ではフォールバックを 30 ページ→画像化諦め→text fallback (本文全文を text で送信) のシンプルな経路にし、テーブル新設は本機能スコープから外す (3.5 の text fallback と同じ扱い)。
+
+→ **最終方針: 30 ページ超は text fallback (本文全文を splitForLine で text 配信) のみ。`mail_body_share_tokens` は導入しない。**
+
+### 4.4 テスト戦略
+
+#### Vitest ユニットテスト
+- `mail-body-image-render.test.ts` (新規):
+  - `buildBodyImageHtml`: 件名あり/なし / 訂正版あり/なし / Google Groups footer 除去 のスナップショット
+  - `renderBodyImageToJpegs`: libreoffice を spawn する子プロセスは **mock しない**(本番と同じ環境前提)。CI 環境に libreoffice が無い場合は skip
+- `mail-body-cleaner.test.ts`: 既存テストはそのまま (fallback パスで使い続けるため)
+- `line-broadcast.test.ts`: 既存テスト期待値を更新
+  - 本文 → text message ではなく image message を期待
+  - 添付 → 全て fallback link (text message) を期待
+  - 画像化失敗時の text fallback パスを 1 ケース追加
+
+#### Playwright E2E
+- 本文画像化が走るルートは LINE_NOTIFY_DRY_RUN=1 でモック中。既存 E2E に画像化失敗ケースを 1 つ追加
+- 実際の libreoffice 描画結果はローカル/本番でユーザーの目視確認に依存
+
+### 4.5 パフォーマンス・運用
+
+- libreoffice + pdftoppm は既存 PDF/Word 画像化と同じプロセス。本文画像化が加わると 1 配信あたり libreoffice 呼び出しが **1 回増加** (約 6 秒)
+- 全添付が URL リンク化することで libreoffice 呼び出しは添付分減少 (Word/PDF 添付の数だけ短縮)
+- 結果として総処理時間は **やや短縮** される見込み (添付が複数あれば顕著)
+
+---
+
+## 5. 影響範囲
+
+### 5.1 変更が必要な既存ファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `apps/web/src/lib/line-broadcast.ts` | 本文 text → image 化、添付の PDF/Word 画像化を撤去 |
+| `apps/web/src/lib/attachment-image-render.ts` | `renderDocxToJpegs` の export 削除 (未使用化), 内部の `renderPdfToJpegs` は本文画像化から再利用 |
+| `apps/web/src/lib/line-broadcast.test.ts` | 期待値を image 中心に更新 |
+| `apps/web/src/lib/attachment-image-render.test.ts` | 既存があれば DOCX テストを削除 (TBD) |
+
+### 5.2 新規ファイル
+
+| ファイル | 役割 |
+|---------|------|
+| `apps/web/src/lib/mail-body-image-render.ts` | 本文画像化の中核 |
+| `apps/web/src/lib/mail-body-image-render.test.ts` | HTML 生成テスト |
+
+### 5.3 DB スキーマ
+
+- **変更なし** (`event_broadcast_messages` の 3 カラムで role 集計可能)
+
+### 5.4 既存機能への影響
+
+| 機能 | 影響 |
+|------|------|
+| メール承認 → LINE 配信 | 表示形式が text → image に変わる (本機能の目的) |
+| 訂正版メール配信 | 同上。`【訂正】` マーカーは画像ヘッダーに移動 |
+| 添付 PDF/Word/Excel | 全て URL リンクに統一 (現行の Excel と同じ挙動) |
+| /api/line-broadcast/images/[token] | 本文画像にも使うので追加変更なし |
+| /api/line-broadcast/attachments/[token] | 変更なし (本文配信からの参照は無い) |
+
+### 5.5 運用への影響
+
+- 本番 Lightsail (現在は Oracle Cloud) 上で `fc-list :lang=ja` が引き続き有効である必要 (既に `fonts-noto-cjk` 導入済み)
+- libreoffice / pdftoppm / poppler-utils が引き続き必要 (本文画像化で本機能完全に依存)
+- ディスク容量: 既存と同程度
+
+---
+
+## 6. 設計判断の根拠
+
+### 6.1 なぜ HTML → libreoffice → PDF → pdftoppm パイプライン?
+
+- **依存ゼロ**: libreoffice / pdftoppm / Noto CJK は既に本番にインストール済み
+- **動作実績**: PDF/Word 画像化で安定運用中 (3 ヶ月以上)
+- **代替案 puppeteer/playwright**: heavy (~250MB chromium), 本番 ARM への load 負荷
+- **代替案 node-canvas + 手動レイアウト**: フォントメトリクス・改ページの自前実装が膨大
+
+### 6.2 なぜ件名を画像ヘッダーに含める?
+
+- 別 text message にすると LINE 上で本文画像の前にテキストが残り、結局縦に伸びる
+- スクショ運用と同じ「1 つの絵で完結」を再現する目的に整合
+
+### 6.3 なぜ添付も URL リンクに統一?
+
+- ユーザー要望 (画像化していた PDF/Word も Excel と同じ URL に揃えたい)
+- 添付ファイルは「明示的に開く」操作のほうが情報量が多い (Word の細かい文字を小画像で見るより、専用アプリで開いた方が読みやすい)
+- 配信時間が短縮 (libreoffice 呼び出しが添付分減る)
+
+### 6.4 なぜ画像化失敗時に text fallback?
+
+- ユーザーの希望は「常に画像」だが、libreoffice クラッシュで配信全体が止まると業務影響が大きい
+- 画像化失敗時に既存の text 経路に倒すことで、可読性は劣るが連絡の到達は守る
+- logger.warn で失敗を可視化し、運用側が原因 (フォント欠落等) に気付ける
+
+### 6.5 なぜ 30 ページ超も text fallback?
+
+- 本文専用 share token テーブル新設は将来の機能 (極長メールが頻発するなら検討)
+- 現状の運用で 30 ページ超のメールは稀 (添付 PDF と違い本文はせいぜい 2-3 ページ)
+- text fallback で十分対応可能
+
+---

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -2124,3 +2124,28 @@
   - 仕様誤解の即修正: `【メール件名】<件名>` → `【<件名>】` (件名そのものを括弧で囲む)
   - 訂正版: `【訂正】「<件名>」\n【メール件名】<件名>` → `【訂正】【<件名>】`
   - mail-body-cleaner.test.ts 14 ケース更新、Codex R1 (high) blockers=0 一発 pass、CI pass (2m55s)、本番反映完了
+
+## 2026-06-01 セッション1（mail-body-as-image: メール本文の画像配信）
+
+### 完了（実装、PR 作成前）
+- **機能 `mail-body-as-image`**（親 Issue #73、子 #74-#78）を `feat/mail-body-as-image` で全 5 タスク実装。1 PR 予定。worktree `C:/tmp/impl-mail-body-as-image`
+  - **目的**: LINE 配信メール本文を A4 縦 JPEG 画像で送り、スマホ LINE の縦長スクロール可読性問題を解消。あわせて添付を全形式 URL リンクに統一
+- **タスク1 (#74)** `f68e918`: `apps/web/src/lib/mail-body-image-render.ts` 新規
+  - `buildBodyImageHtml()`: 件名・本文・訂正フラグを A4 縦 HTML に。`stripMailFooter` 再利用で footer 除去、HTML エスケープ、ヘッダー 4 ケース分岐（件名/訂正の有無）、空本文は `(本文なし)`
+  - `renderBodyImageToJpegs()`: HTML→libreoffice→PDF→`renderPdfToJpegs` で JPEG 化。30 ページ超 `truncated`、失敗時 throw
+  - unit test（スナップショット + 各ケース）。libreoffice 統合テストは未搭載環境では skip
+- **タスク2 (#75)** `f994a18`: `line-broadcast.ts` の `broadcastMailToEvent` 本文を text→画像化。失敗/30 ページ超/0 枚/10 MB 超/baseUrl 未設定は text fallback に降格。`renderAttachment` は全形式 URL リンク統一（PDF/Word 画像化撤廃）。`MessageRole` を `body_image`/`body_text`/`attachment_link` に再編
+- **タスク3 (#76)** `1518d67`: 共通 `runLibreofficeConvertToPdf` を `attachment-image-render.ts` に抽出 export（`runCommand` 再利用）。未使用化した `renderDocxToJpegs` 削除、`mail-body-image-render.ts` のローカル libreoffice 実装も共通化に置換
+- **タスク4 (#77)** `0cb2764`: `line-broadcast.test.ts` を更新。`renderBodyImageToJpegs` をモジュールモック（決定化）し、本文 image / 添付 link / 画像化失敗 text fallback / 30 ページ超 fallback / 訂正フラグ伝播を検証。成功ケースは sharp 生成の有効 JPEG を使用
+- **タスク5 (#78)**: ローカル検証 + worklog + PR 準備
+  - **検証**: apps/web 全ユニット 263 passed / 1 skipped（skip=libreoffice 統合テスト, Windows ローカル未搭載）、`check-types` clean、`lint` clean
+
+### 設計判断・注意点
+- **line-broadcast.test.ts は `renderBodyImageToJpegs` をモック**: libreoffice spawn を mock しない統合テストは `mail-body-image-render.test.ts` 側に隔離（要件 §4.4）。配信オーケストレーションの環境非依存検証のためこちらはモック
+- **30 ページ超は text fallback のみ**（本文専用 share token テーブルは作らない、要件 §4.3）
+- **手順書 Task 5 の `typecheck` は誤記** → 実スクリプトは `check-types`（plan は据え置き、memory に記録）
+
+### 次回 (carryover)
+- 🟡 **PR 作成 → Codex auto-review-loop → ship**（`/prepare-pr` で着手）
+- 🔴 **本番デプロイ後に実機 LINE グループで本文画像表示を目視確認**（DoD 完了条件、Windows ローカルに libreoffice 無く画像描画はローカル未検証。CI/本番 Linux で実描画）
+- 🟢 並行定義の `event-lifecycle-notify`（#79-83 未実装）とは現状ファイル衝突なし

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -2149,3 +2149,6 @@
 - 🟡 **PR 作成 → Codex auto-review-loop → ship**（`/prepare-pr` で着手）
 - 🔴 **本番デプロイ後に実機 LINE グループで本文画像表示を目視確認**（DoD 完了条件、Windows ローカルに libreoffice 無く画像描画はローカル未検証。CI/本番 Linux で実描画）
 - 🟢 並行定義の `event-lifecycle-notify`（#79-83 未実装）とは現状ファイル衝突なし
+
+### レビュー
+- 2026-06-01 /auto-review-loop PR #84: 1R, verdict=pass, effort=high, tokens=47353/500000, result=pass（blockers=0/should_fix=0/nits=0 一発 pass）


### PR DESCRIPTION
## Summary

LINE 配信メールの本文を **A4 縦 JPEG 画像** として送信し、スマホ LINE 上で text が縦に伸びて読みづらい問題を解消する。あわせて添付の取り扱いを **全形式 URL リンクに統一** する。親 Issue #73（子 #74-#78）。

- **本文画像化** (`apps/web/src/lib/mail-body-image-render.ts` 新規)
  - 件名・本文・訂正フラグを A4 縦 HTML テンプレート（Noto Sans CJK JP / 11pt / margin 25mm×20mm）に流し込み、`libreoffice → PDF → pdftoppm` で JPEG 化
  - `stripMailFooter` で Google Groups フッター除去、件名・本文は HTML エスケープ、ヘッダーは件名/訂正の有無で 4 ケース分岐（`【訂正】【件名】` 等）、空本文は `(本文なし)`
- **配信ロジック** (`line-broadcast.ts`)
  - `broadcastMailToEvent` の本文を text → 画像に切替（role `body_image`）
  - **text fallback**: 画像化失敗 / 30 ページ超 / 0 枚 / 10 MB 超 / `PUBLIC_BASE_URL` 未設定はいずれも `buildBroadcastBody` + `splitForLine` の text に降格（連絡到達を優先, 要件 §3.5）
  - **添付**: PDF/Word の画像化を撤廃し、全形式を Excel と同じ署名 URL リンク 1 本に統一（要件 §3.4）
- **リファクタ** (`attachment-image-render.ts`)
  - libreoffice 呼び出しを共通 `runLibreofficeConvertToPdf` に抽出 export（`runCommand` 再利用）、未使用化した `renderDocxToJpegs` を削除
- **DB スキーマ変更なし**（既存 3 カラム `sent_text_count` / `sent_image_count` / `fallback_link_count` を role で再利用）

## Test plan

- [x] apps/web ユニットテスト **263 passed / 1 skipped**（skip = libreoffice 統合テスト、Windows ローカル未搭載のため。CI Linux では実行）
- [x] `check-types`（tsc --noEmit）clean
- [x] `lint`（next lint）clean
- [x] `line-broadcast.test.ts`: 本文 image / 添付 link / 画像化失敗 text fallback / 30 ページ超 fallback / 訂正フラグ伝播を検証（`renderBodyImageToJpegs` をモジュールモックで決定化）
- [ ] **本番デプロイ後、実機 LINE グループで本文画像表示を目視確認**（DoD 完了条件 / 実描画はローカル未検証）

## Notes

- 本番ホストは `libreoffice` + `poppler-utils` + `fonts-noto-cjk` が必須（既に導入済み）
- 30 ページ超は text fallback のみ（本文専用 share token テーブルは導入しない、要件 §4.3）

🤖 Generated with [Claude Code](https://claude.com/claude-code)