### PR TITLE
feat: entry-notify-lottery-treasurer (申込完了の参加者向け抽選日追記 + 会計向け2通目)

### DIFF
--- a/apps/web/e2e/event-lifecycle.spec.ts
+++ b/apps/web/e2e/event-lifecycle.spec.ts
@@ -1,6 +1,11 @@
 import { expect, test } from '@playwright/test'
 import { eq } from 'drizzle-orm'
-import { events, eventLineBroadcasts, lineChannels } from '@kagetra/shared/schema'
+import {
+  events,
+  eventLifecycleNotifications,
+  eventLineBroadcasts,
+  lineChannels,
+} from '@kagetra/shared/schema'
 import {
   AUTHJS_SESSION_COOKIE,
   seedAdminSession,
@@ -106,5 +111,57 @@ test.describe('/events/[id] 進行管理セクション', () => {
     await expect(page.getByText('進行状況', { exact: true })).toBeVisible()
     await expect(page.getByText('未申込')).toBeVisible()
     await expect(page.getByRole('button', { name: '申込済にする' })).toHaveCount(0)
+  })
+
+  // entry-notify-lottery-treasurer (タスク5 E2E) ----------------------------
+  test('admin: /edit で抽選日を保存→/events/[id] で表示→申込済トグルが例外なく完了（2 種別とも once-ever）', async ({
+    context,
+    page,
+  }) => {
+    const event = await seedLinkedEvent('抽選E2E')
+    const session = await seedAdminSession()
+    await addSessionCookie(context, session.sessionToken)
+
+    // 1) 編集画面で抽選日を入力 → 保存
+    await page.goto(`/events/${event.id}/edit`)
+    await page.locator('input[name="lotteryDate"]').fill('2026-01-20')
+    await page.getByRole('button', { name: '更新' }).click()
+    await page.waitForURL(`**/events/${event.id}`)
+
+    // 2) 詳細画面に抽選日が表示される（参加費・締切と並ぶ参照行）
+    await expect(page.getByText('抽選日', { exact: true })).toBeVisible()
+    await expect(page.getByText('2026-01-20', { exact: true })).toBeVisible()
+
+    // 3) 申込済トグル — linked 大会なので確認ダイアログを accept
+    page.on('dialog', (dialog) => void dialog.accept())
+    await page.getByRole('button', { name: '申込済にする' }).click()
+    await expect(page.getByRole('button', { name: '未申込に戻す' })).toBeVisible()
+
+    // 4) DB: entry_applied と entry_applied_treasurer の 2 種別ログが作成される
+    //    （DRY_RUN 下では push は飛ばないが claim → finalize は走るので sent で記録される）
+    const logs = await testDb
+      .select()
+      .from(eventLifecycleNotifications)
+      .where(eq(eventLifecycleNotifications.eventId, event.id))
+    expect(logs).toHaveLength(2)
+    expect(new Set(logs.map((l) => l.type))).toEqual(
+      new Set(['entry_applied', 'entry_applied_treasurer']),
+    )
+  })
+
+  test('一般会員: 抽選日が参照のみで表示される（編集導線は出ない）', async ({ context, page }) => {
+    const event = await createEvent({
+      title: '会員抽選参照E2E',
+      eventDate: '2026-12-01',
+      lotteryDate: '2026-01-20',
+    })
+    const session = await seedMemberSession()
+    await addSessionCookie(context, session.sessionToken)
+
+    await page.goto(`/events/${event.id}`)
+    await expect(page.getByText('抽選日', { exact: true })).toBeVisible()
+    await expect(page.getByText('2026-01-20', { exact: true })).toBeVisible()
+    // 編集導線は admin/vice_admin のみ（会員には出ない）
+    await expect(page.getByRole('link', { name: '編集' })).toHaveCount(0)
   })
 })

--- a/apps/web/src/app/(app)/events/[id]/actions.ts
+++ b/apps/web/src/app/(app)/events/[id]/actions.ts
@@ -475,35 +475,98 @@ export async function setEntryApplied(
     return
   }
 
+  // entry-notify-lottery-treasurer: 申込完了で 2 通送る（参加者向け＋会計向け）。
+  // 両 claim は同一 tx で UNIQUE が判定するので、再トグルや並行呼び出しでも
+  // それぞれ 1 回限り。コミット後の push は独立 try/catch (best-effort)。
   const result = await db.transaction(async (tx) => {
     // 未申込→申込済 の初回遷移だけ通す（ガード）。既に applied なら 0 件で
-    // 通知しない。
+    // 通知しない。会計向け文面に必要なフィールド (lotteryDate / payment*) も
+    // 同時に取り出す（コミット後の文面組立に使う）。
     const flipped = await tx
       .update(events)
       .set({ entryStatus: 'applied', entryAppliedAt: sql`now()`, updatedAt: sql`now()` })
       .where(and(eq(events.id, eventId), eq(events.entryStatus, 'not_applied')))
-      .returning({ id: events.id, title: events.title, status: events.status })
-    if (!flipped[0]) return { notificationId: null as number | null, title: '' }
-    // cancelled 大会には通知しない（要件 §3.2.2 #2、日次バッチ側の除外と対称）。
-    // 状態変更そのものは記録する。
-    if (flipped[0].status === 'cancelled') {
-      return { notificationId: null as number | null, title: '' }
+      .returning({
+        id: events.id,
+        title: events.title,
+        status: events.status,
+        lotteryDate: events.lotteryDate,
+        paymentDeadline: events.paymentDeadline,
+        paymentMethod: events.paymentMethod,
+        paymentInfo: events.paymentInfo,
+      })
+    const row = flipped[0]
+    type PendingNotification = {
+      participantNotificationId: number | null
+      treasurerNotificationId: number | null
+      title: string
+      lotteryDate: string | null
+      paymentDeadline: string | null
+      paymentMethod: string | null
+      paymentInfo: string | null
     }
-    // once-ever claim（再トグルしても UNIQUE で 2 回目以降は claim されない）
-    const claim = await claimLifecycleNotification(tx, eventId, 'entry_applied')
-    return { notificationId: claim.id ?? null, title: flipped[0].title }
+    const empty: PendingNotification = {
+      participantNotificationId: null,
+      treasurerNotificationId: null,
+      title: '',
+      lotteryDate: null,
+      paymentDeadline: null,
+      paymentMethod: null,
+      paymentInfo: null,
+    }
+    if (!row) return empty
+    // cancelled 大会には 2 通とも通知しない（要件 §3.2.2 #2、既存 entry_applied と対称）。
+    // 状態変更そのものは記録する（once-ever スロットは消費しない＝後で復帰しても通知しない方針は既存と一貫）。
+    if (row.status === 'cancelled') return empty
+    // 種別ごとに独立 claim（UNIQUE(event_id,type) で 2 回目以降は claim 失敗）。
+    // 同一 tx 内で両方走らせるので、片方の claim 結果がもう片方を阻害することはない。
+    const participantClaim = await claimLifecycleNotification(tx, eventId, 'entry_applied')
+    const treasurerClaim = await claimLifecycleNotification(tx, eventId, 'entry_applied_treasurer')
+    return {
+      participantNotificationId: participantClaim.id ?? null,
+      treasurerNotificationId: treasurerClaim.id ?? null,
+      title: row.title,
+      lotteryDate: row.lotteryDate,
+      paymentDeadline: row.paymentDeadline,
+      paymentMethod: row.paymentMethod,
+      paymentInfo: row.paymentInfo,
+    }
   })
 
-  if (result.notificationId != null) {
-    const message = buildLifecycleMessage('entry_applied', { title: result.title })
+  // 参加者向け（抽選日があれば追記）。
+  if (result.participantNotificationId != null) {
+    const message = buildLifecycleMessage('entry_applied', {
+      title: result.title,
+      lotteryDateIso: result.lotteryDate,
+    })
     try {
       await sendClaimedNotification(db, {
-        notificationId: result.notificationId,
+        notificationId: result.participantNotificationId,
         eventId,
         message,
       })
     } catch {
       // best-effort: 状態変更はコミット済み。push 失敗で巻き戻さない。
+    }
+  }
+
+  // 会計向け 2 通目（振込方法/期限/詳細、全空なら最小文面）。
+  // 参加者向けの push 失敗ともう片方の送信成否は独立（要件 §3.2.5）。
+  if (result.treasurerNotificationId != null) {
+    const message = buildLifecycleMessage('entry_applied_treasurer', {
+      title: result.title,
+      paymentDeadlineIso: result.paymentDeadline,
+      paymentMethod: result.paymentMethod,
+      paymentInfo: result.paymentInfo,
+    })
+    try {
+      await sendClaimedNotification(db, {
+        notificationId: result.treasurerNotificationId,
+        eventId,
+        message,
+      })
+    } catch {
+      // best-effort
     }
   }
   revalidatePath(`/events/${eventId}`)

--- a/apps/web/src/app/(app)/events/[id]/edit/page.tsx
+++ b/apps/web/src/app/(app)/events/[id]/edit/page.tsx
@@ -84,6 +84,7 @@ export default async function EditEventPage({
           capacity: event.capacity,
           entryDeadline: event.entryDeadline,
           internalDeadline: event.internalDeadline,
+          lotteryDate: event.lotteryDate,
           eventGroupId: event.eventGroupId,
           eligibleGrades: event.eligibleGrades,
           description: event.description,

--- a/apps/web/src/app/(app)/events/[id]/lifecycle-actions.test.ts
+++ b/apps/web/src/app/(app)/events/[id]/lifecycle-actions.test.ts
@@ -64,7 +64,7 @@ describe('event lifecycle actions', () => {
     await closeTestDb()
   })
 
-  it('setEntryApplied(true): linked 大会で申込済 + 完了通知を 1 回送る', async () => {
+  it('setEntryApplied(true): linked 大会で申込済 + 参加者向け/会計向けの 2 通とも sent', async () => {
     const admin = await createAdmin()
     const event = await seedLinkedEvent()
     await setAuthSession({ id: admin.id, role: 'admin' })
@@ -76,15 +76,20 @@ describe('event lifecycle actions', () => {
     expect(row?.entryAppliedAt).not.toBeNull()
 
     const logs = await notifications(event.id)
-    expect(logs).toHaveLength(1)
-    expect(logs[0]).toMatchObject({
-      type: 'entry_applied',
+    // entry-notify-lottery-treasurer: 申込完了で 2 種別とも once-ever claim + push。
+    const byType = new Map(logs.map((l) => [l.type, l]))
+    expect(byType.size).toBe(2)
+    expect(byType.get('entry_applied')).toMatchObject({
+      status: 'sent',
+      lineGroupId: 'Glifecycle',
+    })
+    expect(byType.get('entry_applied_treasurer')).toMatchObject({
       status: 'sent',
       lineGroupId: 'Glifecycle',
     })
   })
 
-  it('setEntryApplied: 再トグル（戻して再申込）でも再通知しない（once-ever）', async () => {
+  it('setEntryApplied: 再トグル（戻して再申込）でも 2 種別とも 1 回限り', async () => {
     const admin = await createAdmin()
     const event = await seedLinkedEvent()
     await setAuthSession({ id: admin.id, role: 'admin' })
@@ -94,11 +99,15 @@ describe('event lifecycle actions', () => {
     await setEntryApplied(event.id, true)
 
     expect((await getEvent(event.id))?.entryStatus).toBe('applied')
-    // 通知ログは初回 claim の 1 行のみ
-    expect(await notifications(event.id)).toHaveLength(1)
+    // 通知ログは entry_applied + entry_applied_treasurer の 2 行のみ（種別ごとに once-ever）
+    const logs = await notifications(event.id)
+    expect(logs).toHaveLength(2)
+    expect(new Set(logs.map((l) => l.type))).toEqual(
+      new Set(['entry_applied', 'entry_applied_treasurer']),
+    )
   })
 
-  it('setEntryApplied(true): 未紐付けは申込済にするが通知は飛ばさず skipped を記録', async () => {
+  it('setEntryApplied(true): 未紐付けは申込済にするが 2 種別とも skipped を記録（スロット消費）', async () => {
     const admin = await createAdmin()
     const event = await createEvent({ title: 'Unlinked' })
     await setAuthSession({ id: admin.id, role: 'admin' })
@@ -107,8 +116,32 @@ describe('event lifecycle actions', () => {
 
     expect((await getEvent(event.id))?.entryStatus).toBe('applied')
     const logs = await notifications(event.id)
-    expect(logs).toHaveLength(1)
-    expect(logs[0]).toMatchObject({ type: 'entry_applied', status: 'skipped' })
+    expect(logs).toHaveLength(2)
+    // バックフィル防止: 後から linked になっても 2 通とも再送しない（既存方針と一貫）
+    expect(logs.every((l) => l.status === 'skipped')).toBe(true)
+    expect(new Set(logs.map((l) => l.type))).toEqual(
+      new Set(['entry_applied', 'entry_applied_treasurer']),
+    )
+  })
+
+  it('setEntryApplied(true): lottery_date / payment 情報を持つ大会でも 2 通とも sent（文面は lib テストで検証）', async () => {
+    const admin = await createAdmin()
+    const event = await seedLinkedEvent({
+      title: '新春かるた大会',
+      lotteryDate: '2026-01-20',
+      paymentDeadline: '2026-01-25',
+      paymentMethod: '北洋銀行',
+      paymentInfo: '普通 1234567 北大かるた会',
+    })
+    await setAuthSession({ id: admin.id, role: 'admin' })
+
+    await setEntryApplied(event.id, true)
+
+    const logs = await notifications(event.id)
+    expect(logs).toHaveLength(2)
+    expect(logs.every((l) => l.status === 'sent')).toBe(true)
+    // 文面そのものは buildLifecycleMessage の純粋関数テストで網羅 (event-lifecycle-notify.test.ts)。
+    // ここでは「会計向け 2 通目の slot 消費＋送信成功」だけ担保する。
   })
 
   it('setEntryApplied(false): 申込日時を null に戻し通知しない', async () => {

--- a/apps/web/src/app/(app)/events/[id]/page.tsx
+++ b/apps/web/src/app/(app)/events/[id]/page.tsx
@@ -330,6 +330,8 @@ export default async function EventDetailPage({
     ...(event.internalDeadline
       ? [{ label: '会内締切', value: event.internalDeadline }]
       : []),
+    // entry-notify-lottery-treasurer: 抽選日（NULL=抽選なし）。会員にも参照のみ表示する（要件 §3.1.2）。
+    ...(event.lotteryDate ? [{ label: '抽選日', value: event.lotteryDate }] : []),
     ...(event.organizer ? [{ label: '主催', value: event.organizer }] : []),
     ...(event.entryMethod
       ? [{ label: '申込方法', value: event.entryMethod }]

--- a/apps/web/src/components/events/event-form.test.tsx
+++ b/apps/web/src/components/events/event-form.test.tsx
@@ -111,4 +111,50 @@ describe('EventForm', () => {
     expect(capA?.value).toBe('32')
     expect(info?.value).toBe('○○銀行 普通 1234567')
   })
+
+  // entry-notify-lottery-treasurer ------------------------------------------
+  it("mode='create' で抽選日 (lotteryDate) の date 入力が描画される（空デフォルト）", () => {
+    const { container } = render(
+      <EventForm mode="create" action={noop} groups={groups} cancelHref="/events" />,
+    )
+    const lottery = container.querySelector(
+      '[name="lotteryDate"]',
+    ) as HTMLInputElement | null
+    expect(lottery).toBeTruthy()
+    expect(lottery?.type).toBe('date')
+    expect(lottery?.value).toBe('')
+  })
+
+  it("mode='edit' で lotteryDate の defaultValues が反映される", () => {
+    const { container } = render(
+      <EventForm
+        mode="edit"
+        action={noop}
+        groups={groups}
+        cancelHref="/events/1"
+        defaultValues={{ lotteryDate: '2026-01-20' }}
+      />,
+    )
+    const lottery = container.querySelector(
+      '[name="lotteryDate"]',
+    ) as HTMLInputElement | null
+    expect(lottery?.value).toBe('2026-01-20')
+  })
+
+  it('embedded（承認画面）モードでは lotteryDate 入力欄は描画しない（要件 §5.2）', () => {
+    const { container } = render(
+      <EventForm
+        mode="create"
+        action={noop}
+        groups={groups}
+        cancelHref="/events"
+        fieldPrefix="u1__"
+      />,
+    )
+    // namespaced も bare もどちらも無いことを確認
+    expect(container.querySelector('[name="u1__lotteryDate"]')).toBeNull()
+    expect(container.querySelector('[name="lotteryDate"]')).toBeNull()
+    // 締切群は描画されていること（embedded でも申込締切は出る）
+    expect(container.querySelector('[name="u1__entryDeadline"]')).toBeTruthy()
+  })
 })

--- a/apps/web/src/components/events/event-form.tsx
+++ b/apps/web/src/components/events/event-form.tsx
@@ -24,6 +24,8 @@ export interface EventFormProps {
     capacity?: number | null
     entryDeadline?: string | null
     internalDeadline?: string | null
+    // entry-notify-lottery-treasurer: 抽選日（NULL=抽選なし）。承認画面 (embedded) では描画しない。
+    lotteryDate?: string | null
     eventGroupId?: number | null
     eligibleGrades?: string[] | null
     description?: string | null
@@ -172,6 +174,24 @@ export function EventForm({
             />
           </div>
         </div>
+
+        {/* entry-notify-lottery-treasurer: 抽選日は単体行で締切群の直下に置く。
+            承認画面 (embedded) では描画しない（要件 §5.2: 承認直後は NULL、編集画面で後入力）。
+            申込完了通知の参加者向け文面に「抽選日は M/D です」を差し込むため手動入力。 */}
+        {!embedded && (
+          <div>
+            <label className={LABEL_CLASS}>抽選日</label>
+            <input
+              name={n('lotteryDate')}
+              type="date"
+              defaultValue={defaultValues?.lotteryDate ?? ''}
+              className={FIELD_CLASS}
+            />
+            <p className="mt-1 text-xs text-ink-meta">
+              指定すると申込完了の LINE 通知に「抽選日は M/D です」が追記されます。
+            </p>
+          </div>
+        )}
 
         <div>
           <label className={LABEL_CLASS}>大会グループ</label>

--- a/apps/web/src/lib/event-lifecycle-notify.test.ts
+++ b/apps/web/src/lib/event-lifecycle-notify.test.ts
@@ -29,10 +29,85 @@ import {
 describe('buildLifecycleMessage', () => {
   const title = '春の大会'
 
-  it('申込完了 (✅)', () => {
+  it('申込完了 (✅) — 抽選日なしは従来どおり', () => {
     expect(buildLifecycleMessage('entry_applied', { title })).toBe(
       '✅【春の大会】への参加申込が完了しました。',
     )
+  })
+
+  it('申込完了 (✅) — lotteryDateIso 非 null で末尾に「抽選日は M/D です」を追記', () => {
+    expect(
+      buildLifecycleMessage('entry_applied', { title, lotteryDateIso: '2026-01-20' }),
+    ).toBe('✅【春の大会】への参加申込が完了しました。\n抽選日は 1/20 です。')
+  })
+
+  it('申込完了 (✅) — lotteryDateIso が null/空文字なら追記なし', () => {
+    expect(buildLifecycleMessage('entry_applied', { title, lotteryDateIso: null })).toBe(
+      '✅【春の大会】への参加申込が完了しました。',
+    )
+    expect(buildLifecycleMessage('entry_applied', { title, lotteryDateIso: '' })).toBe(
+      '✅【春の大会】への参加申込が完了しました。',
+    )
+  })
+
+  it('会計向け (💴) — 期限のみ', () => {
+    expect(
+      buildLifecycleMessage('entry_applied_treasurer', {
+        title,
+        paymentDeadlineIso: '2026-01-25',
+      }),
+    ).toBe('💴【春の大会】会計の方へ\n振込期限：1/25')
+  })
+
+  it('会計向け (💴) — 方法のみ', () => {
+    expect(
+      buildLifecycleMessage('entry_applied_treasurer', {
+        title,
+        paymentMethod: '銀行振込',
+      }),
+    ).toBe('💴【春の大会】会計の方へ\n振込方法：銀行振込')
+  })
+
+  it('会計向け (💴) — 期限・方法・詳細すべてあり', () => {
+    expect(
+      buildLifecycleMessage('entry_applied_treasurer', {
+        title,
+        paymentDeadlineIso: '2026-01-25',
+        paymentMethod: '銀行振込',
+        paymentInfo: '◯◯銀行 △△支店 普通 1234567',
+      }),
+    ).toBe(
+      '💴【春の大会】会計の方へ\n振込期限：1/25\n振込方法：銀行振込\n◯◯銀行 △△支店 普通 1234567',
+    )
+  })
+
+  it('会計向け (💴) — 全項目空なら最小文面', () => {
+    expect(buildLifecycleMessage('entry_applied_treasurer', { title })).toBe(
+      '💴【春の大会】会計の方へ\n参加費の振込手続きをお願いします。振込方法・期限は大会ページでご確認ください。',
+    )
+  })
+
+  it('会計向け (💴) — 空白のみの method/info は無視（最小文面に落ちる）', () => {
+    expect(
+      buildLifecycleMessage('entry_applied_treasurer', {
+        title,
+        paymentMethod: '   ',
+        paymentInfo: '\n  \t',
+      }),
+    ).toBe(
+      '💴【春の大会】会計の方へ\n参加費の振込手続きをお願いします。振込方法・期限は大会ページでご確認ください。',
+    )
+  })
+
+  it('会計向け (💴) — feeJpy を渡しても金額は文面に出ない（会計は合計振込のため）', () => {
+    const msg = buildLifecycleMessage('entry_applied_treasurer', {
+      title,
+      feeJpy: 1500,
+      paymentDeadlineIso: '2026-01-25',
+    })
+    expect(msg).not.toContain('1,500')
+    expect(msg).not.toContain('1500')
+    expect(msg).not.toContain('円')
   })
 
   it('申込締切・事前 (⏰) は MM/DD とリードタイムを差し込む', () => {
@@ -107,7 +182,9 @@ describe('buildLifecycleMessage', () => {
     )
   })
 
-  it('全 8 種別が title を含む非空メッセージを返す（branch 漏れ検出）', () => {
+  it('全 9 種別が title を含む非空メッセージを返す（branch 漏れ検出）', () => {
+    // entry_applied_treasurer も title 行を含む（最小文面に落ちても見出しの【title】会計の方へ が出る）。
+    expect(eventLifecycleNotificationTypeEnum.enumValues.length).toBe(9)
     for (const type of eventLifecycleNotificationTypeEnum.enumValues) {
       const msg = buildLifecycleMessage(type, { title, feeJpy: 800, dateIso: '2026-06-05' })
       expect(msg).toContain('春の大会')

--- a/apps/web/src/lib/event-lifecycle-notify.ts
+++ b/apps/web/src/lib/event-lifecycle-notify.ts
@@ -94,6 +94,15 @@ export interface LifecycleMessageContext {
   dateIso?: string
   /** Lead days for `*_advance` reminders. Defaults to `reminderLeadDays()`. */
   leadDays?: number
+  // entry-notify-lottery-treasurer ------------------------------------------
+  /** 抽選日 'YYYY-MM-DD'。entry_applied で非 null のとき「抽選日は M/D です」を追記（§3.2.2）。 */
+  lotteryDateIso?: string | null
+  /** 振込期限 'YYYY-MM-DD'。entry_applied_treasurer の「振込期限：M/D」に使う（§3.2.3）。 */
+  paymentDeadlineIso?: string | null
+  /** 振込方法（自由記述）。entry_applied_treasurer の「振込方法：…」に使う。 */
+  paymentMethod?: string | null
+  /** 振込先などの支払情報詳細（自由記述）。entry_applied_treasurer にそのまま載せる。 */
+  paymentInfo?: string | null
 }
 
 /**
@@ -111,8 +120,28 @@ export function buildLifecycleMessage(
   const fee = formatFeeAmount(ctx.feeJpy)
 
   switch (type) {
-    case 'entry_applied':
-      return `✅【${title}】への参加申込が完了しました。`
+    case 'entry_applied': {
+      const applied = `✅【${title}】への参加申込が完了しました。`
+      // §3.2.2: 抽選日が設定されていれば末尾に追記。NULL のときは従来どおり追記なし。
+      return ctx.lotteryDateIso
+        ? `${applied}\n抽選日は ${formatMMDD(ctx.lotteryDateIso)} です。`
+        : applied
+    }
+    case 'entry_applied_treasurer': {
+      // §3.2.3: 申込完了の 2 通目（会計向け）。値があるものだけ行連結、全空なら最小文面。
+      // 金額（feeJpy）は載せない／支払いタイプでは出し分けない（現地払い・未設定でも常に送る）。
+      const lines: string[] = []
+      if (ctx.paymentDeadlineIso) lines.push(`振込期限：${formatMMDD(ctx.paymentDeadlineIso)}`)
+      const method = ctx.paymentMethod?.trim()
+      if (method) lines.push(`振込方法：${method}`)
+      const info = ctx.paymentInfo?.trim()
+      if (info) lines.push(info)
+      const body =
+        lines.length > 0
+          ? lines.join('\n')
+          : '参加費の振込手続きをお願いします。振込方法・期限は大会ページでご確認ください。'
+      return `💴【${title}】会計の方へ\n${body}`
+    }
     case 'entry_deadline_advance':
       return `⏰【${title}】の申込締切は ${date}（あと ${lead} 日）です。まだ申込が完了していません。`
     case 'entry_deadline_day':

--- a/apps/web/src/lib/form-schemas.test.ts
+++ b/apps/web/src/lib/form-schemas.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { eventFormSchema } from './form-schemas'
+import { eventFormSchema, extractEventFormData, extractEventUnitsFormData } from './form-schemas'
 
 const baseInput = {
   title: '基本',
@@ -35,5 +35,69 @@ describe('eventFormSchema', () => {
   it('eventGroupId=0 は positive 制約で弾く', () => {
     const result = eventFormSchema.safeParse({ ...baseInput, eventGroupId: '0' })
     expect(result.success).toBe(false)
+  })
+
+  // entry-notify-lottery-treasurer -----------------------------------------
+  it('lotteryDate=YYYY-MM-DD は受理する', () => {
+    const result = eventFormSchema.safeParse({ ...baseInput, lotteryDate: '2026-01-20' })
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.lotteryDate).toBe('2026-01-20')
+  })
+
+  it('lotteryDate=空文字 は null に変換される（=抽選なし）', () => {
+    const result = eventFormSchema.safeParse({ ...baseInput, lotteryDate: '' })
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.lotteryDate).toBeNull()
+  })
+
+  it('lotteryDate=undefined（フィールド未送信）も null に変換される', () => {
+    const result = eventFormSchema.safeParse(baseInput)
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.lotteryDate).toBeNull()
+  })
+
+  it('lotteryDate=不正形式は弾く', () => {
+    const result = eventFormSchema.safeParse({ ...baseInput, lotteryDate: '2026/01/20' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('extractEventFormData', () => {
+  it('lotteryDate を formData から拾い、空文字なら null にパースされる', () => {
+    const fd = new FormData()
+    fd.set('title', 'X')
+    fd.set('eventDate', '2030-06-15')
+    fd.set('status', 'draft')
+    fd.set('lotteryDate', '2026-01-20')
+    const parsed = eventFormSchema.parse(extractEventFormData(fd))
+    expect(parsed.lotteryDate).toBe('2026-01-20')
+
+    const fd2 = new FormData()
+    fd2.set('title', 'X')
+    fd2.set('eventDate', '2030-06-15')
+    fd2.set('status', 'draft')
+    fd2.set('lotteryDate', '')
+    const parsed2 = eventFormSchema.parse(extractEventFormData(fd2))
+    expect(parsed2.lotteryDate).toBeNull()
+  })
+})
+
+describe('extractEventUnitsFormData (承認画面)', () => {
+  it('承認画面では lotteryDate を渡さない → zod パース後は null（要件 §5.2: 承認直後は NULL）', () => {
+    const fd = new FormData()
+    fd.append('unit_key', 'u1')
+    fd.set('u1__register', 'on')
+    fd.set('u1__title', '春の大会')
+    fd.set('u1__eventDate', '2030-06-15')
+    fd.set('u1__status', 'draft')
+    // 仮に承認画面 form 側に lotteryDate を出してしまっても、extract が読まないので無視される。
+    fd.set('u1__lotteryDate', '2026-01-20')
+
+    const units = extractEventUnitsFormData(fd)
+    expect(units).toHaveLength(1)
+    expect(units[0]!.data).not.toHaveProperty('lotteryDate')
+
+    const parsed = eventFormSchema.parse(units[0]!.data)
+    expect(parsed.lotteryDate).toBeNull()
   })
 })

--- a/apps/web/src/lib/form-schemas.ts
+++ b/apps/web/src/lib/form-schemas.ts
@@ -32,6 +32,9 @@ export const eventFormSchema = z.object({
   kind: z.enum(['individual', 'team']),
   entryDeadline: optionalDateStr,
   internalDeadline: optionalDateStr,
+  // entry-notify-lottery-treasurer: 抽選日（任意・NULL=抽選なし）。申込完了通知に差し込む。
+  // 承認画面 (extractEventUnitsFormData) では受け取らない＝NULL のまま、編集画面で後入力。
+  lotteryDate: optionalDateStr,
   eventGroupId: optionalPositiveInt,
   feeJpy: optionalNonNegativeInt,
   paymentDeadline: optionalDateStr,
@@ -70,6 +73,7 @@ export function extractEventFormData(formData: FormData): Record<string, unknown
     kind: formData.get('kind') || 'individual',
     entryDeadline: formData.get('entryDeadline'),
     internalDeadline: formData.get('internalDeadline'),
+    lotteryDate: formData.get('lotteryDate'),
     eventGroupId: formData.get('eventGroupId'),
     feeJpy: formData.get('feeJpy'),
     paymentDeadline: formData.get('paymentDeadline'),

--- a/docs/features/entry-notify-lottery-treasurer/implementation-plan.md
+++ b/docs/features/entry-notify-lottery-treasurer/implementation-plan.md
@@ -23,7 +23,7 @@ status: completed
 - **完了条件:** `pnpm --filter @kagetra/shared check-types` green、migration が `lottery_date` 追加と `ADD VALUE 'entry_applied_treasurer'` を含む、shared の vitest が green。
 
 ### タスク2: 通知文面テンプレの拡張（lib）
-- [ ] 完了
+- [x] 完了
 - **概要:** 参加者向け（抽選日追記）と会計向け（振込方法・期限）の文面生成を追加する。push / claim / finalize は既存ヘルパーをそのまま使う。
 - **変更対象ファイル:**
   - `apps/web/src/lib/event-lifecycle-notify.ts` — `LifecycleMessageContext` に `lotteryDateIso?` / `paymentMethod?` / `paymentInfo?` / `paymentDeadlineIso?`（or 既存 `dateIso` 流用）を追加。`buildLifecycleMessage` に `entry_applied` の抽選日追記と `entry_applied_treasurer` の文面（期限/方法/詳細、全空なら最小文面、金額は載せない）を実装。exhaustiveness guard に新ケース追加

--- a/docs/features/entry-notify-lottery-treasurer/implementation-plan.md
+++ b/docs/features/entry-notify-lottery-treasurer/implementation-plan.md
@@ -33,7 +33,7 @@ status: completed
 - **完了条件:** 上記ユニットテストが green、`buildLifecycleMessage` の戻り文字列が要件 §3.2.2 / §3.2.3 と一致。
 
 ### タスク3: 申込完了 server action の 2通送信化
-- [ ] 完了
+- [x] 完了
 - **概要:** `setEntryApplied(true)` の初回遷移で、参加者向け（抽選日追記）と会計向け（2通目）を once-ever で送る。
 - **変更対象ファイル:**
   - `apps/web/src/app/(app)/events/[id]/actions.ts` — `setEntryApplied`：flip の `returning` に `lotteryDate` / `paymentMethod` / `paymentInfo` / `paymentDeadline` を追加。同一 tx で `entry_applied` と `entry_applied_treasurer` を claim。コミット後に 2 通 push（各 try/catch、best-effort）。cancelled は 2 通とも claim しない

--- a/docs/features/entry-notify-lottery-treasurer/implementation-plan.md
+++ b/docs/features/entry-notify-lottery-treasurer/implementation-plan.md
@@ -1,0 +1,79 @@
+---
+status: completed
+---
+# entry-notify-lottery-treasurer 実装手順書
+
+要件定義書: [requirements.md](./requirements.md)
+
+テストファースト（API/lib → 実装 → フロント → 実装 → E2E）で進める。
+スキーマ追加はすべて nullable / enum 値追加のみ（既存データ・既存挙動は非破壊）。
+すべて 1 PR（子 Issue を `Fixes` でまとめる）。**AI 抽出（schema.ts / prompt.ts）は本 PR では一切触らない**（title-split との衝突回避、要件 §5.3）。
+
+## 実装タスク
+
+### タスク1: DB スキーマ拡張 + migration
+- [x] 完了
+- **概要:** 抽選日カラムと、会計向け通知の once-ever 種別を追加する。非破壊（nullable + enum 値追加）。
+- **変更対象ファイル:**
+  - `packages/shared/src/schema/events.ts` — `lotteryDate: date('lottery_date', { mode: 'string' })`（nullable）を追加
+  - `packages/shared/src/schema/enums.ts` — `eventLifecycleNotificationTypeEnum` に `'entry_applied_treasurer'` を追加
+  - `packages/shared/drizzle/` — 新規 migration を `db:generate`（連番は最新+1。**現状 main は 0020（title-split #111 反映済）→ 0021**）
+- **依存タスク:** なし
+- **対応Issue:** #113
+- **完了条件:** `pnpm --filter @kagetra/shared check-types` green、migration が `lottery_date` 追加と `ADD VALUE 'entry_applied_treasurer'` を含む、shared の vitest が green。
+
+### タスク2: 通知文面テンプレの拡張（lib）
+- [ ] 完了
+- **概要:** 参加者向け（抽選日追記）と会計向け（振込方法・期限）の文面生成を追加する。push / claim / finalize は既存ヘルパーをそのまま使う。
+- **変更対象ファイル:**
+  - `apps/web/src/lib/event-lifecycle-notify.ts` — `LifecycleMessageContext` に `lotteryDateIso?` / `paymentMethod?` / `paymentInfo?` / `paymentDeadlineIso?`（or 既存 `dateIso` 流用）を追加。`buildLifecycleMessage` に `entry_applied` の抽選日追記と `entry_applied_treasurer` の文面（期限/方法/詳細、全空なら最小文面、金額は載せない）を実装。exhaustiveness guard に新ケース追加
+  - `apps/web/src/lib/event-lifecycle-notify.test.ts` — 抽選日あり/なし、会計向けの 期限のみ/方法のみ/詳細あり/全空、金額非表示 の各パターン
+- **依存タスク:** タスク1（enum 値が必要）
+- **対応Issue:** #114
+- **完了条件:** 上記ユニットテストが green、`buildLifecycleMessage` の戻り文字列が要件 §3.2.2 / §3.2.3 と一致。
+
+### タスク3: 申込完了 server action の 2通送信化
+- [ ] 完了
+- **概要:** `setEntryApplied(true)` の初回遷移で、参加者向け（抽選日追記）と会計向け（2通目）を once-ever で送る。
+- **変更対象ファイル:**
+  - `apps/web/src/app/(app)/events/[id]/actions.ts` — `setEntryApplied`：flip の `returning` に `lotteryDate` / `paymentMethod` / `paymentInfo` / `paymentDeadline` を追加。同一 tx で `entry_applied` と `entry_applied_treasurer` を claim。コミット後に 2 通 push（各 try/catch、best-effort）。cancelled は 2 通とも claim しない
+  - `apps/web/src/app/(app)/events/[id]/lifecycle-actions.test.ts` — 2 claim + 2 push、再トグルで再送なし（UNIQUE）、cancelled で送信なし、未紐付けで skipped＋スロット消費
+- **依存タスク:** タスク1・タスク2
+- **対応Issue:** #115
+- **完了条件:** 統合テスト green（`LINE_NOTIFY_DRY_RUN=1`）、`apps/web` check-types green。
+
+### タスク4: 抽選日の入力（フォーム + スキーマ + 作成/編集保存 + 参照表示）
+- [ ] 完了
+- **概要:** 抽選日を手動入力・保存できるようにする。詳細画面に参照表示（任意）。
+- **変更対象ファイル:**
+  - `apps/web/src/lib/form-schemas.ts` — `eventFormSchema` に `lotteryDate: optionalDateStr`、`extractEventFormData` に `lotteryDate: formData.get('lotteryDate')`
+  - `apps/web/src/components/events/event-form.tsx` — `defaultValues.lotteryDate` を受け、`name="lotteryDate"` の `date` 入力を締切群付近に追加
+  - `apps/web/src/app/(app)/events/new/page.tsx` — insert に `lotteryDate` 反映
+  - `apps/web/src/app/(app)/events/[id]/edit/page.tsx` — update に `lotteryDate` 反映、`defaultValues.lotteryDate` 受け渡し
+  - `apps/web/src/app/(app)/events/[id]/page.tsx` — 抽選日の参照表示（任意・参加費/締切と並べて、会員も参照可）
+  - `apps/web/src/lib/form-schemas.test.ts` / `apps/web/src/components/events/event-form.test.tsx` — `lotteryDate` のパース/描画テスト
+- **依存タスク:** タスク1
+- **対応Issue:** #116
+- **完了条件:** フォームスキーマ/コンポーネントのテスト green、新規作成・編集で `lottery_date` が保存・再表示される。
+- **注意（並行作業）:** `form-schemas.ts` は title-split も改修するため、マージ時に rebase で吸収（追加的変更）。`event-form.tsx` は title-split 側で「据え置き」想定だが、フィールド追加は additive に留める。
+
+### タスク5: E2E
+- [ ] 完了
+- **概要:** 抽選日入力 → 申込済トグル（DRY_RUN）→ 会員の参照のみ、までのハッピーパス。
+- **変更対象ファイル:**
+  - `apps/web/e2e/` — `/events/[id]/edit` で抽選日入力→保存、`/events/[id]` で申込済トグルが例外なく完了、会員には抽選日が参照のみ表示されること（既存の lifecycle / events E2E に追記 or 新規 spec）
+- **依存タスク:** タスク3・タスク4
+- **対応Issue:** #117
+- **完了条件:** E2E green、CI（型/lint/test/E2E）通過。
+
+## 実装順序
+1. タスク1（DB・依存なし）
+2. タスク2（lib・タスク1 に依存）
+3. タスク3（server action・タスク1,2 に依存）
+4. タスク4（フォーム/入力・タスク1 に依存。タスク2,3 と並行可）
+5. タスク5（E2E・タスク3,4 に依存）
+
+## マージ / 並行作業メモ
+- ブランチは **現在の main（title-split #111 反映済）から分岐**（`feature/entry-notify-lottery-treasurer` 想定）、worktree は `C:/tmp/...` に明示作成（Windows パス罠回避）。
+- **title-split は PR #111 でマージ済（`e664b3d`、migration 0020）→ 当初の衝突懸念は解消**。in-flight rebase 不要。`events.ts` / migration journal / `form-schemas.ts` は title-split 変更済みの上に追加するだけ（追加的）。
+- 抽選日の **AI 自動抽出は本 PR に含めない**。main に載った新 `EventUnitSchema`（`apps/mail-worker/src/classify/schema.ts`）へ `lottery_date` を追加＋プロンプト調整する **別 follow-up（本 PR の後）** で対応（要件 §5.3・§7）。

--- a/docs/features/entry-notify-lottery-treasurer/implementation-plan.md
+++ b/docs/features/entry-notify-lottery-treasurer/implementation-plan.md
@@ -58,7 +58,7 @@ status: completed
 - **注意（並行作業）:** `form-schemas.ts` は title-split も改修するため、マージ時に rebase で吸収（追加的変更）。`event-form.tsx` は title-split 側で「据え置き」想定だが、フィールド追加は additive に留める。
 
 ### タスク5: E2E
-- [ ] 完了
+- [x] 完了
 - **概要:** 抽選日入力 → 申込済トグル（DRY_RUN）→ 会員の参照のみ、までのハッピーパス。
 - **変更対象ファイル:**
   - `apps/web/e2e/` — `/events/[id]/edit` で抽選日入力→保存、`/events/[id]` で申込済トグルが例外なく完了、会員には抽選日が参照のみ表示されること（既存の lifecycle / events E2E に追記 or 新規 spec）

--- a/docs/features/entry-notify-lottery-treasurer/implementation-plan.md
+++ b/docs/features/entry-notify-lottery-treasurer/implementation-plan.md
@@ -43,7 +43,7 @@ status: completed
 - **完了条件:** 統合テスト green（`LINE_NOTIFY_DRY_RUN=1`）、`apps/web` check-types green。
 
 ### タスク4: 抽選日の入力（フォーム + スキーマ + 作成/編集保存 + 参照表示）
-- [ ] 完了
+- [x] 完了
 - **概要:** 抽選日を手動入力・保存できるようにする。詳細画面に参照表示（任意）。
 - **変更対象ファイル:**
   - `apps/web/src/lib/form-schemas.ts` — `eventFormSchema` に `lotteryDate: optionalDateStr`、`extractEventFormData` に `lotteryDate: formData.get('lotteryDate')`

--- a/docs/features/entry-notify-lottery-treasurer/requirements.md
+++ b/docs/features/entry-notify-lottery-treasurer/requirements.md
@@ -1,0 +1,236 @@
+---
+status: completed
+---
+
+# entry-notify-lottery-treasurer 要件定義書
+
+## 1. 概要
+
+### 目的
+既存の [`event-lifecycle-notify`](../event-lifecycle-notify/requirements.md)（PR #85・本番稼働中）の **申込完了通知** を、宛先の関心ごとに合わせて拡張する。
+申込完了（`entry_applied`）のタイミングで、同じ参加者 LINE グループへ次の 2 通を送る。
+
+1. **参加者向け**: 既存の申込完了メッセージに **抽選日** の案内を追記する。
+2. **会計向け**: 続けて 2 通目として、**振込方法・振込期限** を会計担当へ向けて送る。
+
+### 背景・動機
+- 現状、申込完了時に参加者グループへ送るのは `✅【〇〇大会】への参加申込が完了しました。` の 1 通のみ（[event-lifecycle-notify.ts](../../../apps/web/src/lib/event-lifecycle-notify.ts) の `entry_applied`）。
+- 申込が通ると参加者は「**抽選はいつあるのか**（自分が出られるか、いつ分かるか）」を知りたい。今は別途口頭で連絡している。
+- 会計担当は会で集めた参加費を主催者へ振り込む役割で、申込完了時に「**どう振り込むか・いつまでか**」を把握する必要がある。これも今は手動連絡で漏れやすい。
+- これらの情報のうち **振込方法・期限・参加費は既に events に構造化済み**（`payment_method` / `payment_info` / `payment_deadline` / `fee_jpy`、[events.ts](../../../packages/shared/src/schema/events.ts)）。一方 **抽選日のカラムは存在しない**（新設が必要）。
+
+### 位置付け
+`event-lifecycle-notify` の延長。通知経路（紐付け済み参加者グループ）・push 基盤（[event-lifecycle-notify.ts](../../../apps/web/src/lib/event-lifecycle-notify.ts) の `pushTextToEventGroup`）・once-ever ログ基盤（`event_lifecycle_notifications`）をそのまま再利用する。**新しい通知先（会計ロール／会計専用チャネル）は作らない**。
+
+---
+
+## 2. ユーザーストーリー
+
+### 対象ユーザー
+- **管理者 / 副管理者**（`admin` / `vice_admin`、実質 1 名）: 抽選日・振込情報を入力し、申込状態を「申込済」にする。
+- **大会参加者**: 紐付け済み LINE グループで申込完了＋抽選日の案内を受け取る。
+- **会計担当**: 同じ参加者グループ内で、会計向けの 2 通目（振込方法・期限）を受け取る。専用の宛先・ロールは設けず、グループ内で「会計の方へ」と呼びかける形にする。
+
+### 利用シナリオ
+
+**シナリオ A: 抽選ありの大会で申込完了**
+1. 管理者が大会編集画面で **抽選日**（例 1/20）と、必要なら振込方法・振込期限を入力しておく。
+2. 出欠が固まり、主催者へ申込を提出。管理者が `/events/[id]` の進行管理で「申込済」にする。
+3. Bot が参加者グループへ 2 通を push:
+   - 参加者向け: `✅【〇〇大会】への参加申込が完了しました。\n抽選日は 1/20 です。`
+   - 会計向け: `💴【〇〇大会】会計の方へ\n振込期限：1/25\n振込方法：◯◯銀行 …`
+
+**シナリオ B: 抽選なしの大会（先着・全員参加）**
+1. 抽選日を入力しない（`lottery_date` = NULL）。
+2. 「申込済」にすると参加者向けは **従来どおり** `✅【〇〇大会】への参加申込が完了しました。`（抽選日の行は出ない）。
+3. 会計向けの 2 通目は従来どおり送る（振込情報があれば載る）。
+
+**シナリオ C: 振込情報が未入力 / 現地払い**
+1. 振込方法・期限が未入力、または現地払いの大会でも、会計向けの 2 通目は **常に送る**（支払いタイプで出し分けない）。
+2. 載せる項目が何も無ければ、`💴【〇〇大会】会計の方へ\n参加費の振込手続きをお願いします。振込方法・期限は大会ページでご確認ください。` の最小文面を送る。
+
+**シナリオ D: 再トグル・cancelled**
+1. 誤って未申込へ戻して再度申込済にしても **2 通とも再送しない**（種別ごとに once-ever）。
+2. cancelled の大会では 2 通とも送らない（状態変更のみ記録、既存 `entry_applied` と対称）。
+
+**シナリオ E: LINE グループ未紐付けの大会**
+1. Bot が招待されていない大会では 2 通とも送らない（既存 `pushTextToEventGroup` が `skipped` を返す）。once-ever スロットは消費する（バックフィル防止、既存方針と一貫）。
+
+---
+
+## 3. 機能要件
+
+### 3.1 画面仕様
+
+#### 3.1.1 抽選日の入力（イベント新規作成・編集フォーム）
+[event-form.tsx](../../../apps/web/src/components/events/event-form.tsx) に **抽選日**（`lotteryDate`）の `date` 入力を 1 つ追加する。配置は「大会申込締切 / 会内締切」付近が自然。`admin` / `vice_admin` のみが新規作成・編集できる（既存の権限と同じ）。
+
+- 任意項目。未入力なら NULL（抽選なしを意味する）。
+- 反映先: `/events/new`（作成）と `/events/[id]/edit`（編集）の両方。
+
+#### 3.1.2 抽選日の参照表示（任意）
+イベント詳細 [/events/[id]](../../../apps/web/src/app/(app)/events/[id]/page.tsx) に抽選日が設定されていれば表示する（参加費・締切と並べて）。会員にも参照のみ表示。
+
+#### 3.1.3 申込完了トグル
+進行管理セクションの「申込済」トグルは既存のまま（[EventLifecycleSection.tsx](../../../apps/web/src/components/events/EventLifecycleSection.tsx)）。挙動が「2 通送る」に変わるだけで UI は不変。確認モーダルの文言だけ「参加者向け・会計向けの通知が送られます」に更新してもよい（任意）。
+
+### 3.2 ビジネスルール
+
+#### 3.2.1 通知トリガー（申込完了時の 2 通）
+| 種別 | 宛先 | 文面 | トリガー | 1 回限り保証 |
+|---|---|---|---|---|
+| 申込完了 (`entry_applied`) | 参加者グループ | `✅…申込が完了しました。`＋（抽選日があれば）`抽選日は M/D です。` | 未申込→申込済 の初回遷移（既存） | `(event_id,'entry_applied')` UNIQUE（既存） |
+| 会計向け振込案内 (`entry_applied_treasurer`) **新規** | 同じ参加者グループ（2 通目） | `💴…会計の方へ`＋振込期限／振込方法／支払情報（あるものだけ） | 同上（同じ申込完了の初回遷移） | `(event_id,'entry_applied_treasurer')` UNIQUE（新規） |
+
+- 2 通とも **同じトリガー**（`setEntryApplied(eventId, true)` の初回遷移）で送る。経路は同じ紐付け済み参加者グループ。
+
+#### 3.2.2 参加者向け（`entry_applied`）文面の拡張
+- `lottery_date` が **非 NULL** のとき、既存メッセージの末尾に改行＋ `抽選日は {M/D} です。` を追記。
+- `lottery_date` が NULL のときは **従来どおり**（追記なし）。
+- 日付整形は既存の `formatMMDD`（`M/D`、ゼロ埋めなし）を流用。
+
+#### 3.2.3 会計向け（`entry_applied_treasurer`）文面
+- ヘッダ: `💴【{title}】会計の方へ`
+- 本文（値があるものだけを行として連結）:
+  - `payment_deadline` があれば `振込期限：{M/D}`
+  - `payment_method` があれば `振込方法：{payment_method}`
+  - `payment_info` があれば `{payment_info}`（口座番号等の詳細。自由記述をそのまま）
+- 上記いずれも空なら: `参加費の振込手続きをお願いします。振込方法・期限は大会ページでご確認ください。`
+- **金額（`fee_jpy`）は載せない**（会計が集めた額を主催者へ振り込むため、1 人あたり額の併記はしない＝ユーザー確定）。
+- **支払いタイプ（`payment_type`）では出し分けない**（事前払い／現地払い／未設定いずれでも常に送る＝ユーザー確定）。
+
+> ※ 正確な文面・改行・絵文字はドラフトレビューで微調整可。
+
+#### 3.2.4 通知の前提条件（既存 `entry_applied` と同一・2 通共通）
+1. 当該 event に `event_line_broadcasts.status='linked'` かつ `line_group_id` がある（無ければ送信せず `skipped`）。
+2. event が `cancelled` でない（cancelled なら 2 通とも claim せず送らない。状態変更のみ記録）。
+3. 同じ `(event, 種別)` の `event_lifecycle_notifications` 行がまだ無い（once-ever）。
+
+#### 3.2.5 重複防止（once-ever）
+- `entry_applied` と `entry_applied_treasurer` は **別スロット**（種別ごとに `(event_id, type)` UNIQUE）。
+- 申込完了の server action のトランザクション内で **両方を claim**（INSERT ON CONFLICT DO NOTHING）し、コミット後にそれぞれ push（既存 `claimLifecycleNotification` → `sendClaimedNotification` を 2 回）。
+- 片方の push が失敗してももう片方には影響しない。失敗はログ `failed` で記録、best-effort（既存 §3.2.3 と同じ、自動再送なし）。
+
+### 3.3 権限
+- 抽選日・振込情報の入力、申込済トグル: `admin` / `vice_admin` のみ（既存と同じ）。
+- 一般会員: 抽選日の参照のみ。
+
+---
+
+## 4. 技術設計
+
+### 4.1 DB 設計
+
+#### `events` テーブル変更（カラム追加）
+| カラム | 型 | 制約 | 説明 |
+|---|---|---|---|
+| lottery_date | date (mode:'string') | NULL | 抽選日。NULL=抽選なし。手動入力（AI 抽出は別 follow-up） |
+
+- 既存 `payment_method` / `payment_info` / `payment_deadline` / `fee_jpy` は流用（変更なし）。
+
+#### Enum 追加
+- `event_lifecycle_notification_type`（[enums.ts](../../../packages/shared/src/schema/enums.ts)）に **`entry_applied_treasurer`** を追加（既存 8 種＋1）。
+
+#### Migration
+単一 migration（次番号は実装時に最新を再確認。**現状 main は 0020 まで（title-split #111 反映済）→ 0021**）。
+- `events.lottery_date` 追加（nullable、既存行は NULL）。
+- enum `event_lifecycle_notification_type` に値追加（`ALTER TYPE … ADD VALUE`）。
+- 本番は `db:migrate`（journal ベース・非 interactive、[feedback](../../../.claude/memory) 参照）。
+- **注意（並行作業・解消済）**: title-split は **PR #111 でマージ済**（migration 0020）。本 PR は現在の main から分岐すれば番号衝突なし（**0021**）。詳細は §5.3。
+
+### 4.2 バックエンド設計
+
+#### `apps/web/src/lib/event-lifecycle-notify.ts`（既存ファイルに追加）
+- `LifecycleNotificationType` に `entry_applied_treasurer` が自動で増える（enum 由来）。
+- `LifecycleMessageContext` に任意フィールドを追加:
+  - `lotteryDateIso?: string | null`（参加者向け追記用）
+  - `paymentMethod?: string | null` / `paymentInfo?: string | null`（会計向け用。期限は既存 `dateIso` を流用するか専用フィールドを足す）
+- `buildLifecycleMessage` に 2 ケースを反映:
+  - `entry_applied`: `lotteryDateIso` があれば末尾に `\n抽選日は {M/D} です。` を追記。
+  - `entry_applied_treasurer`: §3.2.3 の文面を組み立て（空項目はスキップ、全空なら最小文面）。
+  - exhaustiveness guard（`never`）に新ケースを追加（追加忘れはコンパイルエラー）。
+- push / claim / finalize ヘルパーは既存をそのまま使う（変更なし）。
+
+#### `apps/web/src/app/(app)/events/[id]/actions.ts` の `setEntryApplied` 拡張
+- 状態 flip の `returning` に `lotteryDate` / `paymentMethod` / `paymentInfo` / `paymentDeadline` を追加。
+- 同一トランザクション内で `claimLifecycleNotification(tx, eventId, 'entry_applied')` に加えて `claimLifecycleNotification(tx, eventId, 'entry_applied_treasurer')` も実行。
+- コミット後、claim できたものについて `sendClaimedNotification` を **2 回**（participant / treasurer）。各 push は try/catch（best-effort、既存と同じ）。
+- cancelled のときは 2 通とも claim しない（既存の早期 return を踏襲）。
+- `setPaymentType` / `setPaymentPaid` は変更なし。
+
+#### イベント新規作成・編集
+- [events/new/page.tsx](../../../apps/web/src/app/(app)/events/new/page.tsx) と [events/[id]/edit/page.tsx](../../../apps/web/src/app/(app)/events/[id]/edit/page.tsx) の server action（insert/update events）で `lotteryDate` を保存。
+- 編集画面の `defaultValues` に `lotteryDate` を渡す。
+
+#### フォームスキーマ
+- [form-schemas.ts](../../../apps/web/src/lib/form-schemas.ts) の `eventFormSchema` に `lotteryDate: optionalDateStr` を追加。`extractEventFormData` に `lotteryDate: formData.get('lotteryDate')` を追加。
+- **注意（並行作業）**: title-split も form-schemas.ts を改修するため軽微な衝突可能性（§5.3）。
+
+### 4.3 フロントエンド設計
+- [event-form.tsx](../../../apps/web/src/components/events/event-form.tsx): `defaultValues.lotteryDate?: string | null` を追加し、`name="lotteryDate"` の `date` 入力を 1 つ描画（締切群の近く）。
+- 進行管理 UI（`EventLifecycleSection`）の確認モーダル文言を必要なら更新（任意）。
+- イベント詳細での抽選日表示（任意・3.1.2）。
+
+### 4.4 環境変数 / 設定
+- 追加なし（push 基盤・`LINE_NOTIFY_DRY_RUN` 等は既存を流用）。日次バッチ・systemd の追加もなし（トリガーは申込完了 server action のみ）。
+
+---
+
+## 5. 影響範囲
+
+### 5.1 変更が必要な既存ファイル
+- `packages/shared/src/schema/events.ts`: `lotteryDate` カラム追加。
+- `packages/shared/src/schema/enums.ts`: `event_lifecycle_notification_type` に `entry_applied_treasurer` 追加。
+- `packages/shared/drizzle/`: 新規 migration 1 本（lottery_date 追加＋enum 値追加）。
+- `apps/web/src/lib/event-lifecycle-notify.ts`: `LifecycleMessageContext` 拡張、`buildLifecycleMessage` に 2 ケース反映。
+- `apps/web/src/app/(app)/events/[id]/actions.ts`: `setEntryApplied` を 2 通送信に拡張。
+- `apps/web/src/lib/form-schemas.ts`: `lotteryDate` のパース追加。
+- `apps/web/src/components/events/event-form.tsx`: 抽選日入力欄追加。
+- `apps/web/src/app/(app)/events/new/page.tsx` / `events/[id]/edit/page.tsx`: lottery_date 保存・defaultValues。
+- 各 `*.test.ts(x)`: 文面生成・`setEntryApplied`・フォームスキーマ・E2E の更新／追加。
+
+### 5.2 既存機能への影響
+- **event-lifecycle-notify**: `entry_applied` の文面が「抽選日があれば追記」に変わる（抽選日 NULL の既存挙動は不変）。`payment_deadline` リマインド等の他種別は不変。
+- **mail-tournament-import / 承認画面**: **本 PR では触らない**。AI 抽出での抽選日取得と承認画面での入力は、**別の AI 抽出 follow-up（本 PR の後）** に分離（§5.3）。承認直後の段階では `lottery_date` は NULL、管理者が編集画面で後から入力できる。
+- **既存 events 行**: `lottery_date` は NULL で入る（抽選なし扱い）。副作用なし。
+- 公開 HTTP エンドポイント・webhook の追加なし。systemd / cron の追加なし。
+
+### 5.3 並行作業（tournament-title-split）— 解消済
+`feature/tournament-title-split` は **PR #111 で main にマージ済**（merge `e664b3d`、migration 0020、本番反映済 2026-06-04）。AI 抽出（[schema.ts](../../../apps/mail-worker/src/classify/schema.ts) / [prompt.ts](../../../apps/mail-worker/src/classify/prompt.ts)）は既に `events[]` 配列形（PROMPT_VERSION 2.0.0）へ作り替え済みで main に載っている。**当初懸念したブロッキング衝突は解消**。
+
+- **段取り**: 本機能は **現在の main（title-split 反映済）から分岐**して独立 PR 化。in-flight ブランチへの rebase は不要。migration は **0021**。
+- **AI 抽出 follow-up（別 PR・本 PR の後）**: 抽選日の AI 自動抽出は、main に載った新 `EventUnitSchema`（[schema.ts](../../../apps/mail-worker/src/classify/schema.ts)）へ `lottery_date` を追加＋プロンプト調整する別 PR で対応。
+- 共有ファイル（`events.ts` / migration journal / `form-schemas.ts`）は title-split が既に変更済み。本 PR はその上に**追加するだけ**（追加的・衝突なし）。
+
+---
+
+## 6. 設計判断の根拠
+
+1. **会計向けを「新ロール・新経路」にせず参加者グループへ同送**（ユーザー確定）: 会計専用チャネルやロール追加は重い。同じグループに 2 通目として「会計の方へ」と呼びかければ、既存の push・紐付け基盤をそのまま使え、改修が最小。
+2. **2 通に分ける（1 通統合にしない）**（ユーザー確定）: 参加者向けと会計向けで関心ごと・宛先が違うため、視覚的に分かれていた方が読みやすい。once-ever も種別ごとに独立管理できる。
+3. **会計向けは支払いタイプで出し分けず常に送る**（ユーザー確定）: 「申込が済んだら会計に振込の段取りを知らせる」を確実にする。現地払い・未設定でも最小文面で送り、抜けを作らない。
+4. **金額は載せない**（ユーザー確定）: 会計が振り込むのは集めた合計で、1 人あたり額（`fee_jpy`）の併記は計算式（チーム料金・割引）次第で誤解を生む。期日と振込方法だけを正確に伝える。
+5. **抽選日は専用カラム（手動入力）を新設、AI 抽出は後回し**（ユーザー確定＋並行作業回避）: 文面差し込みには構造化された日付が要る。AI 抽出はスキーマを作り替え中の title-split と衝突するため、まず手動入力で機能を成立させ、AI 抽出は title-split マージ後の小 follow-up に分離。
+6. **`entry_applied_treasurer` を独立 enum 種別にする**: 「申込完了」と「会計向け案内」を別スロットで once-ever 管理すると、再トグル・cron 再実行に強く、送信成否も種別ごとに監査できる（既存の「1 種別 = 1 スロット」設計と一貫）。
+7. **トリガーは申込完了の server action のみ（日次バッチを足さない）**: ユーザー要望は「申込完了時に」。締切リマインドは既存 `payment_deadline_*` が担っており、本機能で新規バッチは不要。
+
+---
+
+## 7. 範囲外
+- 抽選 **結果**（通過／落選など）の通知（ユーザー確定: 今回は抽選「日」の告知のみ）。
+- 抽選日の **AI 自動抽出**（title-split マージ後の別 follow-up）。
+- 会計専用ロール・会計専用 LINE グループ／チャネルの新設。
+- 会計向け金額（合計・1 人あたり）の併記。
+- 申込締切リマインドへの会計向け文面追加（本機能は申込完了時のみ。締切系は既存のまま）。
+- 通知文面の編集 UI（固定テンプレ、将来拡張点）。
+
+---
+
+## 8. 開発・テスト戦略
+- **ユニット（Vitest）**:
+  - `buildLifecycleMessage('entry_applied', …)`: 抽選日あり／なしの両分岐。
+  - `buildLifecycleMessage('entry_applied_treasurer', …)`: 期限のみ／方法のみ／詳細あり／全空（最小文面）の各パターン、金額を載せないこと。
+  - `eventFormSchema` / `extractEventFormData` の `lotteryDate` パース（空→NULL、形式不正で弾く）。
+- **統合（Vitest + 実 DB）**: `setEntryApplied(true)` の初回遷移で `entry_applied` と `entry_applied_treasurer` の 2 行が claim され、2 通 push されること（`LINE_NOTIFY_DRY_RUN=1`）。再トグルで再送されないこと（UNIQUE）。cancelled で 2 通とも送られないこと。未紐付けで `skipped`・スロット消費されること。
+- **E2E（Playwright）**: `/events/[id]/edit` で抽選日を入力→保存、`/events/[id]` で申込済トグル（DRY_RUN 下で例外なく完了）。会員には抽選日が参照のみで表示されること。
+- **デプロイ**: migration（`db:migrate`）→ apps/web リビルド（static cp 忘れ注意）→ DRY_RUN で 1 大会動作確認 → 本番。新規 systemd / cron なし。

--- a/packages/shared/__tests__/schema-lifecycle.test.ts
+++ b/packages/shared/__tests__/schema-lifecycle.test.ts
@@ -24,6 +24,9 @@ describe('event-lifecycle-notify schema', () => {
       'payment_deadline_day',
       'onsite_payment_advance',
       'onsite_payment_day',
+      // entry-notify-lottery-treasurer: 申込完了時の 2 通目（会計向け振込案内）。完了トリガー
+      // 由来で daily batch は走査しない（reminder batch は type を明示指定するため、末尾追加は安全）。
+      'entry_applied_treasurer',
     ])
     expect(eventLifecycleNotificationStatusEnum.enumValues).toEqual(['sent', 'failed', 'skipped'])
   })

--- a/packages/shared/drizzle/0021_amazing_mentor.sql
+++ b/packages/shared/drizzle/0021_amazing_mentor.sql
@@ -1,0 +1,2 @@
+ALTER TYPE "public"."event_lifecycle_notification_type" ADD VALUE 'entry_applied_treasurer';--> statement-breakpoint
+ALTER TABLE "events" ADD COLUMN "lottery_date" date;

--- a/packages/shared/drizzle/meta/0021_snapshot.json
+++ b/packages/shared/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,2764 @@
+{
+  "id": "fc9c985b-520a-434a-a2d7-a57d1b333832",
+  "prevId": "63c9abb3-c847-4ae7-b86f-707af9f6d5db",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_user_id": {
+          "name": "line_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "grade": {
+          "name": "grade",
+          "type": "grade",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_invited": {
+          "name": "is_invited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affiliation": {
+          "name": "affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dan": {
+          "name": "dan",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zen_nichikyo": {
+          "name": "zen_nichikyo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_linked_at": {
+          "name": "line_linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_link_method": {
+          "name": "line_link_method",
+          "type": "line_link_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notification_line_user_id": {
+          "name": "notification_line_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_name_unique": {
+          "name": "users_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_line_user_id_unique": {
+          "name": "users_line_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "line_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_dan_range": {
+          "name": "users_dan_range",
+          "value": "\"users\".\"dan\" BETWEEN 0 AND 9 OR \"users\".\"dan\" IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_groups": {
+      "name": "event_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_groups_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_groups_name_unique": {
+          "name": "event_groups_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "events_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formal_name": {
+          "name": "formal_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official": {
+          "name": "official",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'individual'"
+        },
+        "entry_deadline": {
+          "name": "entry_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_deadline": {
+          "name": "internal_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_group_id": {
+          "name": "event_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligible_grades": {
+          "name": "eligible_grades",
+          "type": "grade[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_jpy": {
+          "name": "fee_jpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_deadline": {
+          "name": "payment_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lottery_date": {
+          "name": "lottery_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_info": {
+          "name": "payment_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_method": {
+          "name": "entry_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizer": {
+          "name": "organizer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_a": {
+          "name": "capacity_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_b": {
+          "name": "capacity_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_c": {
+          "name": "capacity_c",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_d": {
+          "name": "capacity_d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_e": {
+          "name": "capacity_e",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_status": {
+          "name": "entry_status",
+          "type": "event_entry_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_applied'"
+        },
+        "entry_applied_at": {
+          "name": "entry_applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_type": {
+          "name": "payment_type",
+          "type": "event_payment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "event_payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unpaid'"
+        },
+        "payment_paid_at": {
+          "name": "payment_paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournament_draft_id": {
+          "name": "tournament_draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournament_draft_unit_key": {
+          "name": "tournament_draft_unit_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_tournament_draft_unit_key_uniq": {
+          "name": "events_tournament_draft_unit_key_uniq",
+          "columns": [
+            {
+              "expression": "tournament_draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tournament_draft_unit_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"events\".\"tournament_draft_id\" IS NOT NULL AND \"events\".\"tournament_draft_unit_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_created_by_users_id_fk": {
+          "name": "events_created_by_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_event_group_id_event_groups_id_fk": {
+          "name": "events_event_group_id_event_groups_id_fk",
+          "tableFrom": "events",
+          "tableTo": "event_groups",
+          "columnsFrom": [
+            "event_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_attendances": {
+      "name": "event_attendances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_attendances_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attend": {
+          "name": "attend",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_attendances_event_id_events_id_fk": {
+          "name": "event_attendances_event_id_events_id_fk",
+          "tableFrom": "event_attendances",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_attendances_user_id_users_id_fk": {
+          "name": "event_attendances_user_id_users_id_fk",
+          "tableFrom": "event_attendances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_attendances_event_id_user_id_unique": {
+          "name": "event_attendances_event_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_items": {
+      "name": "schedule_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "schedule_items_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "schedule_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_items_owner_id_users_id_fk": {
+          "name": "schedule_items_owner_id_users_id_fk",
+          "tableFrom": "schedule_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_messages": {
+      "name": "mail_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_messages_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_addresses": {
+          "name": "to_addresses",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_message_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "mail_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imap_uid": {
+          "name": "imap_uid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imap_box": {
+          "name": "imap_box",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "triage_status": {
+          "name": "triage_status",
+          "type": "mail_triage_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unprocessed'"
+        },
+        "triaged_at": {
+          "name": "triaged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triaged_by_user_id": {
+          "name": "triaged_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_messages_received_at_desc_idx": {
+          "name": "mail_messages_received_at_desc_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_messages_triage_status_idx": {
+          "name": "mail_messages_triage_status_idx",
+          "columns": [
+            {
+              "expression": "triage_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_messages_triaged_by_user_id_users_id_fk": {
+          "name": "mail_messages_triaged_by_user_id_users_id_fk",
+          "tableFrom": "mail_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triaged_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mail_messages_message_id_unique": {
+          "name": "mail_messages_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_attachments": {
+      "name": "mail_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_attachments_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "mail_message_id": {
+          "name": "mail_message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extracted_text": {
+          "name": "extracted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_status": {
+          "name": "extraction_status",
+          "type": "attachment_extraction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mail_attachments_mail_message_id_idx": {
+          "name": "mail_attachments_mail_message_id_idx",
+          "columns": [
+            {
+              "expression": "mail_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_attachments_mail_message_id_mail_messages_id_fk": {
+          "name": "mail_attachments_mail_message_id_mail_messages_id_fk",
+          "tableFrom": "mail_attachments",
+          "tableTo": "mail_messages",
+          "columnsFrom": [
+            "mail_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tournament_drafts": {
+      "name": "tournament_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tournament_drafts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tournament_draft_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_correction": {
+          "name": "is_correction",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "references_subject": {
+          "name": "references_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_by_draft_id": {
+          "name": "superseded_by_draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracted_payload": {
+          "name": "extracted_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ai_raw_response": {
+          "name": "ai_raw_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_tokens_input": {
+          "name": "ai_tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_tokens_output": {
+          "name": "ai_tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_cost_usd": {
+          "name": "ai_cost_usd",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by_user_id": {
+          "name": "rejected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_drafts_status_created": {
+          "name": "idx_drafts_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tournament_drafts_message_id_mail_messages_id_fk": {
+          "name": "tournament_drafts_message_id_mail_messages_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "mail_messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tournament_drafts_event_id_events_id_fk": {
+          "name": "tournament_drafts_event_id_events_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tournament_drafts_approved_by_user_id_users_id_fk": {
+          "name": "tournament_drafts_approved_by_user_id_users_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tournament_drafts_rejected_by_user_id_users_id_fk": {
+          "name": "tournament_drafts_rejected_by_user_id_users_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "rejected_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tournament_drafts_message_id_unique": {
+          "name": "tournament_drafts_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tournament_drafts_confidence_range": {
+          "name": "tournament_drafts_confidence_range",
+          "value": "\"tournament_drafts\".\"confidence\" BETWEEN 0 AND 1 OR \"tournament_drafts\".\"confidence\" IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.line_channels": {
+      "name": "line_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "line_channels_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_secret": {
+          "name": "channel_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_access_token": {
+          "name": "channel_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "line_channel_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "line_channel_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system_notify'"
+        },
+        "assigned_user_id": {
+          "name": "assigned_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_event_id": {
+          "name": "assigned_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_destination_id": {
+          "name": "webhook_destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_line_user_id": {
+          "name": "notification_line_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "line_channels_assigned_user_id_users_id_fk": {
+          "name": "line_channels_assigned_user_id_users_id_fk",
+          "tableFrom": "line_channels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "line_channels_assigned_event_id_events_id_fk": {
+          "name": "line_channels_assigned_event_id_events_id_fk",
+          "tableFrom": "line_channels",
+          "tableTo": "events",
+          "columnsFrom": [
+            "assigned_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "line_channels_channel_id_unique": {
+          "name": "line_channels_channel_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "channel_id"
+          ]
+        },
+        "line_channels_assigned_user_id_unique": {
+          "name": "line_channels_assigned_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "assigned_user_id"
+          ]
+        },
+        "line_channels_assigned_event_id_unique": {
+          "name": "line_channels_assigned_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "assigned_event_id"
+          ]
+        },
+        "line_channels_webhook_destination_id_unique": {
+          "name": "line_channels_webhook_destination_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "webhook_destination_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_worker_jobs": {
+      "name": "mail_worker_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_worker_jobs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "since": {
+          "name": "since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_worker_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_mail_worker_jobs_status_requested_at": {
+          "name": "idx_mail_worker_jobs_status_requested_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_worker_jobs_requested_by_user_id_users_id_fk": {
+          "name": "mail_worker_jobs_requested_by_user_id_users_id_fk",
+          "tableFrom": "mail_worker_jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mail_worker_jobs_run_id_mail_worker_runs_id_fk": {
+          "name": "mail_worker_jobs_run_id_mail_worker_runs_id_fk",
+          "tableFrom": "mail_worker_jobs",
+          "tableTo": "mail_worker_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_worker_runs": {
+      "name": "mail_worker_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_worker_runs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "mail_worker_run_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_worker_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_user_id": {
+          "name": "triggered_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "since": {
+          "name": "since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_worker_runs_triggered_by_user_id_users_id_fk": {
+          "name": "mail_worker_runs_triggered_by_user_id_users_id_fk",
+          "tableFrom": "mail_worker_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggered_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_line_broadcasts": {
+      "name": "event_line_broadcasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_line_broadcasts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_channel_id": {
+          "name": "line_channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code_expires_at": {
+          "name": "invite_code_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_group_id": {
+          "name": "line_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_line_broadcast_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invite_pending'"
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extended_until": {
+          "name": "extended_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoke_reason": {
+          "name": "revoke_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_line_broadcasts_invite_code_active_uq": {
+          "name": "event_line_broadcasts_invite_code_active_uq",
+          "columns": [
+            {
+              "expression": "invite_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"event_line_broadcasts\".\"invite_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_line_broadcasts_event_id_events_id_fk": {
+          "name": "event_line_broadcasts_event_id_events_id_fk",
+          "tableFrom": "event_line_broadcasts",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "event_line_broadcasts_line_channel_id_line_channels_id_fk": {
+          "name": "event_line_broadcasts_line_channel_id_line_channels_id_fk",
+          "tableFrom": "event_line_broadcasts",
+          "tableTo": "line_channels",
+          "columnsFrom": [
+            "line_channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_line_broadcasts_event_id_unique": {
+          "name": "event_line_broadcasts_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_broadcast_messages": {
+      "name": "event_broadcast_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_broadcast_messages_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_line_broadcast_id": {
+          "name": "event_line_broadcast_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mail_message_id": {
+          "name": "mail_message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "event_broadcast_message_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "is_correction": {
+          "name": "is_correction",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sent_text_count": {
+          "name": "sent_text_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_image_count": {
+          "name": "sent_image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "fallback_link_count": {
+          "name": "fallback_link_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_broadcast_messages_event_line_broadcast_id_event_line_broadcasts_id_fk": {
+          "name": "event_broadcast_messages_event_line_broadcast_id_event_line_broadcasts_id_fk",
+          "tableFrom": "event_broadcast_messages",
+          "tableTo": "event_line_broadcasts",
+          "columnsFrom": [
+            "event_line_broadcast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_broadcast_messages_mail_message_id_mail_messages_id_fk": {
+          "name": "event_broadcast_messages_mail_message_id_mail_messages_id_fk",
+          "tableFrom": "event_broadcast_messages",
+          "tableTo": "mail_messages",
+          "columnsFrom": [
+            "mail_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_broadcast_messages_broadcast_mail_uq": {
+          "name": "event_broadcast_messages_broadcast_mail_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_line_broadcast_id",
+            "mail_message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachment_share_tokens": {
+      "name": "attachment_share_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "attachment_share_tokens_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "mail_attachment_id": {
+          "name": "mail_attachment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attachment_share_tokens_attachment_idx": {
+          "name": "attachment_share_tokens_attachment_idx",
+          "columns": [
+            {
+              "expression": "mail_attachment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachment_share_tokens_expires_at_idx": {
+          "name": "attachment_share_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attachment_share_tokens_mail_attachment_id_mail_attachments_id_fk": {
+          "name": "attachment_share_tokens_mail_attachment_id_mail_attachments_id_fk",
+          "tableFrom": "attachment_share_tokens",
+          "tableTo": "mail_attachments",
+          "columnsFrom": [
+            "mail_attachment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "attachment_share_tokens_mail_attachment_id_unique": {
+          "name": "attachment_share_tokens_mail_attachment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mail_attachment_id"
+          ]
+        },
+        "attachment_share_tokens_token_unique": {
+          "name": "attachment_share_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_lifecycle_notifications": {
+      "name": "event_lifecycle_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_lifecycle_notifications_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "event_lifecycle_notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "event_lifecycle_notification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sent'"
+        },
+        "line_group_id": {
+          "name": "line_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_lifecycle_notifications_event_type_uq": {
+          "name": "event_lifecycle_notifications_event_type_uq",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_lifecycle_notifications_event_id_events_id_fk": {
+          "name": "event_lifecycle_notifications_event_id_events_id_fk",
+          "tableFrom": "event_lifecycle_notifications",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "push_subscriptions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_id_idx": {
+          "name": "push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_id_fk": {
+          "name": "push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_subscriptions_endpoint_unique": {
+          "name": "push_subscriptions_endpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "endpoint"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attachment_extraction_status": {
+      "name": "attachment_extraction_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "extracted",
+        "failed",
+        "unsupported"
+      ]
+    },
+    "public.event_broadcast_message_status": {
+      "name": "event_broadcast_message_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sending",
+        "sent",
+        "partial",
+        "failed"
+      ]
+    },
+    "public.event_entry_status": {
+      "name": "event_entry_status",
+      "schema": "public",
+      "values": [
+        "not_applied",
+        "applied"
+      ]
+    },
+    "public.event_kind": {
+      "name": "event_kind",
+      "schema": "public",
+      "values": [
+        "individual",
+        "team"
+      ]
+    },
+    "public.event_lifecycle_notification_status": {
+      "name": "event_lifecycle_notification_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.event_lifecycle_notification_type": {
+      "name": "event_lifecycle_notification_type",
+      "schema": "public",
+      "values": [
+        "entry_applied",
+        "entry_deadline_advance",
+        "entry_deadline_day",
+        "payment_paid",
+        "payment_deadline_advance",
+        "payment_deadline_day",
+        "onsite_payment_advance",
+        "onsite_payment_day",
+        "entry_applied_treasurer"
+      ]
+    },
+    "public.event_line_broadcast_status": {
+      "name": "event_line_broadcast_status",
+      "schema": "public",
+      "values": [
+        "invite_pending",
+        "joined_waiting_code",
+        "linked",
+        "revoked",
+        "released"
+      ]
+    },
+    "public.event_payment_status": {
+      "name": "event_payment_status",
+      "schema": "public",
+      "values": [
+        "unpaid",
+        "paid"
+      ]
+    },
+    "public.event_payment_type": {
+      "name": "event_payment_type",
+      "schema": "public",
+      "values": [
+        "advance",
+        "onsite"
+      ]
+    },
+    "public.event_status": {
+      "name": "event_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "cancelled",
+        "done"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female"
+      ]
+    },
+    "public.grade": {
+      "name": "grade",
+      "schema": "public",
+      "values": [
+        "A",
+        "B",
+        "C",
+        "D",
+        "E"
+      ]
+    },
+    "public.line_channel_purpose": {
+      "name": "line_channel_purpose",
+      "schema": "public",
+      "values": [
+        "system_notify",
+        "event_broadcast"
+      ]
+    },
+    "public.line_channel_status": {
+      "name": "line_channel_status",
+      "schema": "public",
+      "values": [
+        "available",
+        "assigned",
+        "active",
+        "system",
+        "disabled"
+      ]
+    },
+    "public.line_link_method": {
+      "name": "line_link_method",
+      "schema": "public",
+      "values": [
+        "self_identify",
+        "admin_link",
+        "account_switch"
+      ]
+    },
+    "public.mail_classification": {
+      "name": "mail_classification",
+      "schema": "public",
+      "values": [
+        "tournament",
+        "noise",
+        "unknown"
+      ]
+    },
+    "public.mail_message_status": {
+      "name": "mail_message_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "fetched",
+        "parse_failed",
+        "fetch_failed",
+        "ai_processing",
+        "ai_done",
+        "ai_failed",
+        "oversize_skipped",
+        "archived"
+      ]
+    },
+    "public.mail_triage_status": {
+      "name": "mail_triage_status",
+      "schema": "public",
+      "values": [
+        "unprocessed",
+        "processed",
+        "deferred"
+      ]
+    },
+    "public.mail_worker_job_status": {
+      "name": "mail_worker_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "claimed",
+        "done",
+        "failed"
+      ]
+    },
+    "public.mail_worker_run_kind": {
+      "name": "mail_worker_run_kind",
+      "schema": "public",
+      "values": [
+        "cron",
+        "manual"
+      ]
+    },
+    "public.mail_worker_run_status": {
+      "name": "mail_worker_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "imap_failed",
+        "ai_failed",
+        "partial"
+      ]
+    },
+    "public.schedule_kind": {
+      "name": "schedule_kind",
+      "schema": "public",
+      "values": [
+        "practice",
+        "meeting",
+        "social",
+        "other"
+      ]
+    },
+    "public.tournament_draft_status": {
+      "name": "tournament_draft_status",
+      "schema": "public",
+      "values": [
+        "pending_review",
+        "approved",
+        "rejected",
+        "ai_failed",
+        "superseded"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "vice_admin",
+        "member"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/shared/drizzle/meta/_journal.json
+++ b/packages/shared/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1780544571419,
       "tag": "0020_amazing_maverick",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1780589405725,
+      "tag": "0021_amazing_mentor",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/schema/enums.ts
+++ b/packages/shared/src/schema/enums.ts
@@ -109,6 +109,9 @@ export const eventLifecycleNotificationTypeEnum = pgEnum('event_lifecycle_notifi
   'payment_deadline_day',
   'onsite_payment_advance',
   'onsite_payment_day',
+  // entry-notify-lottery-treasurer: 申込完了時に参加者グループへ送る 2 通目（会計向け振込案内）。
+  // entry_applied と別スロットで once-ever 管理する（(event_id, type) UNIQUE）。
+  'entry_applied_treasurer',
 ])
 export const eventLifecycleNotificationStatusEnum = pgEnum('event_lifecycle_notification_status', [
   'sent',

--- a/packages/shared/src/schema/events.ts
+++ b/packages/shared/src/schema/events.ts
@@ -37,6 +37,9 @@ export const events = pgTable('events', {
   eligibleGrades: gradeEnum('eligible_grades').array(),
   feeJpy: integer('fee_jpy'),
   paymentDeadline: date('payment_deadline', { mode: 'string' }),
+  // entry-notify-lottery-treasurer: 抽選日。NULL=抽選なし（先着・全員参加）。申込完了通知の
+  // 参加者向け文面に「抽選日は M/D です」を差し込む。手動入力（AI 抽出は別 follow-up）。
+  lotteryDate: date('lottery_date', { mode: 'string' }),
   paymentInfo: text('payment_info'),
   paymentMethod: text('payment_method'),
   entryMethod: text('entry_method'),


### PR DESCRIPTION
## Summary
`event-lifecycle-notify` の **申込完了通知** を 2 通化する拡張（親 #112、子 #113-#117）。

1. **参加者向け** (`entry_applied`): 既存文面の末尾に `lottery_date` 設定時のみ「抽選日は M/D です」を追記。
2. **会計向け** (`entry_applied_treasurer` 新規 enum): 同じ参加者グループへ 2 通目として `💴【title】会計の方へ` + 振込期限／振込方法／支払情報を送る。値があるものだけ行連結、全空なら最小文面、金額は載せない・支払いタイプで出し分けない。

両通は同じ申込完了トリガー（`setEntryApplied(true)` の初回遷移）で、同一 tx で独立 claim → コミット後に独立 try/catch で push（要件 §3.2.5）。種別ごとに `(event_id, type)` UNIQUE で once-ever。

### 変更内容
- **DB** (task1, #113): `events.lottery_date` (nullable date) 追加、`event_lifecycle_notification_type` に `entry_applied_treasurer` 追加。migration `0021_amazing_mentor.sql`（非破壊：`ADD VALUE` + `ADD COLUMN`）
- **lib** (task2, #114): `LifecycleMessageContext` に `lotteryDateIso` / `paymentDeadlineIso` / `paymentMethod` / `paymentInfo` を追加。`buildLifecycleMessage` に新ケース 2 件（exhaustiveness guard で漏れ防止）
- **server action** (task3, #115): `setEntryApplied` の returning に 4 カラム追加、tx 内で 2 claim、コミット後に 2 通独立 push。cancelled は両方 claim しない（既存 entry_applied と対称）
- **フォーム/参照表示** (task4, #116): `eventFormSchema` + `extractEventFormData` + `event-form.tsx` + new/edit ページ + 詳細ページ。承認画面 (`extractEventUnitsFormData` / embedded mode) は触らない（要件 §5.2: 承認直後は NULL、編集画面で後入力）
- **E2E** (task5, #117): /edit で抽選日入力→保存→詳細表示→申込済トグルで 2 種別とも sent

### 既存挙動への影響（非破壊）
- `entry_applied` の文面は `lottery_date=NULL` で完全に従来通り
- `payment_deadline_*` 等の他種別・reminder batch は不変（type を明示指定する設計のため enum 末尾追加で誤発火しない）
- 既存 events 行は `lottery_date=NULL` で入る
- 承認画面 (`mail-tournament-import`) は AI 抽出スキーマ含めて未変更（別 follow-up PR 予定、要件 §5.3）

### 関連 Issue
Closes #113 #114 #115 #116 #117
親 #112 は全子クローズ後にトラッキングを更新。

## Test plan
- [ ] CI: 型 / lint / Vitest / Playwright が green
- [ ] DRY_RUN ローカル: linked 大会で申込済トグル → entry_applied と entry_applied_treasurer の 2 行が sent で記録される
- [ ] 抽選日入力 → 詳細画面に「抽選日: M/D」表示、会員でも参照のみ可
- [ ] 承認画面では抽選日欄が出ない（embedded 非表示）
- [ ] 本番反映後: migration 0021 適用 → 実機 LINE で 2 通受信を目視

🤖 Generated with [Claude Code](https://claude.com/claude-code)