### PR TITLE
ci: main push で本番へ即時自動デプロイ (Actions + SSH)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Shell scripts are piped to bash on Linux hosts (e.g. scripts/deploy/*.sh via
+# GitHub Actions deploy). CRLF would break them with `$'\r': command not found`,
+# so force LF regardless of the committer's platform / autocrlf setting.
+*.sh text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,56 @@ jobs:
         run: pnpm test:e2e
         env:
           DATABASE_URL: ${{ env.TEST_DATABASE_URL }}
+
+  deploy:
+    name: Deploy to production
+    needs: [ci]
+    # main への push のみ。PR (pull_request) や他ブランチでは走らない。
+    # fork PR には secrets が渡らないので deploy 鍵は露出しない。
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # 同時デプロイを直列化し、走行中のデプロイは中断しない。
+    concurrency:
+      group: production-deploy
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure SSH (deploy key + pinned host key)
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          printf '%s\n' "${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Deploy to Oracle host
+        run: |
+          set -uo pipefail
+          # auto-deploy.sh を kagetra として host に流し込む (最小権限:
+          # git/build/cp は kagetra 所有、systemctl restart のみ scoped sudo)。
+          # 接続失敗のみ最大3回リトライ。build 失敗 (FAILED) は即座に失敗扱い。
+          attempt=0
+          while :; do
+            attempt=$((attempt + 1))
+            out=$(ssh -i ~/.ssh/deploy_key -o BatchMode=yes -o ConnectTimeout=30 \
+              kagetra@new.hokudaicarta.com 'bash -s' < scripts/deploy/auto-deploy.sh 2>&1) || true
+            echo "$out"
+            if echo "$out" | grep -qE 'DEPLOY_RESULT=(SUCCESS|NOOP|SKIPPED_NOCODE)'; then
+              echo "deploy ok"; exit 0
+            fi
+            if echo "$out" | grep -q 'DEPLOY_RESULT=FAILED'; then
+              echo "::error::deploy script reported FAILED"; exit 1
+            fi
+            if [ "$attempt" -ge 3 ]; then
+              echo "::error::host unreachable / no result after $attempt attempts"; exit 1
+            fi
+            echo "connection issue, retrying ($attempt)..."; sleep 10
+          done
+
+      - name: Cleanup SSH key
+        if: always()
+        run: rm -f ~/.ssh/deploy_key

--- a/scripts/deploy/auto-deploy.sh
+++ b/scripts/deploy/auto-deploy.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# 本番ホスト (Oracle Cloud) 上で実行する自動デプロイスクリプト。
+# GitHub Actions の deploy job が `ssh kagetra@host 'bash -s' < このファイル` で
+# 流し込む。kagetra ユーザー (=/opt/kagetra 所有) として実行される前提。
+#
+# 安全策:
+#   - 追跡対象のローカル変更があれば中断 (ホスト側の手当てを壊さない)
+#   - 変更が docs/.claude 等のみなら build/restart をスキップ (無駄な再起動回避)
+#   - build 成功後にのみ restart (build 失敗時は全サービス旧コードのまま継続)
+#   - restart 後に healthcheck
+#
+# 権限: git/build/cp は kagetra が直接実行 (所有者)。systemctl restart のみ
+#       /etc/sudoers.d/kagetra-deploy で web/api に限定して NOPASSWD 許可。
+set -uo pipefail
+
+REPO=/opt/kagetra
+log()  { echo "[deploy $(date -u +%H:%M:%S)] $*"; }
+fail() { echo "[deploy ERROR] $*" >&2; echo "DEPLOY_RESULT=FAILED"; exit 1; }
+
+cd "$REPO" || fail "cannot cd to $REPO"
+
+# 追跡対象のローカル変更があれば中断。未追跡 (.cache/.config/.local 等の
+# corepack/pnpm キャッシュ) は fetch/checkout と衝突しないので無視。
+if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+  git status --short --untracked-files=no
+  fail "tracked local changes present on host — aborting"
+fi
+
+OLD=$(git rev-parse HEAD)
+log "before: $(git rev-parse --short HEAD)"
+git fetch origin main -q || fail "git fetch failed"
+NEW=$(git rev-parse origin/main)
+if [ "$OLD" = "$NEW" ]; then
+  log "already up to date ($(git rev-parse --short HEAD))"
+  echo "DEPLOY_RESULT=NOOP"; exit 0
+fi
+
+CHANGED=$(git diff --name-only "$OLD" "$NEW")
+git checkout -B main origin/main -q || fail "git checkout failed"
+log "after: $(git rev-parse --short HEAD)"
+
+# 変更パスから対象アプリを判定 (packages/ 変更は全アプリに波及)
+if echo "$CHANGED" | grep -qE '^packages/'; then SHARED=1; else SHARED=0; fi
+if [ "$SHARED" = 1 ] || echo "$CHANGED" | grep -qE '^apps/web/';         then WEB=1;    else WEB=0;    fi
+if [ "$SHARED" = 1 ] || echo "$CHANGED" | grep -qE '^apps/api/';         then API=1;    else API=0;    fi
+if [ "$SHARED" = 1 ] || echo "$CHANGED" | grep -qE '^apps/mail-worker/'; then WORKER=1; else WORKER=0; fi
+
+if [ "$WEB$API$WORKER" = "000" ]; then
+  log "no buildable code changed (docs/.claude/scripts only) — skipping build & restart"
+  echo "DEPLOY_RESULT=SKIPPED_NOCODE"; exit 0
+fi
+log "targets: web=$WEB api=$API worker=$WORKER (shared=$SHARED)"
+
+corepack pnpm install --frozen-lockfile || fail "pnpm install failed"
+
+# --- build (失敗時は restart 前に中断 → 全サービス旧コード継続) ---
+if [ "$WEB" = 1 ];    then log "build apps/web";         corepack pnpm --filter @kagetra/web build         || fail "web build failed (no restart performed)"; fi
+if [ "$API" = 1 ];    then log "build apps/api";         corepack pnpm --filter @kagetra/api build         || fail "api build failed (no restart performed)"; fi
+if [ "$WORKER" = 1 ]; then log "build apps/mail-worker"; corepack pnpm --filter @kagetra/mail-worker build || fail "mail-worker build failed (no restart performed)"; fi
+
+# --- apps/web 静的アセット cp (最重要、忘れると CSS/JS 全 404) ---
+if [ "$WEB" = 1 ]; then
+  STATIC_SRC="$REPO/apps/web/.next/static"
+  STATIC_DEST="$REPO/apps/web/.next/standalone/apps/web/.next"
+  [ -d "$STATIC_SRC" ] || fail "web static dir missing after build"
+  rm -rf "$STATIC_DEST/static"
+  cp -r "$STATIC_SRC" "$STATIC_DEST/" || fail "web static cp failed"
+  if [ -d "$REPO/apps/web/public" ]; then
+    cp -r "$REPO/apps/web/public" "$REPO/apps/web/.next/standalone/apps/web/" || fail "web public cp failed"
+  fi
+  log "web static assets copied"
+fi
+
+# --- restart (build 成功後のみ到達)。mail-worker は oneshot+timer なので
+#     次回 timer 発火で新バンドルが走る → restart 不要 ---
+if [ "$WEB" = 1 ]; then sudo -n systemctl restart kagetra-web.service || fail "web restart failed"; fi
+if [ "$API" = 1 ]; then sudo -n systemctl restart kagetra-api.service || fail "api restart failed"; fi
+
+sleep 4
+if [ "$WEB" = 1 ]; then
+  [ "$(sudo -n systemctl is-active kagetra-web.service)" = active ] || fail "web service not active after restart"
+  CODE=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 http://127.0.0.1:3000 || echo "000")
+  log "web healthcheck http://127.0.0.1:3000 -> $CODE"
+  case "$CODE" in 2*|3*) ;; *) fail "web healthcheck got HTTP $CODE" ;; esac
+fi
+if [ "$API" = 1 ]; then
+  [ "$(sudo -n systemctl is-active kagetra-api.service)" = active ] || fail "api service not active after restart"
+fi
+
+log "deployed HEAD: $(git rev-parse --short HEAD)"
+echo "DEPLOY_RESULT=SUCCESS"

--- a/scripts/deploy/auto-deploy.sh
+++ b/scripts/deploy/auto-deploy.sh
@@ -72,6 +72,22 @@ if [ "$WEB" = 1 ]; then
   log "web static assets copied"
 fi
 
+# --- DB migration (drizzle の SQL が変わったときのみ、restart 前に適用) ---
+# 既存の冪等 apply-migrations.sh (journal+hash で適用済みは skip)。追加系
+# migration は restart 前適用で「新コードが新 schema に出会える」順序になる。
+# 失敗時は restart せず中断 → 旧コード+旧 schema のまま整合が保たれる。
+if echo "$CHANGED" | grep -qE '^packages/shared/drizzle/[0-9].*\.sql$'; then
+  log "DB migration(s) changed — applying via apply-migrations.sh (idempotent)"
+  ENVFILE=/opt/kagetra/.env.production
+  [ -f "$ENVFILE" ] || fail "env file not found: $ENVFILE"
+  # DATABASE_URL を抽出 (前後の引用符は除去)。env ファイル全体は source しない
+  # (systemd EnvironmentFile 形式は bash の . で壊れ得るため)。
+  DB_URL=$(grep -E '^DATABASE_URL=' "$ENVFILE" | head -1 | sed -E "s/^DATABASE_URL=//; s/^\"(.*)\"$/\1/; s/^'(.*)'$/\1/")
+  [ -n "$DB_URL" ] || fail "DATABASE_URL not found in $ENVFILE"
+  DATABASE_URL="$DB_URL" bash "$REPO/scripts/deploy/apply-migrations.sh" || fail "migration apply failed (no restart performed)"
+  log "migrations applied"
+fi
+
 # --- restart (build 成功後のみ到達)。mail-worker は oneshot+timer なので
 #     次回 timer 発火で新バンドルが走る → restart 不要 ---
 if [ "$WEB" = 1 ]; then sudo -n systemctl restart kagetra-web.service || fail "web restart failed"; fi


### PR DESCRIPTION
main マージ後 CI 通過を待って GitHub Actions から本番(Oracle)へ即時デプロイ。public repo のため self-hosted runner 不使用、最小権限 kagetra ユーザー(scoped sudo: systemctl restart のみ)へ deploy 専用鍵で SSH。auto-deploy.sh は変更パス検知し docs のみは build/restart スキップ、build 成功後のみ restart(失敗時は旧コード継続)+healthcheck。secrets は push 限定で fork PR 非伝播、host鍵 pin、SSH(22)は既存の key-only 公開のまま(firewall 不変)。詳細はコミット参照。🤖 Generated with Claude Code