### PR TITLE
fix(deploy): auto-deploy で NEXT_PUBLIC_* を build に渡す（VAPID 公開鍵維持）

### DIFF
--- a/scripts/deploy/auto-deploy.sh
+++ b/scripts/deploy/auto-deploy.sh
@@ -54,6 +54,16 @@ log "targets: web=$WEB api=$API worker=$WORKER (shared=$SHARED)"
 
 corepack pnpm install --frozen-lockfile || fail "pnpm install failed"
 
+# NEXT_PUBLIC_* は Next.js の build 時にクライアントバンドルへ inline される。
+# .env.production は systemd EnvironmentFile (実行時) なので build には自動で渡らない。
+# VAPID 公開鍵 (NEXT_PUBLIC_VAPID_PUBLIC_KEY) などデフォルト値の無い公開 env を
+# クライアントへ焼き込むため、NEXT_PUBLIC_ 行だけ抽出して export してから build する。
+# (NEXT_PUBLIC_API_URL は api.ts 側に `?? '/hono-api'` デフォルトがあり従来 inline
+#  されていなくても動作したが、VAPID 公開鍵はデフォルトが無く inline 必須。)
+if [ -f /opt/kagetra/.env.production ]; then
+  set -a; . <(grep -E '^NEXT_PUBLIC_[A-Za-z0-9_]+=' /opt/kagetra/.env.production); set +a
+fi
+
 # --- build (失敗時は restart 前に中断 → 全サービス旧コード継続) ---
 if [ "$WEB" = 1 ];    then log "build apps/web";         corepack pnpm --filter @kagetra/web build         || fail "web build failed (no restart performed)"; fi
 if [ "$API" = 1 ];    then log "build apps/api";         corepack pnpm --filter @kagetra/api build         || fail "api build failed (no restart performed)"; fi

--- a/scripts/deploy/auto-deploy.sh
+++ b/scripts/deploy/auto-deploy.sh
@@ -61,7 +61,17 @@ corepack pnpm install --frozen-lockfile || fail "pnpm install failed"
 # (NEXT_PUBLIC_API_URL は api.ts 側に `?? '/hono-api'` デフォルトがあり従来 inline
 #  されていなくても動作したが、VAPID 公開鍵はデフォルトが無く inline 必須。)
 if [ -f /opt/kagetra/.env.production ]; then
-  set -a; . <(grep -E '^NEXT_PUBLIC_[A-Za-z0-9_]+=' /opt/kagetra/.env.production); set +a
+  # source せず key=value として読み取って export する（右辺を shell 評価しない）。
+  # `NEXT_PUBLIC_FOO=$(...)` や `;` を含む値が混ざっても deploy 権限でコマンド実行
+  # されないよう、設定ファイルはデータとして扱う（下部の DATABASE_URL 抽出と同方針）。
+  while IFS= read -r np_line; do
+    np_key=${np_line%%=*}
+    np_val=${np_line#*=}
+    np_val=${np_val%$'\r'}                     # 末尾 CR 除去
+    np_val=${np_val%\"}; np_val=${np_val#\"}   # 両端のダブルクォート除去
+    np_val=${np_val%\'}; np_val=${np_val#\'}   # 両端のシングルクォート除去
+    export "$np_key=$np_val"
+  done < <(grep -E '^NEXT_PUBLIC_[A-Za-z0-9_]+=' /opt/kagetra/.env.production)
 fi
 
 # --- build (失敗時は restart 前に中断 → 全サービス旧コード継続) ---


### PR DESCRIPTION
## Summary
- `auto-deploy.sh` の build フェーズ（install 後・build 前）に、`/opt/kagetra/.env.production` の `NEXT_PUBLIC_*` 行のみを export する処理を追加
- NEXT_PUBLIC_* は Next.js build 時にクライアントへ inline されるが、従来 build に渡されず apps/web に .env も無いため inline されていなかった
- `NEXT_PUBLIC_API_URL` は `?? '/hono-api'` デフォルトで動作していたが、VAPID 公開鍵 `NEXT_PUBLIC_VAPID_PUBLIC_KEY` はデフォルト無し → web 再ビルドのたびに消え Web Push（バッジ/通知）が無効化される穴を恒久的に塞ぐ
- 秘密 env（DATABASE_URL / VAPID_PRIVATE_KEY 等）は除外、`.env.production` 不在時はスキップ

## 背景
PR #95 (mail-triage-badge) で Web Push 導入。VAPID 公開鍵は本番手動 build で反映済みだが、本修正で次回以降の auto-deploy でも維持される。

## Test plan
- [x] `bash -n` 構文チェック OK
- [x] grep ロジック検証（NEXT_PUBLIC_ のみ抽出、秘密 env 除外）
- [x] LF 改行（.gitattributes 準拠）

🤖 Generated with [Claude Code](https://claude.com/claude-code)