### PR TITLE
fix: メール本文画像の1枚目が真っ白になる不具合 (libreoffice --writer)

### DIFF
--- a/apps/web/src/lib/attachment-image-render.ts
+++ b/apps/web/src/lib/attachment-image-render.ts
@@ -154,11 +154,21 @@ export async function renderPdfToJpegs(
 }
 
 /**
- * Convert any libreoffice-readable input file (`.docx`, `.html`, `.odt`, …)
+ * Convert any libreoffice-readable *text* document (`.html`, `.docx`, `.odt`, …)
  * to a PDF written into `outDir` with the same basename (e.g. `body.html` →
  * `body.pdf`). `libreoffice --headless --convert-to pdf` is the documented
  * one-shot conversion; it spawns a fresh `soffice` process per call and exits
  * when done, so we don't manage a long-running daemon.
+ *
+ * `--writer` forces the input to load in the Writer (text) component. Without
+ * it, libreoffice opens HTML in its "Web" layout, which has a long-standing
+ * bug that prepends a blank first page — the real content then starts on
+ * page 2, and renderPdfToJpegs faithfully turns that blank page into a white
+ * first JPEG (issue #93: LINE showed a blank image before the body). The
+ * Writer text layout has no such page, so a one-screen body renders to a
+ * single page. etherpad-lite fixed the identical symptom the same way. The
+ * only caller renders HTML (mail body) and `--writer` is correct for any text
+ * document, so it is safe for every input that flows through here.
  *
  * Shared by the mail-body image-render path (mail-body-image-render.ts) so the
  * libreoffice invocation — flags, timeout, stdout-drain, stderr surfacing —
@@ -172,7 +182,9 @@ export async function runLibreofficeConvertToPdf(
 ): Promise<void> {
   await runCommand(
     'libreoffice',
-    ['--headless', '--convert-to', 'pdf', '--outdir', outDir, inputPath],
+    // --writer: see docstring — load HTML as a Writer text document to avoid
+    // the "Web" layout's spurious blank first page.
+    ['--headless', '--writer', '--convert-to', 'pdf', '--outdir', outDir, inputPath],
     { timeoutMs: 120_000 },
   )
 }

--- a/apps/web/src/lib/mail-body-image-render.test.ts
+++ b/apps/web/src/lib/mail-body-image-render.test.ts
@@ -127,13 +127,18 @@ const describeIfLibreoffice = libreofficeAvailable() ? describe : describe.skip
 describeIfLibreoffice(
   'renderBodyImageToJpegs (integration: requires libreoffice)',
   () => {
-    it('renders a short body to at least one JPEG page', async () => {
+    it('renders a short body to exactly one JPEG page (no blank first page)', async () => {
       const result = await renderBodyImageToJpegs({
         subject: 'スモークテスト',
         rawBody: 'これは本文画像化のスモークテストです。',
         isCorrection: false,
       })
-      expect(result.pages.length).toBeGreaterThanOrEqual(1)
+      // Regression guard for issue #93: a one-screen body must render to a
+      // single page. The libreoffice HTML "Web" layout used to prepend a
+      // blank first page (content on page 2), which surfaced as a white
+      // first image on LINE; --writer (runLibreofficeConvertToPdf) avoids it.
+      // A spurious blank page would make this 2, so assert exactly 1.
+      expect(result.pages.length).toBe(1)
       expect(result.truncated).toBe(false)
       // JPEG magic bytes: FF D8 FF
       const first = result.pages[0]!


### PR DESCRIPTION
## Summary
- LINE 配信のメール本文画像で **1 枚目が真っ白**になる不具合を修正（2 枚目に本文がずれ込む）
- `runLibreofficeConvertToPdf` の libreoffice 呼び出しに `--writer` を追加し、HTML を Writer ドキュメントとして開かせて先頭空白ページを回避
- libreoffice 統合テストを「短い本文 → ちょうど 1 ページ」に強化（リグレッションガード）

## 原因
LibreOffice は Writer コンポーネントを明示せず HTML を `--convert-to pdf` すると「Web レイアウト」で開き、**先頭に空白ページを挿入する既知バグ**がある（本文は 2 ページ目から）。`renderPdfToJpegs` が PDF 全ページを JPEG 化するため、空白ページがそのまま 1 枚目の画像として LINE に届いていた。`runLibreofficeConvertToPdf` の唯一の呼び出し元は本文画像化（HTML 入力）のみで、添付は全形式 URL リンク化済みのため `--writer` 追加による他フォーマット変換への影響はない。etherpad-lite が同症状を同じ `--writer` で修正している。

## Bug
Fixes #93

## Test plan
- [ ] CI: check-types / lint / unit
- [ ] CI（Linux, libreoffice 実描画）: 統合テストで「短い本文 → ちょうど 1 ページ」を検証
- [ ] 本番デプロイ後、実機 LINE で本文画像が 1 枚目から表示されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
