### PR TITLE
feat(mail-inbox-mailer): inbox をメーラー化、AI 抽出を管理者起動式に作り替え (#119)

### DIFF
--- a/apps/mail-worker/src/index.ts
+++ b/apps/mail-worker/src/index.ts
@@ -201,7 +201,11 @@ async function main(): Promise<void> {
     // mail-inbox-mailer: extract-only mode は IMAP fetch せず、manual_extract
     // ジョブだけを 1 件 pick して runManualExtract を回す。
     if (flags.mode === 'extract') {
-      await runExtractOnlyDispatcher({ llmExtractor: llmExtractor!, log })
+      await runExtractOnlyDispatcher({
+        llmExtractor: llmExtractor!,
+        webPushConfig,
+        log,
+      })
       return
     }
 
@@ -314,6 +318,7 @@ async function main(): Promise<void> {
  */
 async function runExtractOnlyDispatcher(opts: {
   llmExtractor: LLMExtractor
+  webPushConfig: ReturnType<typeof loadWebPushConfig>
   log: ReturnType<typeof consoleLogger>
 }): Promise<void> {
   const db = getDb()
@@ -356,6 +361,7 @@ async function runExtractOnlyDispatcher(opts: {
       mailMessageId,
       llmExtractor: opts.llmExtractor,
       triggeredByUserId: job.requestedByUserId,
+      webPushConfig: opts.webPushConfig,
       logger: opts.log,
     })
     await markJobDone(db, job.id, result.runId)

--- a/apps/mail-worker/src/index.ts
+++ b/apps/mail-worker/src/index.ts
@@ -12,6 +12,7 @@ import {
   markJobFailed,
   parseManualExtractPayload,
   recoverStaleClaimedJobs,
+  STALE_CLAIM_RECOVERY_MS_EXTRACT,
 } from './jobs.js'
 import { FixtureLLMExtractor, loadFixturesFromDir } from './classify/llm/fixture.js'
 import { AnthropicSonnet46Extractor } from './classify/llm/anthropic.js'
@@ -323,12 +324,18 @@ async function runExtractOnlyDispatcher(opts: {
 }): Promise<void> {
   const db = getDb()
 
-  // 既存 fetch mode と同じ stale recovery を流す。manual_extract ジョブが
-  // claimed のまま死んだ場合も同じ仕組みで回復させる。
-  await recoverStaleClaimedJobs(db).then(
+  // mail-inbox-mailer (Codex r8 should-fix): manual_extract は systemd 側で
+  // TimeoutStartSec=300 (5 分) で kill されるので、fetch と同じ 1 時間閾値だと
+  // LLM/API ハングで kill されたジョブが ai_processing のまま最大 1 時間
+  // 残ってしまい polling 画面が進まない。manual_extract だけ 10 分閾値で
+  // 専用復旧し、他 kind (fetch) は fetch dispatcher 側に任せる。
+  await recoverStaleClaimedJobs(db, {
+    staleAfterMs: STALE_CLAIM_RECOVERY_MS_EXTRACT,
+    kinds: ['manual_extract'],
+  }).then(
     (recovered) => {
       if (recovered > 0) {
-        opts.log.warn('recovered stale claimed mail_worker_jobs rows', { recovered })
+        opts.log.warn('recovered stale claimed manual_extract jobs', { recovered })
       }
     },
     (err) => {

--- a/apps/mail-worker/src/index.ts
+++ b/apps/mail-worker/src/index.ts
@@ -1,7 +1,7 @@
 import { readFile, readdir, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { runOnce, RunOnceError, runPipeline } from './pipeline.js'
+import { runManualExtract, runOnce, RunOnceError, runPipeline } from './pipeline.js'
 import { FixtureMailSource } from './fetch/fetcher.js'
 import { closeDb, getDb } from './db.js'
 import { loadLogConfig, loadLlmConfig, loadWebPushConfig } from './config.js'
@@ -10,12 +10,23 @@ import {
   claimNextJob,
   markJobDone,
   markJobFailed,
+  parseManualExtractPayload,
   recoverStaleClaimedJobs,
 } from './jobs.js'
 import { FixtureLLMExtractor, loadFixturesFromDir } from './classify/llm/fixture.js'
 import { AnthropicSonnet46Extractor } from './classify/llm/anthropic.js'
 import type { LLMExtractor } from './classify/llm/types.js'
 import type { ExtractionPayload } from './classify/schema.js'
+
+/**
+ * mail-inbox-mailer: dispatcher の動作 mode。
+ * - 'fetch': 既存 cron。IMAP fetch + persist のみ実行。**AI 抽出は呼ばない**。
+ *            `fetch` ジョブの claim も受ける（既存の手動 fetch 操作）。
+ * - 'extract': mail-inbox-mailer タスク2 の新規モード。IMAP fetch をスキップ
+ *              して `manual_extract` ジョブのみ pick → `runManualExtract`。
+ *              30 秒間隔の systemd timer から起動される想定。
+ */
+type DispatcherMode = 'fetch' | 'extract'
 
 interface CliFlags {
   /**
@@ -34,6 +45,8 @@ interface CliFlags {
    */
   noClaim: boolean
   fixtureDir: string | undefined
+  /** mail-inbox-mailer: dispatcher mode (default: 'fetch'). */
+  mode: DispatcherMode
 }
 
 /**
@@ -53,6 +66,7 @@ function parseArgs(argv: readonly string[]): CliFlags {
     dryRun: false,
     noClaim: false,
     fixtureDir: undefined,
+    mode: 'fetch',
   }
   for (const arg of argv) {
     if (arg === '--once') flags.once = true
@@ -65,6 +79,11 @@ function parseArgs(argv: readonly string[]): CliFlags {
       flags.since = parseSinceArg(value)
     } else if (arg.startsWith('--fixture-dir=')) {
       flags.fixtureDir = arg.slice('--fixture-dir='.length)
+    } else if (arg.startsWith('--mode=')) {
+      const value = arg.slice('--mode='.length)
+      if (value === 'extract-only') flags.mode = 'extract'
+      else if (value === 'fetch-only' || value === 'fetch') flags.mode = 'fetch'
+      else throw new Error(`unknown --mode value: ${value} (expected fetch-only or extract-only)`)
     } else if (arg === '--help' || arg === '-h') {
       printUsage()
       process.exit(0)
@@ -93,6 +112,10 @@ function printUsage(): void {
   --fixture-dir=PATH     Directory of *.eml files for --mock-imap (default: ./test/fixtures).
   --dry-run              Parse only; do not write to DB or call the LLM.
   --no-claim             Skip mail_worker_jobs claim and run a pure cron tick (test/debug).
+  --mode=fetch-only      (default) IMAP fetch + 'fetch' job dispatch. AI extraction
+                         is NOT invoked (mail-inbox-mailer: cron AI 廃止)。
+  --mode=extract-only    Skip IMAP fetch entirely; only claim 'manual_extract'
+                         jobs and run runManualExtract on each.
   --help, -h             Show this help.
 `)
 }
@@ -114,11 +137,16 @@ async function loadFixtureBuffers(dir: string): Promise<Array<{ source: Buffer }
 async function main(): Promise<void> {
   const flags = parseArgs(process.argv.slice(2))
 
-  // Build the LLM extractor. Three branches:
-  //   --dry-run    → no extractor (AI phase is skipped entirely)
-  //   --mock-llm   → FixtureLLMExtractor (no ANTHROPIC_API_KEY required)
-  //   default      → AnthropicSonnet46Extractor (loadLlmConfig validates env)
-  const llmExtractor = await buildLlmExtractor(flags)
+  // mail-inbox-mailer: AI 抽出は extract-only mode のみで使う。fetch mode は
+  // cron AI 廃止により llmExtractor を渡さない運用に変更（cron が
+  // ANTHROPIC_API_KEY なしで動くようになる）。
+  //
+  // build branches:
+  //   --dry-run                 → undefined (AI phase skipped entirely)
+  //   --mode=fetch-only (def)   → undefined (cron AI 廃止)
+  //   --mode=extract-only       → FixtureLLMExtractor or AnthropicSonnet46Extractor
+  const llmExtractor =
+    flags.mode === 'extract' ? await buildLlmExtractor(flags) : undefined
 
   // Build the IMAP source: `--mock-imap` reads fixture eml files; otherwise
   // we let `runPipeline` instantiate a `LiveMailSource` (via the default).
@@ -133,7 +161,7 @@ async function main(): Promise<void> {
   // Default lookback for cron / live IMAP. Logged the first time we apply it
   // so operators know why a manual `pnpm start` looks at the last 7 days.
   const cronSince = flags.since ?? defaultLiveSince()
-  if (!flags.since && !flags.mockImap) {
+  if (!flags.since && !flags.mockImap && flags.mode === 'fetch') {
 
     console.log(
       `[mail-worker] --since not provided; defaulting to last ${LIVE_DEFAULT_SINCE_DAYS} days (since=${cronSince.toISOString()}). Pass --since=YYYY-MM-DD to override.`,
@@ -167,6 +195,13 @@ async function main(): Promise<void> {
       })
 
       console.log('pipeline summary:', summary)
+      return
+    }
+
+    // mail-inbox-mailer: extract-only mode は IMAP fetch せず、manual_extract
+    // ジョブだけを 1 件 pick して runManualExtract を回す。
+    if (flags.mode === 'extract') {
+      await runExtractOnlyDispatcher({ llmExtractor: llmExtractor!, log })
       return
     }
 
@@ -206,7 +241,9 @@ async function main(): Promise<void> {
       },
     )
 
-    const job = await claimNextJob(db).catch((err) => {
+    // mail-inbox-mailer: fetch mode は 'fetch' ジョブだけ拾う。
+    // 'manual_extract' は 30 秒間隔の extract-only timer に任せる。
+    const job = await claimNextJob(db, { kinds: ['fetch'] }).catch((err) => {
       log.warn('claimNextJob failed; falling back to cron tick', {
         err: err instanceof Error ? err.message : String(err),
       })
@@ -216,6 +253,7 @@ async function main(): Promise<void> {
     if (job) {
       log.info('claimed mail_worker_jobs row', {
         jobId: job.id,
+        kind: job.kind,
         requestedByUserId: job.requestedByUserId,
         since: job.since?.toISOString() ?? null,
       })
@@ -262,6 +300,76 @@ async function main(): Promise<void> {
     }
   } finally {
     await closeDb()
+  }
+}
+
+/**
+ * mail-inbox-mailer タスク2: extract-only dispatcher。
+ *
+ * 30 秒間隔の systemd timer から呼ばれる想定。1 tick で manual_extract ジョブを
+ * 1 件だけ pick して runManualExtract を回す（次の tick で次の 1 件、という
+ * sequential 動作）。pick できなければ no-op で抜ける。
+ *
+ * IMAP fetch を一切呼ばないので、ANTHROPIC_API_KEY だけあれば動く。
+ */
+async function runExtractOnlyDispatcher(opts: {
+  llmExtractor: LLMExtractor
+  log: ReturnType<typeof consoleLogger>
+}): Promise<void> {
+  const db = getDb()
+
+  // 既存 fetch mode と同じ stale recovery を流す。manual_extract ジョブが
+  // claimed のまま死んだ場合も同じ仕組みで回復させる。
+  await recoverStaleClaimedJobs(db).then(
+    (recovered) => {
+      if (recovered > 0) {
+        opts.log.warn('recovered stale claimed mail_worker_jobs rows', { recovered })
+      }
+    },
+    (err) => {
+      opts.log.warn('recoverStaleClaimedJobs failed; continuing', {
+        err: err instanceof Error ? err.message : String(err),
+      })
+    },
+  )
+
+  const job = await claimNextJob(db, { kinds: ['manual_extract'] }).catch((err) => {
+    opts.log.warn('claimNextJob (extract-only) failed', {
+      err: err instanceof Error ? err.message : String(err),
+    })
+    return null
+  })
+
+  if (!job) {
+    opts.log.info('extract-only: no pending manual_extract jobs')
+    return
+  }
+
+  opts.log.info('claimed manual_extract job', {
+    jobId: job.id,
+    requestedByUserId: job.requestedByUserId,
+  })
+
+  try {
+    const { mail_message_id: mailMessageId } = parseManualExtractPayload(job.payload)
+    const result = await runManualExtract({
+      mailMessageId,
+      llmExtractor: opts.llmExtractor,
+      triggeredByUserId: job.requestedByUserId,
+      logger: opts.log,
+    })
+    await markJobDone(db, job.id, result.runId)
+
+    console.log('manual_extract result:', result)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    await markJobFailed(db, job.id, message, null).catch((markErr) => {
+      opts.log.warn('markJobFailed (manual_extract) also failed', {
+        jobId: job.id,
+        err: markErr instanceof Error ? markErr.message : String(markErr),
+      })
+    })
+    throw err
   }
 }
 

--- a/apps/mail-worker/src/jobs.ts
+++ b/apps/mail-worker/src/jobs.ts
@@ -1,6 +1,21 @@
-import { and, asc, eq, isNotNull, lt, sql } from 'drizzle-orm'
+import { and, asc, eq, inArray, isNotNull, lt, sql } from 'drizzle-orm'
 import { mailWorkerJobs } from '@kagetra/shared/schema'
 import type { Db } from './db.js'
+
+/**
+ * `mail_worker_jobs.kind` の TS リテラル型。enum は drizzle スキーマ側で
+ * 'fetch' | 'manual_extract' を定義しており、dispatcher 分岐の identity と
+ * して使う。
+ *
+ * - 'fetch'         : IMAP 取得 + persist のみ。AI 抽出は呼ばない（既存 cron）。
+ * - 'manual_extract': inbox 詳細から「会で流す（AI 抽出）」を押した時の手動
+ *                    AI ジョブ。`payload.mail_message_id` で対象を指定する。
+ */
+export type MailWorkerJobKind = 'fetch' | 'manual_extract'
+
+export interface ManualExtractPayload {
+  mail_message_id: number
+}
 
 /**
  * How long a `claimed` row may sit before the dispatcher recovers it back to
@@ -34,6 +49,23 @@ export type ClaimedJob = {
   /** `--since` cutoff requested by the admin, or null for default lookback. */
   since: Date | null
   requestedAt: Date
+  /** mail-inbox-mailer: ジョブ種別。`'fetch'` (IMAP) と `'manual_extract'` (AI 抽出) を識別。 */
+  kind: MailWorkerJobKind
+  /**
+   * mail-inbox-mailer: kind 固有引数。`manual_extract` の場合は
+   * `{ mail_message_id }` を含む。JSON 由来なので型は jsonb→unknown、
+   * 呼び出し側で narrow する。
+   */
+  payload: unknown
+}
+
+export interface ClaimNextJobOptions {
+  /**
+   * mail-inbox-mailer: pick できるジョブ種別を絞る。指定しない場合は全種別を
+   * 対象とする（既存呼び出しの互換）。dispatcher の mode (`--mode=extract-only`)
+   * から `['manual_extract']` を渡して IMAP fetch ジョブを取らない。
+   */
+  kinds?: MailWorkerJobKind[]
 }
 
 /**
@@ -46,8 +78,15 @@ export type ClaimedJob = {
  * non-blocking queue claim. The SELECT and UPDATE both live inside the same
  * transaction so the row's lock is released only after the status flip
  * commits — no other worker can see it as pending.
+ *
+ * mail-inbox-mailer: 第 2 引数 `opts.kinds` で kind フィルタを掛けられる。
+ * 未指定なら全種別。fetch mode は `['fetch']`、extract-only mode は
+ * `['manual_extract']` を渡す想定。
  */
-export async function claimNextJob(db: Db): Promise<ClaimedJob | null> {
+export async function claimNextJob(
+  db: Db,
+  opts: ClaimNextJobOptions = {},
+): Promise<ClaimedJob | null> {
   return db.transaction(async (tx) => {
     const candidates = await tx
       .select({
@@ -55,9 +94,18 @@ export async function claimNextJob(db: Db): Promise<ClaimedJob | null> {
         requestedByUserId: mailWorkerJobs.requestedByUserId,
         since: mailWorkerJobs.since,
         requestedAt: mailWorkerJobs.requestedAt,
+        kind: mailWorkerJobs.kind,
+        payload: mailWorkerJobs.payload,
       })
       .from(mailWorkerJobs)
-      .where(eq(mailWorkerJobs.status, 'pending'))
+      .where(
+        opts.kinds && opts.kinds.length > 0
+          ? and(
+              eq(mailWorkerJobs.status, 'pending'),
+              inArray(mailWorkerJobs.kind, opts.kinds),
+            )
+          : eq(mailWorkerJobs.status, 'pending'),
+      )
       .orderBy(asc(mailWorkerJobs.requestedAt))
       .limit(1)
       .for('update', { skipLocked: true })
@@ -73,6 +121,8 @@ export async function claimNextJob(db: Db): Promise<ClaimedJob | null> {
         requestedByUserId: mailWorkerJobs.requestedByUserId,
         since: mailWorkerJobs.since,
         requestedAt: mailWorkerJobs.requestedAt,
+        kind: mailWorkerJobs.kind,
+        payload: mailWorkerJobs.payload,
       })
     if (updated.length === 0) {
       // Should be impossible while we hold the row lock, but stay defensive
@@ -85,8 +135,29 @@ export async function claimNextJob(db: Db): Promise<ClaimedJob | null> {
       requestedByUserId: row.requestedByUserId,
       since: row.since,
       requestedAt: row.requestedAt,
+      kind: row.kind,
+      payload: row.payload,
     }
   })
+}
+
+/**
+ * mail-inbox-mailer: `manual_extract` ジョブの payload を narrow する。
+ * jsonb から `mail_message_id: number` が取り出せなければ throw する。
+ * dispatcher が claim 直後に呼ぶ薄いガード。
+ */
+export function parseManualExtractPayload(payload: unknown): ManualExtractPayload {
+  if (
+    payload &&
+    typeof payload === 'object' &&
+    'mail_message_id' in payload &&
+    typeof (payload as { mail_message_id: unknown }).mail_message_id === 'number'
+  ) {
+    return { mail_message_id: (payload as { mail_message_id: number }).mail_message_id }
+  }
+  throw new Error(
+    `manual_extract job payload missing mail_message_id (got ${JSON.stringify(payload)})`,
+  )
 }
 
 /**

--- a/apps/mail-worker/src/jobs.ts
+++ b/apps/mail-worker/src/jobs.ts
@@ -161,6 +161,21 @@ export function parseManualExtractPayload(payload: unknown): ManualExtractPayloa
 }
 
 /**
+ * mail-inbox-mailer (Codex r8 should-fix): manual_extract は systemd 側の
+ * TimeoutStartSec=300 (5 分) で SIGKILL されるので、fetch と同じ 1 時間閾値で
+ * recover していると LLM/API ハング → kill 後に最大 1 時間 ai_processing が
+ * 残ってしまう。extract-only mode 用に短い閾値（10 分）を別に用意する。
+ */
+export const STALE_CLAIM_RECOVERY_MS_EXTRACT = 10 * 60 * 1000 // 10 min
+
+export interface RecoverStaleClaimedJobsOptions {
+  /** stale 判定する経過 ms。未指定なら STALE_CLAIM_RECOVERY_MS（1 時間）。 */
+  staleAfterMs?: number
+  /** 復旧対象 kind を絞る。未指定なら全 kind を対象。 */
+  kinds?: MailWorkerJobKind[]
+}
+
+/**
  * Reset rows stuck in `claimed` past the stale threshold back to `pending`
  * so the dispatcher can re-claim them. Returns the number of rows recovered.
  *
@@ -173,21 +188,34 @@ export function parseManualExtractPayload(payload: unknown): ManualExtractPayloa
  * `claimedAt` is set back to NULL on recovery so the next claim attempt
  * stamps it fresh — without this, the row's claimedAt would carry the dead
  * worker's timestamp into the new run and confuse troubleshooting.
+ *
+ * mail-inbox-mailer: 引数を options 化し kind フィルタと閾値を渡せるように
+ * 拡張した。extract-only dispatcher は manual_extract だけを 10 分閾値で
+ * 復旧し、fetch dispatcher は既定 1 時間 + 全 kind で復旧する。
  */
 export async function recoverStaleClaimedJobs(
   db: Db,
-  staleAfterMs: number = STALE_CLAIM_RECOVERY_MS,
+  opts: RecoverStaleClaimedJobsOptions = {},
 ): Promise<number> {
+  const staleAfterMs = opts.staleAfterMs ?? STALE_CLAIM_RECOVERY_MS
   const cutoff = new Date(Date.now() - staleAfterMs)
+  const kinds = opts.kinds
   const recovered = await db
     .update(mailWorkerJobs)
     .set({ status: 'pending', claimedAt: null })
     .where(
-      and(
-        eq(mailWorkerJobs.status, 'claimed'),
-        isNotNull(mailWorkerJobs.claimedAt),
-        lt(mailWorkerJobs.claimedAt, cutoff),
-      ),
+      kinds && kinds.length > 0
+        ? and(
+            eq(mailWorkerJobs.status, 'claimed'),
+            isNotNull(mailWorkerJobs.claimedAt),
+            lt(mailWorkerJobs.claimedAt, cutoff),
+            inArray(mailWorkerJobs.kind, kinds),
+          )
+        : and(
+            eq(mailWorkerJobs.status, 'claimed'),
+            isNotNull(mailWorkerJobs.claimedAt),
+            lt(mailWorkerJobs.claimedAt, cutoff),
+          ),
     )
     .returning({ id: mailWorkerJobs.id })
   return recovered.length

--- a/apps/mail-worker/src/notify/web-push.ts
+++ b/apps/mail-worker/src/notify/web-push.ts
@@ -33,7 +33,8 @@ export async function notifyNewMailPush(
 ): Promise<void> {
   webpush.setVapidDetails(config.subject, config.publicKey, config.privateKey)
 
-  // バッジは未処理総数（unprocessed + deferred）。count API と同じ条件。
+  // バッジは未処理総数（= unprocessed）。count API と同じ条件。
+  // mail-inbox-mailer: 2 状態化により deferred は廃止。
   const [row] = await db
     .select({ value: count() })
     .from(mailMessages)

--- a/apps/mail-worker/src/notify/web-push.ts
+++ b/apps/mail-worker/src/notify/web-push.ts
@@ -92,3 +92,89 @@ export async function notifyNewMailPush(
     }
   }
 }
+
+/**
+ * mail-inbox-mailer タスク7 (Codex r1 should-fix): 手動 AI 抽出 (runManualExtract)
+ * の完了通知。詳細画面の「完了したら通知します」表記の裏付け。
+ *
+ * runManualExtract は `--mode=extract-only` の dispatcher が起動し、Sonnet で
+ * 5〜30 秒走るので、抽出中にユーザーが画面を閉じる可能性がある。完了 / 失敗を
+ * Web Push でプッシュして気づけるようにする。
+ */
+export interface ExtractCompletedInfo {
+  mailMessageId: number
+  subject: string | null
+  /**
+   * 'success' = AI が大会案内として抽出に成功 (draft pending_review)。
+   * 'failed'  = AI 抽出失敗 / noise 判定 / oversize 等で draft が ai_failed
+   *            に倒れたケース。ユーザーが手動でリトライ or 手動作成へ流れる
+   *            想定。
+   */
+  result: 'success' | 'failed'
+}
+
+export async function notifyExtractCompleted(
+  db: Db,
+  config: WebPushConfig,
+  info: ExtractCompletedInfo,
+  logger: NotifyLogger = NOOP_LOGGER,
+): Promise<void> {
+  webpush.setVapidDetails(config.subject, config.publicKey, config.privateKey)
+
+  const [row] = await db
+    .select({ value: count() })
+    .from(mailMessages)
+    .where(ne(mailMessages.triageStatus, 'processed'))
+  const badge = row?.value ?? 0
+
+  const subs = await db
+    .select({
+      endpoint: pushSubscriptions.endpoint,
+      p256dh: pushSubscriptions.p256dh,
+      auth: pushSubscriptions.auth,
+    })
+    .from(pushSubscriptions)
+    .innerJoin(users, eq(pushSubscriptions.userId, users.id))
+    .where(inArray(users.role, ['admin', 'vice_admin']))
+  if (subs.length === 0) return
+
+  const subject = info.subject ?? '(件名なし)'
+  const title = info.result === 'success' ? 'AI 抽出完了' : 'AI 抽出に失敗'
+  const payload = JSON.stringify({
+    title,
+    body: subject.slice(0, 200),
+    // 詳細画面に直接飛ばす（polling で開いていれば router.refresh が拾うが、
+    // 別端末から開く動線をこちらで担保する）。
+    url: `/admin/mail-inbox/mail/${info.mailMessageId}`,
+    badge,
+  })
+
+  for (const sub of subs) {
+    try {
+      await webpush.sendNotification(
+        {
+          endpoint: sub.endpoint,
+          keys: { p256dh: sub.p256dh, auth: sub.auth },
+        },
+        payload,
+      )
+    } catch (err) {
+      const statusCode = (err as { statusCode?: number }).statusCode
+      if (statusCode === 404 || statusCode === 410) {
+        await db
+          .delete(pushSubscriptions)
+          .where(eq(pushSubscriptions.endpoint, sub.endpoint))
+          .catch(() => undefined)
+        logger.info('removed expired push subscription', {
+          endpoint: sub.endpoint,
+        })
+      } else {
+        logger.warn('web push send failed (extract completed)', {
+          endpoint: sub.endpoint,
+          statusCode,
+          err: err instanceof Error ? err.message : String(err),
+        })
+      }
+    }
+  }
+}

--- a/apps/mail-worker/src/pipeline.ts
+++ b/apps/mail-worker/src/pipeline.ts
@@ -13,7 +13,11 @@ import {
   type MailWorkerRunSummary,
   type Notifier,
 } from './notify/orchestrator.js'
-import { notifyNewMailPush, type NewMailInfo } from './notify/web-push.js'
+import {
+  notifyExtractCompleted,
+  notifyNewMailPush,
+  type NewMailInfo,
+} from './notify/web-push.js'
 import type { WebPushConfig } from './config.js'
 
 export interface PipelineSummary {
@@ -746,9 +750,13 @@ export class RunOnceError extends Error {
 // 流れ:
 //   1. mail_worker_runs (kind='manual', status='running') を INSERT
 //   2. classifyMail + persistOutcome を per-mail try/catch で実行
-//   3. terminal status を計算して mail_worker_runs を UPDATE
-//   4. (ai_failed の) 通知は今回スコープ外（既存 evaluateAndNotify は cron 流れ
-//      に紐付き、AI 失敗の連続検知は cron AI 廃止により意味を失う）
+//   3. **persistOutcome が ai_processing draft を更新しない kind**
+//      (noise / oversize_skipped / skipped_noise) では、Server Action が事前に
+//      作った draft が永遠に ai_processing で残り UI polling が停止しない
+//      問題があるため、明示的に ai_failed へ終端させる (Codex r1 blocker)。
+//   4. terminal status を計算して mail_worker_runs を UPDATE
+//   5. Web Push で完了通知を送る（success / failed）。UI 表記
+//      「完了したら通知します」の裏付け (Codex r1 should-fix)。
 //
 // 注: classifyMail 自体が draft 行を `status='ai_processing'` でマークする前に
 // 走るが、Server Action が draft を INSERT 済みなので redundant ではない。
@@ -762,6 +770,11 @@ export interface RunManualExtractOptions {
   llmExtractor: LLMExtractor
   /** 起動者 (mail_worker_jobs.requested_by_user_id)。run 行の triggered_by に乗る。 */
   triggeredByUserId: string
+  /**
+   * Web Push 完了通知用 VAPID 設定。null/未設定なら配信スキップ（鍵未設定
+   * 環境でも extract 自体は動く）。Codex r1 should-fix 対応。
+   */
+  webPushConfig?: WebPushConfig | null
   logger?: PipelineLogger
 }
 
@@ -855,6 +868,52 @@ export async function runManualExtract(
           limitBytes: outcome.limitBytes,
         })
       }
+
+      // Codex r1 blocker: persistOutcome は noise / oversize_skipped /
+      // skipped_noise の場合 tournament_drafts を触らない。Server Action
+      // (triggerExtractDraft) が事前に作った draft が `ai_processing` のまま
+      // 永遠に残り、UI polling が止まらない。
+      //
+      // - failed   → persistOutcome が upsertDraft で ai_failed に上書き済 (OK)
+      // - tournament → upsertDraft で pending_review に上書き済 (OK)
+      // - noise    → mail_messages.classification='noise' に倒すが draft は
+      //              「pending_review/ai_failed のみ superseded」なので
+      //              ai_processing は対象外。ai_failed へ強制終端する。
+      // - oversize_skipped → draft は触られない。同じく強制終端。
+      // - skipped_noise   → force:true で来ないはずだが防御的に同じ扱い。
+      //
+      // tally への影響: 既存の aiSucceeded（noise）はそのまま残しつつ、UI 観点で
+      // draft を「再試行可能な ai_failed」へ寄せる（UI は ai_failed で
+      // 「再試行」「手動でイベントを作成」を出す）。
+      if (
+        outcome.kind === 'noise' ||
+        outcome.kind === 'oversize_skipped' ||
+        outcome.kind === 'skipped_noise'
+      ) {
+        const closed = await db
+          .update(tournamentDrafts)
+          .set({ status: 'ai_failed', updatedAt: sql`now()` })
+          .where(
+            and(
+              eq(tournamentDrafts.messageId, opts.mailMessageId),
+              eq(tournamentDrafts.status, 'ai_processing'),
+            ),
+          )
+          .returning({ id: tournamentDrafts.id })
+        if (closed.length > 0) {
+          log.info('manual_extract forced ai_processing draft to ai_failed', {
+            runId,
+            mailMessageId: opts.mailMessageId,
+            kind: outcome.kind,
+          })
+          // 実害は無いが UI 表記との整合のため aiFailed もカウント。
+          // （tally.aiSucceeded は noise 経由で既に +1 されているが、aiFailed
+          // をインクリメントすることで run.status='ai_failed' に倒れて Web Push
+          // が「失敗」として通知される）
+          tally.aiFailed += 1
+        }
+      }
+
       log.info('manual_extract outcome', {
         runId,
         mailMessageId: opts.mailMessageId,
@@ -910,6 +969,36 @@ export async function runManualExtract(
       error: topLevelError ? topLevelError.message : null,
     })
     .where(eq(mailWorkerRuns.id, runId))
+
+  // Codex r1 should-fix: 完了通知 (Web Push)。詳細画面の
+  // 「完了したら通知します」表記の裏付け。鍵未設定 (config が null) なら
+  // skip（既存 cron と同じ慣行）。配信失敗は best-effort で run 自体は止めない。
+  if (opts.webPushConfig) {
+    try {
+      const subjectRow = await db
+        .select({ subject: mailMessages.subject })
+        .from(mailMessages)
+        .where(eq(mailMessages.id, opts.mailMessageId))
+        .limit(1)
+      const subject = subjectRow[0]?.subject ?? null
+      await notifyExtractCompleted(
+        db,
+        opts.webPushConfig,
+        {
+          mailMessageId: opts.mailMessageId,
+          subject,
+          result: status === 'success' ? 'success' : 'failed',
+        },
+        log,
+      )
+    } catch (err) {
+      log.warn('manual_extract completion notify failed', {
+        runId,
+        mailMessageId: opts.mailMessageId,
+        err: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
 
   return {
     runId,

--- a/apps/mail-worker/src/pipeline.ts
+++ b/apps/mail-worker/src/pipeline.ts
@@ -932,6 +932,29 @@ export async function runManualExtract(
         mailMessageId: opts.mailMessageId,
         err: message,
       })
+
+      // Codex r2 blocker: classifyMail / persistOutcome が例外を投げた場合、
+      // 事前作成された ai_processing draft が更新されないまま dispatcher が
+      // markJobDone するため、UI polling が永遠に止まらない。catch 内でも
+      // best-effort で draft を ai_failed に倒す（失敗してもこの try は
+      // 既に上位 catch で扱われているので run 自体は続行）。
+      try {
+        await db
+          .update(tournamentDrafts)
+          .set({ status: 'ai_failed', updatedAt: sql`now()` })
+          .where(
+            and(
+              eq(tournamentDrafts.messageId, opts.mailMessageId),
+              eq(tournamentDrafts.status, 'ai_processing'),
+            ),
+          )
+      } catch (closeErr) {
+        log.warn('manual_extract draft close after error failed', {
+          runId,
+          mailMessageId: opts.mailMessageId,
+          err: closeErr instanceof Error ? closeErr.message : String(closeErr),
+        })
+      }
     }
   } catch (err) {
     // outer catch は classifyMail の外（DB connection 切断など）。tally に乗ら
@@ -941,6 +964,27 @@ export async function runManualExtract(
       runId,
       err: topLevelError.message,
     })
+
+    // Codex r2 blocker (outer 経路): inner middle catch を経由できない致命的
+    // 失敗でも draft が ai_processing で残ると UI が止まらないため、防御的に
+    // 強制終端する。失敗しても run 行更新は続行。
+    try {
+      await db
+        .update(tournamentDrafts)
+        .set({ status: 'ai_failed', updatedAt: sql`now()` })
+        .where(
+          and(
+            eq(tournamentDrafts.messageId, opts.mailMessageId),
+            eq(tournamentDrafts.status, 'ai_processing'),
+          ),
+        )
+    } catch (closeErr) {
+      log.warn('manual_extract draft close after top-level error failed', {
+        runId,
+        mailMessageId: opts.mailMessageId,
+        err: closeErr instanceof Error ? closeErr.message : String(closeErr),
+      })
+    }
   }
 
   const status: 'success' | 'ai_failed' =

--- a/apps/mail-worker/src/pipeline.ts
+++ b/apps/mail-worker/src/pipeline.ts
@@ -730,6 +730,200 @@ export class RunOnceError extends Error {
   }
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// runManualExtract: mail-inbox-mailer タスク2
+//
+// 管理者が inbox 詳細で「会で流す（AI 抽出）」ボタンを押すと、Server Action が
+// `mail_worker_jobs` に kind='manual_extract', payload={mail_message_id} を
+// INSERT する。`--mode=extract-only` で起動した mail-worker は 30 秒間隔で
+// このジョブを claim し、本関数を呼ぶ。
+//
+// 既存の `runOnce` (IMAP fetch + AI) と意図的に別関数として切り出した理由:
+//   - IMAP fetch を skip するので runPipeline の流れを使わない
+//   - cron AI 廃止に伴い、AI 抽出はこの経路に集約される
+//   - 失敗時のステータス計算 ('ai_failed') がシンプル
+//
+// 流れ:
+//   1. mail_worker_runs (kind='manual', status='running') を INSERT
+//   2. classifyMail + persistOutcome を per-mail try/catch で実行
+//   3. terminal status を計算して mail_worker_runs を UPDATE
+//   4. (ai_failed の) 通知は今回スコープ外（既存 evaluateAndNotify は cron 流れ
+//      に紐付き、AI 失敗の連続検知は cron AI 廃止により意味を失う）
+//
+// 注: classifyMail 自体が draft 行を `status='ai_processing'` でマークする前に
+// 走るが、Server Action が draft を INSERT 済みなので redundant ではない。
+// classifyMail 内の updateStatus は mail_messages.status を更新するもの。
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface RunManualExtractOptions {
+  /** 対象の mail_messages.id。Server Action が payload に乗せて渡した値。 */
+  mailMessageId: number
+  /** AI 抽出器。`buildLlmExtractor` から渡される。 */
+  llmExtractor: LLMExtractor
+  /** 起動者 (mail_worker_jobs.requested_by_user_id)。run 行の triggered_by に乗る。 */
+  triggeredByUserId: string
+  logger?: PipelineLogger
+}
+
+export interface RunManualExtractResult {
+  /** mail_worker_runs.id */
+  runId: number
+  /** terminal status */
+  status: 'success' | 'ai_failed'
+  /** classifyMail/persistOutcome が回せた件数 */
+  draftsInserted: number
+  draftsUpdated: number
+  draftsPreserved: number
+  aiSucceeded: number
+  aiFailed: number
+  aiSkipped: number
+  aiErrors: string[]
+}
+
+export async function runManualExtract(
+  opts: RunManualExtractOptions,
+): Promise<RunManualExtractResult> {
+  const log = opts.logger ?? NOOP_LOGGER
+  const db = getDb()
+
+  const inserted = await db
+    .insert(mailWorkerRuns)
+    .values({
+      startedAt: sql`now()`,
+      kind: 'manual',
+      status: 'running',
+      triggeredByUserId: opts.triggeredByUserId,
+      since: null,
+    })
+    .returning({ id: mailWorkerRuns.id })
+  const runId = inserted[0]!.id
+
+  // 個別 mail への classify を per-mail try/catch で。pipeline.ts の runAiPhase
+  // と同じ構造（mail_messages.status を `ai_processing` でマーク → classifyMail
+  // → persistOutcome → tally 加算）。再利用したいが runAiPhase は private 関数
+  // なので、ここで簡潔に inline する。
+  const tally = {
+    draftsInserted: 0,
+    draftsUpdated: 0,
+    draftsPreserved: 0,
+    aiSucceeded: 0,
+    aiFailed: 0,
+    aiSkipped: 0,
+    aiErrors: [] as string[],
+  }
+  let topLevelError: Error | null = null
+
+  try {
+    // Best-effort marker。crash recovery のため。
+    try {
+      await updateStatus(db, opts.mailMessageId, 'ai_processing')
+    } catch (err) {
+      log.warn('manual_extract ai status marker failed', {
+        runId,
+        mailMessageId: opts.mailMessageId,
+        err: err instanceof Error ? err.message : String(err),
+      })
+    }
+
+    try {
+      // force:true で classification='noise' でも AI を呼ぶ（管理者が明示的に
+      // AI 抽出を要求したケース。pre-filter が noise と判定したメールでも
+      // 「会で流す」と判断した時点で AI 抽出すべき）。
+      const outcome = await classifyMail(db, opts.mailMessageId, opts.llmExtractor, {
+        force: true,
+      })
+      const t = await persistOutcome(db, opts.mailMessageId, outcome)
+      tally.draftsInserted += t.draftsInserted
+      tally.draftsUpdated += t.draftsUpdated
+      tally.draftsPreserved += t.draftsPreserved
+      tally.aiSucceeded += t.aiSucceeded
+      tally.aiFailed += t.aiFailed
+      tally.aiSkipped += t.aiSkipped
+      if (
+        outcome.kind === 'failed' &&
+        tally.aiErrors.length < MAX_ERRORS_IN_SUMMARY
+      ) {
+        const detail = outcome.rawResponse ?? outcome.reason
+        tally.aiErrors.push(truncateAiError(detail))
+      }
+      if (outcome.kind === 'oversize_skipped') {
+        log.warn('manual_extract oversize_skipped', {
+          runId,
+          mailMessageId: opts.mailMessageId,
+          filename: outcome.filename,
+          sizeBytes: outcome.sizeBytes,
+          limitBytes: outcome.limitBytes,
+        })
+      }
+      log.info('manual_extract outcome', {
+        runId,
+        mailMessageId: opts.mailMessageId,
+        kind: outcome.kind,
+        draftsInserted: t.draftsInserted,
+        draftsUpdated: t.draftsUpdated,
+      })
+    } catch (err) {
+      tally.aiFailed += 1
+      const message = err instanceof Error ? err.message : String(err)
+      if (tally.aiErrors.length < MAX_ERRORS_IN_SUMMARY) {
+        tally.aiErrors.push(truncateAiError(message))
+      }
+      log.warn('manual_extract phase failed', {
+        runId,
+        mailMessageId: opts.mailMessageId,
+        err: message,
+      })
+    }
+  } catch (err) {
+    // outer catch は classifyMail の外（DB connection 切断など）。tally に乗ら
+    // ない致命的失敗。
+    topLevelError = err instanceof Error ? err : new Error(String(err))
+    log.warn('manual_extract top-level error', {
+      runId,
+      err: topLevelError.message,
+    })
+  }
+
+  const status: 'success' | 'ai_failed' =
+    topLevelError !== null || tally.aiFailed > 0 ? 'ai_failed' : 'success'
+
+  const errors: string[] = []
+  if (topLevelError) errors.push(topLevelError.message)
+  for (const e of tally.aiErrors) errors.push(e)
+
+  const summaryJson: MailWorkerRunSummary = {
+    fetched: 0,
+    classified: tally.aiSucceeded + tally.aiFailed + tally.aiSkipped,
+    drafts_created: tally.draftsInserted,
+    ai_failed: tally.aiFailed,
+    imap_error: false,
+    errors: errors.slice(0, MAX_ERRORS_IN_SUMMARY),
+    new_draft_subjects: [],
+  }
+
+  await db
+    .update(mailWorkerRuns)
+    .set({
+      finishedAt: sql`now()`,
+      status,
+      summary: summaryJson,
+      error: topLevelError ? topLevelError.message : null,
+    })
+    .where(eq(mailWorkerRuns.id, runId))
+
+  return {
+    runId,
+    status,
+    draftsInserted: tally.draftsInserted,
+    draftsUpdated: tally.draftsUpdated,
+    draftsPreserved: tally.draftsPreserved,
+    aiSucceeded: tally.aiSucceeded,
+    aiFailed: tally.aiFailed,
+    aiSkipped: tally.aiSkipped,
+    aiErrors: tally.aiErrors,
+  }
+}
+
 function computeRunStatus(
   summary: PipelineSummary,
   imapError: boolean,

--- a/apps/mail-worker/systemd/kagetra-mail-worker-extract.service
+++ b/apps/mail-worker/systemd/kagetra-mail-worker-extract.service
@@ -1,0 +1,36 @@
+[Unit]
+Description=Kagetra mail-worker (manual AI extract jobs)
+After=network.target postgresql.service
+Documentation=https://github.com/poponta2020/kagetra_new/blob/main/docs/deploy/mail-worker.md
+
+# mail-inbox-mailer (タスク6): 「会で流す（AI 抽出）」ボタン押下で生成される
+# `mail_worker_jobs.kind='manual_extract'` ジョブだけを処理する extract-only
+# モードの専用ユニット。30 秒間隔の kagetra-mail-worker-extract.timer から
+# 起動される。
+#
+# 既存の kagetra-mail-worker.service とは:
+#   - cron AI 廃止により、IMAP fetch とは分離（fetch は 30 分 timer のまま）
+#   - 1 tick につき 1 ジョブのみ pick (FIFO で順次処理)
+#   - ANTHROPIC_API_KEY が必須 (loadLlmConfig が起動時に validate)
+
+[Service]
+Type=oneshot
+User=kagetra
+Group=kagetra
+WorkingDirectory=/opt/kagetra
+EnvironmentFile=/opt/kagetra/.env.production
+
+# `--mode=extract-only`: IMAP fetch を完全スキップ。
+# `manual_extract` ジョブ 1 件 pick → runManualExtract → exit。
+# 失敗時は exit 1。journalctl で確認できる。
+ExecStart=/usr/bin/corepack pnpm --filter @kagetra/mail-worker exec node dist/index.js --mode=extract-only
+
+StandardOutput=journal
+StandardError=journal
+
+# 1 AI 抽出のタイムアウト目安: Sonnet 4.6 + PDF/画像で 5-30 秒。
+# 余裕を持って 5 分上限 (前段の dispatch + DB write 含めても十分)。
+# これを超えるなら本物のハング / 詰まりなので kill して次 timer に任せる。
+TimeoutStartSec=300
+
+TimeoutStopSec=30

--- a/apps/mail-worker/systemd/kagetra-mail-worker-extract.timer
+++ b/apps/mail-worker/systemd/kagetra-mail-worker-extract.timer
@@ -1,0 +1,30 @@
+[Unit]
+Description=Run kagetra mail-worker (manual_extract) every 30 seconds
+Documentation=https://github.com/poponta2020/kagetra_new/blob/main/docs/deploy/mail-worker.md
+Requires=kagetra-mail-worker-extract.service
+
+# mail-inbox-mailer (タスク6): manual_extract ジョブ専用の高頻度 timer。
+# UI の「会で流す（AI 抽出）」ボタンを押してから抽出完了通知（Web Push）
+# までの体感を 30 秒以内に収めるのが目的。
+
+[Timer]
+# 起動直後の二重起動を避けるため少しだけ待つ（fetch timer と同じ慣行）。
+OnBootSec=1min
+
+# 30 秒間隔。前回 active になった時点から数えるので、長時間 AI 抽出が走った
+# 場合は次の発火がその分後ろにずれる（Type=oneshot との組み合わせで多重起動
+# しない）。pending ジョブがなければ即 exit する軽量処理なので、30 秒ごとに
+# 起動するコスト感は許容範囲。
+OnUnitActiveSec=30s
+
+# 高精度。30 秒間隔なので AccuracySec=1min は実質「次回まで最大 90 秒」に
+# なって UX を悪化させる。5 秒に絞る。
+AccuracySec=5s
+
+# 起動時 catch-up は不要（30 秒間隔で十分追いつく）。
+Persistent=false
+
+Unit=kagetra-mail-worker-extract.service
+
+[Install]
+WantedBy=timers.target

--- a/apps/mail-worker/systemd/kagetra-mail-worker.service
+++ b/apps/mail-worker/systemd/kagetra-mail-worker.service
@@ -25,7 +25,11 @@ EnvironmentFile=/opt/kagetra/.env.production
 
 # corepack 経由で pnpm を呼ぶことで Node 同梱版を使う (グローバル pnpm
 # 不要)。--filter で workspace を限定し、build 済みの dist/index.js を実行。
-ExecStart=/usr/bin/corepack pnpm --filter @kagetra/mail-worker exec node dist/index.js
+# mail-inbox-mailer (タスク6): cron AI 廃止に伴い --mode=fetch-only を明示。
+# 既定値も 'fetch' なのでフラグなしと等価だが、設定ファイル側で意図を表す。
+# AI 抽出ジョブ (manual_extract) は別ユニット kagetra-mail-worker-extract.timer
+# が 30 秒間隔で処理する。
+ExecStart=/usr/bin/corepack pnpm --filter @kagetra/mail-worker exec node dist/index.js --mode=fetch-only
 
 # journalctl -u kagetra-mail-worker.service で運用ログを追える。
 StandardOutput=journal

--- a/apps/mail-worker/test/jobs.test.ts
+++ b/apps/mail-worker/test/jobs.test.ts
@@ -7,6 +7,7 @@ import {
   claimNextJob,
   markJobDone,
   markJobFailed,
+  parseManualExtractPayload,
   recoverStaleClaimedJobs,
   STALE_CLAIM_RECOVERY_MS,
 } from '../src/jobs.js'
@@ -30,13 +31,21 @@ async function seedAdmin() {
   })
 }
 
-async function seedJob(opts: { since?: Date | null } = {}): Promise<number> {
+async function seedJob(
+  opts: {
+    since?: Date | null
+    kind?: 'fetch' | 'manual_extract'
+    payload?: Record<string, unknown> | null
+  } = {},
+): Promise<number> {
   const inserted = await testDb
     .insert(mailWorkerJobs)
     .values({
       requestedByUserId: ADMIN_USER_ID,
       since: opts.since ?? null,
       status: 'pending',
+      kind: opts.kind ?? 'fetch',
+      payload: opts.payload ?? null,
     })
     .returning({ id: mailWorkerJobs.id })
   return inserted[0]!.id
@@ -63,11 +72,63 @@ describe('jobs queue', () => {
     expect(claimed!.id).toBe(id)
     expect(claimed!.requestedByUserId).toBe(ADMIN_USER_ID)
     expect(claimed!.since?.toISOString()).toBe(since.toISOString())
+    // mail-inbox-mailer: 既定 kind は 'fetch'、payload は null。
+    expect(claimed!.kind).toBe('fetch')
+    expect(claimed!.payload).toBeNull()
 
     // DB state: status=claimed, claimed_at populated.
     const row = (await testDb.select().from(mailWorkerJobs))[0]!
     expect(row.status).toBe('claimed')
     expect(row.claimedAt).not.toBeNull()
+  })
+
+  // mail-inbox-mailer: kind フィルタ動作。fetch mode の dispatcher は
+  // `['fetch']` で claim し、extract-only mode の dispatcher は
+  // `['manual_extract']` で claim する想定。
+  it('claimNextJob with kinds=["fetch"] skips manual_extract jobs', async () => {
+    // manual_extract を先に積み（古い）、fetch を後に積む。kinds=['fetch'] は
+    // 順序を無視して fetch を取り、manual_extract は pending のまま残る。
+    const meId = await seedJob({
+      kind: 'manual_extract',
+      payload: { mail_message_id: 123 },
+    })
+    const fetchId = await seedJob({ kind: 'fetch' })
+
+    const claimed = await claimNextJob(getDb(), { kinds: ['fetch'] })
+    expect(claimed?.id).toBe(fetchId)
+    expect(claimed?.kind).toBe('fetch')
+
+    // manual_extract は pending のまま。
+    const rows = await testDb.select().from(mailWorkerJobs)
+    const me = rows.find((r) => r.id === meId)!
+    expect(me.status).toBe('pending')
+  })
+
+  it('claimNextJob with kinds=["manual_extract"] only picks manual_extract jobs and returns its payload', async () => {
+    const fetchId = await seedJob({ kind: 'fetch' })
+    const meId = await seedJob({
+      kind: 'manual_extract',
+      payload: { mail_message_id: 42 },
+    })
+
+    const claimed = await claimNextJob(getDb(), { kinds: ['manual_extract'] })
+    expect(claimed?.id).toBe(meId)
+    expect(claimed?.kind).toBe('manual_extract')
+    // payload は jsonb→unknown。helper で narrow できることを確認。
+    expect(parseManualExtractPayload(claimed!.payload).mail_message_id).toBe(42)
+
+    // fetch は pending のまま。
+    const rows = await testDb.select().from(mailWorkerJobs)
+    const fetch = rows.find((r) => r.id === fetchId)!
+    expect(fetch.status).toBe('pending')
+  })
+
+  it('parseManualExtractPayload throws on missing mail_message_id', () => {
+    expect(() => parseManualExtractPayload(null)).toThrow(/missing mail_message_id/)
+    expect(() => parseManualExtractPayload({})).toThrow(/missing mail_message_id/)
+    expect(() => parseManualExtractPayload({ mail_message_id: '42' })).toThrow(
+      /missing mail_message_id/,
+    )
   })
 
   it('returns null when no pending jobs are available', async () => {

--- a/apps/mail-worker/test/manual-extract.test.ts
+++ b/apps/mail-worker/test/manual-extract.test.ts
@@ -1,0 +1,182 @@
+import { fileURLToPath } from 'node:url'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { eq } from 'drizzle-orm'
+import {
+  mailMessages,
+  mailWorkerRuns,
+  tournamentDrafts,
+  users,
+} from '@kagetra/shared/schema'
+import { runManualExtract } from '../src/pipeline.js'
+import {
+  FixtureLLMExtractor,
+  loadFixturesFromDir,
+} from '../src/classify/llm/fixture.js'
+import { BrokenLLMExtractor } from '../src/classify/llm/broken.js'
+import {
+  closeTestDb,
+  testDb,
+  truncateMailTables,
+  truncateMailWorkerTables,
+} from './test-db.js'
+import { closeDb } from '../src/db.js'
+
+const LLM_FIXTURE_DIR = fileURLToPath(new URL('./fixtures/llm/', import.meta.url))
+const ADMIN_USER_ID = 'admin-extract-only'
+
+async function buildExtractor(): Promise<FixtureLLMExtractor> {
+  return new FixtureLLMExtractor(await loadFixturesFromDir(LLM_FIXTURE_DIR))
+}
+
+async function seedAdmin() {
+  await testDb.insert(users).values({
+    id: ADMIN_USER_ID,
+    name: 'Admin',
+    email: 'admin-extract@example.com',
+    role: 'admin',
+  })
+}
+
+/**
+ * mail-inbox-mailer: manual_extract dispatcher が呼ぶ AI 抽出専用パスのテスト。
+ * IMAP fetch 経路を通らず、既存 mail_messages 行に対して classifyMail + persistOutcome
+ * を回し、mail_worker_runs を kind='manual' で残せることを確認する。
+ */
+async function seedMailMessage(opts: {
+  subject?: string
+  classification?: 'tournament' | 'noise' | 'unknown' | null
+}) {
+  const [row] = await testDb
+    .insert(mailMessages)
+    .values({
+      messageId: `<manual-${Date.now()}-${Math.floor(Math.random() * 1e6)}@test>`,
+      fromAddress: 'organizer@example.com',
+      fromName: '主催者',
+      toAddresses: ['kagetra@example.com'],
+      subject: opts.subject ?? '[taikai-ajka:829] 第66回標榜大会のご案内',
+      receivedAt: new Date(),
+      bodyText: 'テスト本文',
+      bodyHtml: null,
+      status: 'fetched',
+      classification: opts.classification ?? null,
+      imapUid: null,
+      imapBox: null,
+    })
+    .returning({ id: mailMessages.id })
+  return row!.id
+}
+
+describe('runManualExtract (mail-inbox-mailer task2)', () => {
+  beforeEach(async () => {
+    await truncateMailTables()
+    await truncateMailWorkerTables()
+    await testDb.execute(/* sql */`TRUNCATE TABLE users RESTART IDENTITY CASCADE`)
+    await seedAdmin()
+  })
+
+  afterAll(async () => {
+    await closeDb()
+    await closeTestDb()
+  })
+
+  it('classifyMail + persistOutcome を流し、mail_worker_runs を kind=manual / status=success で残す', async () => {
+    // fixture loader は emailMeta.subject で match するので、payload と同じ
+    // subject を mail に持たせる必要がある。tournament-announcement の subject
+    // を流用。
+    const mailId = await seedMailMessage({
+      subject: '[taikai-ajka:829] 第66回標榜大会のご案内',
+    })
+    const llm = await buildExtractor()
+
+    const result = await runManualExtract({
+      mailMessageId: mailId,
+      llmExtractor: llm,
+      triggeredByUserId: ADMIN_USER_ID,
+    })
+
+    expect(result.status).toBe('success')
+    expect(result.aiSucceeded).toBe(1)
+    expect(result.aiFailed).toBe(0)
+    expect(result.draftsInserted).toBe(1)
+
+    // run 行
+    const runs = await testDb.select().from(mailWorkerRuns)
+    expect(runs).toHaveLength(1)
+    expect(runs[0]!.kind).toBe('manual')
+    expect(runs[0]!.status).toBe('success')
+    expect(runs[0]!.triggeredByUserId).toBe(ADMIN_USER_ID)
+    expect(runs[0]!.finishedAt).not.toBeNull()
+    expect(runs[0]!.since).toBeNull()
+
+    // draft 行
+    const drafts = await testDb.select().from(tournamentDrafts)
+    expect(drafts).toHaveLength(1)
+    expect(drafts[0]!.messageId).toBe(mailId)
+    expect(drafts[0]!.status).toBe('pending_review')
+
+    // mail 行は ai_done に遷移
+    const mail = await testDb
+      .select()
+      .from(mailMessages)
+      .where(eq(mailMessages.id, mailId))
+    expect(mail[0]!.status).toBe('ai_done')
+  })
+
+  it('classification=noise の mail も force:true で AI を回す（pre-filter を上書き）', async () => {
+    // mail-inbox-mailer の主旨: 「管理者が AI 抽出を明示要求した時点で、
+    // pre-filter の noise 判定は無視する」。runManualExtract は classifyMail
+    // に force:true を渡すので、classification='noise' でも skipped_noise には
+    // ならず AI が走る。
+    const mailId = await seedMailMessage({
+      subject: '[taikai-ajka:829] 第66回標榜大会のご案内',
+      classification: 'noise',
+    })
+    const llm = await buildExtractor()
+
+    const result = await runManualExtract({
+      mailMessageId: mailId,
+      llmExtractor: llm,
+      triggeredByUserId: ADMIN_USER_ID,
+    })
+
+    expect(result.aiSkipped).toBe(0)
+    expect(result.aiSucceeded).toBe(1)
+    expect(result.draftsInserted).toBe(1)
+  })
+
+  it('LLM が二回失敗すると run.status=ai_failed + ai_failed draft が作られる', async () => {
+    const mailId = await seedMailMessage({})
+    const result = await runManualExtract({
+      mailMessageId: mailId,
+      llmExtractor: new BrokenLLMExtractor(),
+      triggeredByUserId: ADMIN_USER_ID,
+    })
+
+    expect(result.status).toBe('ai_failed')
+    expect(result.aiFailed).toBe(1)
+    expect(result.aiSucceeded).toBe(0)
+    expect(result.aiErrors.length).toBeGreaterThan(0)
+
+    const runs = await testDb.select().from(mailWorkerRuns)
+    expect(runs[0]!.status).toBe('ai_failed')
+
+    // draft 行は ai_failed で残る（再試行できる状態）
+    const drafts = await testDb.select().from(tournamentDrafts)
+    expect(drafts).toHaveLength(1)
+    expect(drafts[0]!.status).toBe('ai_failed')
+  })
+
+  it('存在しない mail_message_id を渡すと aiFailed=1 で finish する（top-level に伝播させない）', async () => {
+    const result = await runManualExtract({
+      mailMessageId: 999_999,
+      llmExtractor: new BrokenLLMExtractor(),
+      triggeredByUserId: ADMIN_USER_ID,
+    })
+
+    // 例外を投げず ai_failed として記録する（dispatcher 側で 1 ジョブごとに
+    // try/catch する設計と整合）。
+    expect(result.status).toBe('ai_failed')
+    expect(result.aiFailed).toBe(1)
+    expect(result.aiErrors[0]).toMatch(/not found/)
+  })
+})

--- a/apps/mail-worker/test/manual-extract.test.ts
+++ b/apps/mail-worker/test/manual-extract.test.ts
@@ -216,7 +216,11 @@ describe('runManualExtract (mail-inbox-mailer task2)', () => {
     })
 
     // 例外を投げず ai_failed として記録する（dispatcher 側で 1 ジョブごとに
-    // try/catch する設計と整合）。
+    // try/catch する設計と整合）。Codex r2 blocker: catch 経路でも draft を
+    // 強制終端するコードを追加したが、本テストでは対象 mail が存在せず、
+    // 同 mail_id にぶら下がる draft も無いので catch 内 UPDATE は no-op になる
+    // のみ。catch 経路の draft 強制終端は、実運用時にエラーログを介して
+    // 確認する（直接 verify する unit test は CASCADE FK の制約上困難）。
     expect(result.status).toBe('ai_failed')
     expect(result.aiFailed).toBe(1)
     expect(result.aiErrors[0]).toMatch(/not found/)

--- a/apps/mail-worker/test/manual-extract.test.ts
+++ b/apps/mail-worker/test/manual-extract.test.ts
@@ -144,6 +144,48 @@ describe('runManualExtract (mail-inbox-mailer task2)', () => {
     expect(result.draftsInserted).toBe(1)
   })
 
+  // Codex r1 blocker: persistOutcome は noise/oversize_skipped/skipped_noise で
+  // tournament_drafts を触らないため、triggerExtractDraft が先に作った
+  // ai_processing draft が永遠に残り polling が停止しない。runManualExtract で
+  // 強制終端ロジック (ai_failed へ倒す) を追加したので、その動作を verify する。
+  it('AI が noise 判定の場合、事前作成 ai_processing draft を ai_failed に強制終端する', async () => {
+    // fixture map にマッチしない subject の mail を渡す → FixtureLLMExtractor は
+    // noise を返す（fallback FIXTURE_NOISE_PAYLOAD）。
+    const mailId = await seedMailMessage({
+      subject: '完全に大会と関係ない件名',
+    })
+    const llm = await buildExtractor()
+
+    // 事前に triggerExtractDraft が作るのと同じ shape で ai_processing draft を作る。
+    await testDb.insert(tournamentDrafts).values({
+      messageId: mailId,
+      status: 'ai_processing',
+      extractedPayload: {},
+      promptVersion: '',
+      aiModel: '',
+    })
+
+    const result = await runManualExtract({
+      mailMessageId: mailId,
+      llmExtractor: llm,
+      triggeredByUserId: ADMIN_USER_ID,
+    })
+
+    // tally: noise 判定で aiSucceeded=1 / 強制終端で aiFailed=1。
+    expect(result.aiSucceeded).toBe(1)
+    expect(result.aiFailed).toBe(1)
+    // run.status は ai_failed に倒れる（UI が「失敗」として扱う）。
+    expect(result.status).toBe('ai_failed')
+
+    // draft は ai_failed に倒れている（polling が停止する）。
+    const drafts = await testDb
+      .select()
+      .from(tournamentDrafts)
+      .where(eq(tournamentDrafts.messageId, mailId))
+    expect(drafts).toHaveLength(1)
+    expect(drafts[0]!.status).toBe('ai_failed')
+  })
+
   it('LLM が二回失敗すると run.status=ai_failed + ai_failed draft が作られる', async () => {
     const mailId = await seedMailMessage({})
     const result = await runManualExtract({

--- a/apps/mail-worker/test/notify/web-push.test.ts
+++ b/apps/mail-worker/test/notify/web-push.test.ts
@@ -48,7 +48,7 @@ async function seedSub(userId: string, endpoint: string) {
   })
 }
 
-async function seedMail(triageStatus: 'unprocessed' | 'processed' | 'deferred') {
+async function seedMail(triageStatus: 'unprocessed' | 'processed') {
   await testDb.insert(mailMessages).values({
     messageId: `<${crypto.randomUUID()}@test>`,
     fromAddress: 'organizer@example.com',
@@ -76,8 +76,9 @@ describe('notifyNewMailPush (mail-triage-badge)', () => {
     await seedSub(admin.id, 'https://push.example/admin')
     await seedSub(vice.id, 'https://push.example/vice')
     await seedSub(member.id, 'https://push.example/member') // 対象外
+    // mail-inbox-mailer: deferred 廃止。未処理 2 件 + processed 1 件で badge=2。
     await seedMail('unprocessed')
-    await seedMail('deferred')
+    await seedMail('unprocessed')
     await seedMail('processed') // バッジに含めない
 
     await notifyNewMailPush(testDb, CONFIG, {
@@ -89,7 +90,7 @@ describe('notifyNewMailPush (mail-triage-badge)', () => {
     // admin + vice の 2 件のみ（member は除外）
     expect(mocks.send).toHaveBeenCalledTimes(2)
     const payload = JSON.parse(mocks.send.mock.calls[0]![1] as string)
-    expect(payload.badge).toBe(2) // unprocessed + deferred
+    expect(payload.badge).toBe(2) // unprocessed × 2
     expect(payload.url).toBe('/admin/mail-inbox')
     expect(payload.body).toContain('テスト大会のご案内')
     expect(payload.body).toContain('主催者')

--- a/apps/web/e2e/mail-inbox-ai-extract.spec.ts
+++ b/apps/web/e2e/mail-inbox-ai-extract.spec.ts
@@ -92,7 +92,7 @@ test.describe('mail-inbox-mailer: AI extract trigger', () => {
       .where(eq(mailWorkerJobs.kind, 'manual_extract'))
     expect(jobs).toHaveLength(1)
     expect(jobs[0]!.payload).toEqual({ mail_message_id: mail.id })
-    expect(jobs[0]!.requestedByUserId).toBe(admin.user.id)
+    expect(jobs[0]!.requestedByUserId).toBe(admin.userId)
 
     await context.close()
   })

--- a/apps/web/e2e/mail-inbox-ai-extract.spec.ts
+++ b/apps/web/e2e/mail-inbox-ai-extract.spec.ts
@@ -1,0 +1,130 @@
+import { expect, test } from '@playwright/test'
+import { eq } from 'drizzle-orm'
+import {
+  mailWorkerJobs,
+  tournamentDrafts,
+} from '@kagetra/shared/schema'
+import {
+  AUTHJS_SESSION_COOKIE,
+  seedAdminSession,
+} from '../src/test-utils/playwright-auth'
+import { createMailMessage } from '../src/test-utils/seed'
+import { testDb, truncateAll } from '../src/test-utils/db'
+
+/**
+ * mail-inbox-mailer タスク7: 「会で流す（AI 抽出）」確認ダイアログ → triggerExtractDraft
+ * のフロントエンド連動を end-to-end で確認する。
+ *
+ * DOM 契約:
+ *   - 未処理 + draft なしの mail 詳細画面に「会で流す（AI 抽出）」ボタンが出る
+ *   - ボタン押下で確認ダイアログが開く
+ *   - 「はい」で tournament_drafts INSERT (status='ai_processing') と
+ *     mail_worker_jobs INSERT (kind='manual_extract', payload={mail_message_id})
+ *   - 完了後の画面再取得で ExtractionInProgressCard 表示に切り替わる
+ */
+async function addSessionCookie(
+  context: import('@playwright/test').BrowserContext,
+  token: string,
+) {
+  await context.addCookies([
+    {
+      name: AUTHJS_SESSION_COOKIE,
+      value: token,
+      domain: 'localhost',
+      path: '/',
+      httpOnly: true,
+      sameSite: 'Lax',
+    },
+  ])
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test.describe('mail-inbox-mailer: AI extract trigger', () => {
+  test.beforeEach(async () => {
+    await truncateAll()
+  })
+
+  test('「会で流す」→ 確認 →「はい」で draft (ai_processing) + manual_extract job が作られる', async ({
+    browser,
+  }) => {
+    const admin = await seedAdminSession({ name: 'Inbox Admin' })
+    const mail = await createMailMessage({
+      subject: '【ご案内】第99回テスト大会',
+      bodyText: 'テストの本文です。',
+      triageStatus: 'unprocessed',
+    })
+
+    const context = await browser.newContext()
+    await addSessionCookie(context, admin.sessionToken)
+    const page = await context.newPage()
+
+    await page.goto(`/admin/mail-inbox/mail/${mail.id}`)
+
+    // mail-inbox-mailer: 本文は details トグルではなく即時表示。
+    await expect(page.getByText('テストの本文です。')).toBeVisible()
+
+    // 3 ボタンが揃って出る。
+    const triggerButton = page.getByRole('button', { name: '会で流す（AI 抽出）' })
+    await expect(triggerButton).toBeVisible()
+    await expect(page.getByRole('button', { name: '既存イベントに紐付ける' })).toBeVisible()
+    await expect(page.getByRole('button', { name: '対応不要' })).toBeVisible()
+
+    // 確認ダイアログ → 「はい」
+    await triggerButton.click()
+    await expect(page.getByText('AI で抽出します')).toBeVisible()
+    await page.getByRole('button', { name: 'はい' }).click()
+
+    // ExtractionInProgressCard が表示される（refresh 後）。
+    await expect(page.getByText('AI 抽出中…')).toBeVisible()
+
+    // DB を直接覗いて Server Action の副作用を verify。
+    const drafts = await testDb
+      .select()
+      .from(tournamentDrafts)
+      .where(eq(tournamentDrafts.messageId, mail.id))
+    expect(drafts).toHaveLength(1)
+    expect(drafts[0]!.status).toBe('ai_processing')
+
+    const jobs = await testDb
+      .select()
+      .from(mailWorkerJobs)
+      .where(eq(mailWorkerJobs.kind, 'manual_extract'))
+    expect(jobs).toHaveLength(1)
+    expect(jobs[0]!.payload).toEqual({ mail_message_id: mail.id })
+    expect(jobs[0]!.requestedByUserId).toBe(admin.user.id)
+
+    await context.close()
+  })
+
+  test('「いいえ」を押せば draft も job も作らずダイアログだけ閉じる', async ({
+    browser,
+  }) => {
+    const admin = await seedAdminSession({ name: 'Inbox Admin' })
+    const mail = await createMailMessage({
+      subject: '別件メール',
+      triageStatus: 'unprocessed',
+    })
+
+    const context = await browser.newContext()
+    await addSessionCookie(context, admin.sessionToken)
+    const page = await context.newPage()
+
+    await page.goto(`/admin/mail-inbox/mail/${mail.id}`)
+    await page.getByRole('button', { name: '会で流す（AI 抽出）' }).click()
+    await page.getByRole('button', { name: 'いいえ' }).click()
+
+    await expect(page.getByText('AI で抽出します')).not.toBeVisible()
+
+    const drafts = await testDb
+      .select()
+      .from(tournamentDrafts)
+      .where(eq(tournamentDrafts.messageId, mail.id))
+    expect(drafts).toHaveLength(0)
+
+    const jobs = await testDb.select().from(mailWorkerJobs)
+    expect(jobs).toHaveLength(0)
+
+    await context.close()
+  })
+})

--- a/apps/web/e2e/mail-inbox-link-event.spec.ts
+++ b/apps/web/e2e/mail-inbox-link-event.spec.ts
@@ -1,0 +1,101 @@
+import { expect, test } from '@playwright/test'
+import { eq } from 'drizzle-orm'
+import { mailMessages } from '@kagetra/shared/schema'
+import {
+  AUTHJS_SESSION_COOKIE,
+  seedAdminSession,
+} from '../src/test-utils/playwright-auth'
+import { createEvent, createMailMessage } from '../src/test-utils/seed'
+import { testDb, truncateAll } from '../src/test-utils/db'
+
+/**
+ * mail-inbox-mailer タスク7: 「既存イベントに紐付ける」シートのフロント連動を
+ * end-to-end で確認する。
+ *
+ * フロー:
+ *   1. mail 詳細を開く → 「既存イベントに紐付ける」を押す
+ *   2. シートに候補（未開催 + 過去 30 日）が並ぶ
+ *   3. 選択 → 「結びつける」→ linkMailToEvent → /admin/mail-inbox に戻る
+ *   4. DB を確認:
+ *      - mail_messages.linked_event_id = ev.id
+ *      - triage_status='processed'
+ *      - triaged_at / triaged_by_user_id がセット
+ *
+ * LINE 配信は after() で発火するが、テスト DB 環境では LINE channel binding が
+ * 無いので broadcastMailToEvent は早期 return（skipped）して terminating すれば
+ * よい。配信成功までは DB 状態としては確認しない（タスク3 の Vitest で hook を
+ * spy したのと役割を分ける）。
+ */
+async function addSessionCookie(
+  context: import('@playwright/test').BrowserContext,
+  token: string,
+) {
+  await context.addCookies([
+    {
+      name: AUTHJS_SESSION_COOKIE,
+      value: token,
+      domain: 'localhost',
+      path: '/',
+      httpOnly: true,
+      sameSite: 'Lax',
+    },
+  ])
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test.describe('mail-inbox-mailer: link mail to existing event', () => {
+  test.beforeEach(async () => {
+    await truncateAll()
+  })
+
+  test('既存イベント結びつけシート → 紐付け → triage=processed + linked_event_id 確定', async ({
+    browser,
+  }) => {
+    const admin = await seedAdminSession({ name: 'Link Admin' })
+
+    // 未開催の event を 1 件用意（候補に出る範囲）。
+    const event = await createEvent({
+      title: '結びつけ先大会 A',
+      eventDate: '2099-12-01',
+      status: 'published',
+    })
+
+    const mail = await createMailMessage({
+      subject: '【補足】組合せ表',
+      bodyText: '組合せ表 v1 です。',
+      triageStatus: 'unprocessed',
+    })
+
+    const context = await browser.newContext()
+    await addSessionCookie(context, admin.sessionToken)
+    const page = await context.newPage()
+
+    await page.goto(`/admin/mail-inbox/mail/${mail.id}`)
+
+    // シート起動。
+    await page.getByRole('button', { name: '既存イベントに紐付ける' }).click()
+
+    // 候補に target event のタイトルが出る。
+    const optionLabel = page.locator('label', { hasText: '結びつけ先大会 A' })
+    await expect(optionLabel).toBeVisible()
+    await optionLabel.locator('input[type=radio]').check()
+
+    // 「結びつける」押下で /admin/mail-inbox に遷移。
+    await page.getByRole('button', { name: '結びつける' }).click()
+    await page.waitForURL('**/admin/mail-inbox')
+
+    // DB 状態を verify。
+    const after = await testDb
+      .select()
+      .from(mailMessages)
+      .where(eq(mailMessages.id, mail.id))
+    expect(after).toHaveLength(1)
+    expect(after[0]!.linkedEventId).toBe(event.id)
+    expect(after[0]!.triageStatus).toBe('processed')
+    expect(after[0]!.triagedByUserId).toBe(admin.user.id)
+    expect(after[0]!.triagedAt).not.toBeNull()
+
+    await context.close()
+  })
+})

--- a/apps/web/e2e/mail-inbox-link-event.spec.ts
+++ b/apps/web/e2e/mail-inbox-link-event.spec.ts
@@ -93,7 +93,7 @@ test.describe('mail-inbox-mailer: link mail to existing event', () => {
     expect(after).toHaveLength(1)
     expect(after[0]!.linkedEventId).toBe(event.id)
     expect(after[0]!.triageStatus).toBe('processed')
-    expect(after[0]!.triagedByUserId).toBe(admin.user.id)
+    expect(after[0]!.triagedByUserId).toBe(admin.userId)
     expect(after[0]!.triagedAt).not.toBeNull()
 
     await context.close()

--- a/apps/web/src/app/(app)/admin/mail-inbox/actions.test.ts
+++ b/apps/web/src/app/(app)/admin/mail-inbox/actions.test.ts
@@ -104,6 +104,9 @@ const {
   triggerMailFetch,
   dismissMail,
   undoTriage,
+  triggerExtractDraft,
+  linkMailToEvent,
+  unlinkMailFromEvent,
 } = await import('./actions')
 
 function buildApproveFormData(overrides: Partial<Record<string, string>> = {}) {
@@ -1452,6 +1455,220 @@ describe('admin/mail-inbox actions', () => {
 
       const after = await getMail(mail.id)
       expect(after?.triageStatus).toBe('processed')
+    })
+  })
+
+  // ── mail-inbox-mailer task3: triggerExtractDraft / linkMailToEvent / unlinkMailFromEvent ──
+  describe('triggerExtractDraft (mail-inbox-mailer)', () => {
+    it('draft なし: 新規 tournament_drafts(status=ai_processing) + manual_extract job を作る', async () => {
+      const admin = await createAdmin()
+      await setAuthSession({ id: admin.id, role: 'admin' })
+      const mail = await createMailMessage({ triageStatus: 'unprocessed' })
+
+      const result = await triggerExtractDraft(mail.id)
+      expect(result.ok).toBe(true)
+      if (!result.ok) return
+
+      const draft = await testDb
+        .select()
+        .from(tournamentDrafts)
+        .where(eq(tournamentDrafts.id, result.draftId))
+      expect(draft).toHaveLength(1)
+      expect(draft[0]!.status).toBe('ai_processing')
+      expect(draft[0]!.messageId).toBe(mail.id)
+      expect(draft[0]!.promptVersion).toBe('')
+      expect(draft[0]!.aiModel).toBe('')
+      expect(draft[0]!.extractedPayload).toEqual({})
+
+      const job = await testDb
+        .select()
+        .from(mailWorkerJobs)
+        .where(eq(mailWorkerJobs.id, result.jobId))
+      expect(job).toHaveLength(1)
+      expect(job[0]!.kind).toBe('manual_extract')
+      expect(job[0]!.status).toBe('pending')
+      expect(job[0]!.payload).toEqual({ mail_message_id: mail.id })
+      expect(job[0]!.requestedByUserId).toBe(admin.id)
+
+      // 未処理バッジには残す（draft 作成だけで processed にはしない）。
+      const afterMail = await getMail(mail.id)
+      expect(afterMail?.triageStatus).toBe('unprocessed')
+    })
+
+    it('既存 ai_failed draft: status=ai_processing にリセット + 新ジョブ enqueue', async () => {
+      const admin = await createAdmin()
+      await setAuthSession({ id: admin.id, role: 'admin' })
+      const mail = await createMailMessage({ triageStatus: 'unprocessed' })
+      const existing = await createTournamentDraft({
+        messageId: mail.id,
+        status: 'ai_failed',
+        promptVersion: '1.0.0',
+        aiModel: 'claude-sonnet-4-5',
+        extractedPayload: { dummy: true },
+      })
+
+      const result = await triggerExtractDraft(mail.id)
+      expect(result.ok).toBe(true)
+      if (!result.ok) return
+      // 同じ draft 行が UPDATE される (UNIQUE 制約より)。
+      expect(result.draftId).toBe(existing.id)
+
+      const after = await testDb
+        .select()
+        .from(tournamentDrafts)
+        .where(eq(tournamentDrafts.id, existing.id))
+      expect(after[0]!.status).toBe('ai_processing')
+      expect(after[0]!.promptVersion).toBe('')
+      expect(after[0]!.aiModel).toBe('')
+      expect(after[0]!.extractedPayload).toEqual({})
+    })
+
+    it('pending_review draft が既にある場合は error を返す（再抽出は別経路）', async () => {
+      const admin = await createAdmin()
+      await setAuthSession({ id: admin.id, role: 'admin' })
+      const mail = await createMailMessage()
+      await createTournamentDraft({
+        messageId: mail.id,
+        status: 'pending_review',
+      })
+
+      const result = await triggerExtractDraft(mail.id)
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.error).toMatch(/既に AI 抽出済み/)
+    })
+
+    it('存在しない mail は error を返す', async () => {
+      const admin = await createAdmin()
+      await setAuthSession({ id: admin.id, role: 'admin' })
+
+      const result = await triggerExtractDraft(999_999)
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.error).toMatch(/mail not found/)
+    })
+
+    it('未認証 / member は呼べない', async () => {
+      const mail = await createMailMessage()
+      await setAuthSession(null)
+      await expect(triggerExtractDraft(mail.id)).rejects.toThrow('Unauthorized')
+
+      const member = await createUser()
+      await setAuthSession({ id: member.id, role: 'member' })
+      await expect(triggerExtractDraft(mail.id)).rejects.toThrow('Forbidden')
+    })
+  })
+
+  describe('linkMailToEvent (mail-inbox-mailer)', () => {
+    it('linked_event_id を立て、triage processed、after() で broadcastMailToEvent を起動', async () => {
+      const admin = await createAdmin()
+      await setAuthSession({ id: admin.id, role: 'admin' })
+      const mail = await createMailMessage({ triageStatus: 'unprocessed' })
+      const event = await createEvent({ title: '結びつけ先大会' })
+
+      afterMock.mockImplementationOnce((cb) => {
+        return cb()
+      })
+      broadcastMailToEventMock.mockClear()
+
+      const result = await linkMailToEvent(mail.id, event.id)
+      expect(result.ok).toBe(true)
+
+      const after = await getMail(mail.id)
+      expect(after?.linkedEventId).toBe(event.id)
+      expect(after?.triageStatus).toBe('processed')
+      expect(after?.triagedByUserId).toBe(admin.id)
+      expect(after?.triagedAt).toBeInstanceOf(Date)
+
+      // broadcastMailToEvent が isCorrection=false で呼ばれる。
+      expect(broadcastMailToEventMock).toHaveBeenCalledTimes(1)
+      // hoisted mock の signature は引数なしだが、実引数は (db, { eventId, ... })。
+      // 型を緩めて payload オブジェクトを直接検証する。
+      const callArgs = (
+        broadcastMailToEventMock.mock.calls[0] as unknown as [
+          unknown,
+          { eventId: number; mailMessageId: number; isCorrection: boolean },
+        ]
+      )
+      expect(callArgs[1]).toEqual({
+        eventId: event.id,
+        mailMessageId: mail.id,
+        isCorrection: false,
+      })
+    })
+
+    it('既に紐付け済みの mail は二重紐付け不可', async () => {
+      const admin = await createAdmin()
+      await setAuthSession({ id: admin.id, role: 'admin' })
+      const event = await createEvent({ title: 'A' })
+      const event2 = await createEvent({ title: 'B' })
+      const mail = await createMailMessage()
+      await linkMailToEvent(mail.id, event.id)
+
+      const result = await linkMailToEvent(mail.id, event2.id)
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.error).toMatch(/既に別イベントに紐付け済/)
+    })
+
+    it('存在しない event は error を返す（mail は変更しない）', async () => {
+      const admin = await createAdmin()
+      await setAuthSession({ id: admin.id, role: 'admin' })
+      const mail = await createMailMessage({ triageStatus: 'unprocessed' })
+
+      const result = await linkMailToEvent(mail.id, 999_999)
+      expect(result.ok).toBe(false)
+
+      const after = await getMail(mail.id)
+      expect(after?.linkedEventId).toBeNull()
+      expect(after?.triageStatus).toBe('unprocessed')
+    })
+
+    it('未認証 / member は呼べない', async () => {
+      const mail = await createMailMessage()
+      const event = await createEvent({ title: 'E' })
+
+      await setAuthSession(null)
+      await expect(linkMailToEvent(mail.id, event.id)).rejects.toThrow('Unauthorized')
+
+      const member = await createUser()
+      await setAuthSession({ id: member.id, role: 'member' })
+      await expect(linkMailToEvent(mail.id, event.id)).rejects.toThrow('Forbidden')
+    })
+  })
+
+  describe('unlinkMailFromEvent (mail-inbox-mailer)', () => {
+    it('linked_event_id を NULL に戻し triage_status を unprocessed に戻す', async () => {
+      const admin = await createAdmin()
+      await setAuthSession({ id: admin.id, role: 'admin' })
+      const event = await createEvent({ title: '解除元' })
+      const mail = await createMailMessage()
+      await linkMailToEvent(mail.id, event.id)
+
+      await unlinkMailFromEvent(mail.id)
+
+      const after = await getMail(mail.id)
+      expect(after?.linkedEventId).toBeNull()
+      expect(after?.triageStatus).toBe('unprocessed')
+      expect(after?.triagedAt).toBeNull()
+      expect(after?.triagedByUserId).toBeNull()
+    })
+
+    it('存在しない mail は throw する', async () => {
+      const admin = await createAdmin()
+      await setAuthSession({ id: admin.id, role: 'admin' })
+      await expect(unlinkMailFromEvent(999_999)).rejects.toThrow('mail not found')
+    })
+
+    it('未認証 / member は呼べない', async () => {
+      const mail = await createMailMessage()
+
+      await setAuthSession(null)
+      await expect(unlinkMailFromEvent(mail.id)).rejects.toThrow('Unauthorized')
+
+      const member = await createUser()
+      await setAuthSession({ id: member.id, role: 'member' })
+      await expect(unlinkMailFromEvent(mail.id)).rejects.toThrow('Forbidden')
     })
   })
 })

--- a/apps/web/src/app/(app)/admin/mail-inbox/actions.test.ts
+++ b/apps/web/src/app/(app)/admin/mail-inbox/actions.test.ts
@@ -1692,6 +1692,42 @@ describe('admin/mail-inbox actions', () => {
       })
     })
 
+    // Codex r5 should-fix: UI 候補条件 (cancelled 除外 / 過去 30 日以内) を
+    // Server Action 側でも verify する。
+    it('cancelled イベントへの linkMailToEvent は拒否される', async () => {
+      const admin = await createAdmin()
+      await setAuthSession({ id: admin.id, role: 'admin' })
+      const event = await createEvent({
+        title: 'キャンセル済',
+        status: 'cancelled',
+      })
+      const mail = await createMailMessage({ triageStatus: 'unprocessed' })
+
+      const result = await linkMailToEvent(mail.id, event.id)
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.error).toMatch(/キャンセル済み/)
+    })
+
+    it('過去 31 日より古いイベントへの linkMailToEvent は拒否される', async () => {
+      const admin = await createAdmin()
+      await setAuthSession({ id: admin.id, role: 'admin' })
+      // 60 日前の日付。
+      const old = new Date(Date.now() - 60 * 24 * 3600 * 1000)
+      const oldStr = `${old.getFullYear()}-${String(old.getMonth() + 1).padStart(2, '0')}-${String(old.getDate()).padStart(2, '0')}`
+      const event = await createEvent({
+        title: '過去のイベント',
+        status: 'done',
+        eventDate: oldStr,
+      })
+      const mail = await createMailMessage({ triageStatus: 'unprocessed' })
+
+      const result = await linkMailToEvent(mail.id, event.id)
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.error).toMatch(/過去 30 日/)
+    })
+
     // Codex r3 blocker: 状態検証ガード。
     it('既に processed のメールは linkMailToEvent できない', async () => {
       const admin = await createAdmin()

--- a/apps/web/src/app/(app)/admin/mail-inbox/actions.test.ts
+++ b/apps/web/src/app/(app)/admin/mail-inbox/actions.test.ts
@@ -1538,6 +1538,39 @@ describe('admin/mail-inbox actions', () => {
       expect(result.error).toMatch(/既に AI 抽出済み/)
     })
 
+    // Codex r3 blocker: 状態検証ガードのテスト。詳細画面は unprocessed のときだけ
+    // ボタンを出すが、別タブ / 別管理者で stale 状態のまま呼び出されるケースを
+    // サーバー側でも拒否する。
+    it('既に processed のメールは triggerExtractDraft できない', async () => {
+      const admin = await createAdmin()
+      await setAuthSession({ id: admin.id, role: 'admin' })
+      const mail = await createMailMessage({ triageStatus: 'processed' })
+
+      const result = await triggerExtractDraft(mail.id)
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.error).toMatch(/既に処理済み/)
+
+      const jobs = await testDb.select().from(mailWorkerJobs)
+      expect(jobs).toHaveLength(0)
+    })
+
+    it('linked_event_id がある mail は triggerExtractDraft できない', async () => {
+      const admin = await createAdmin()
+      await setAuthSession({ id: admin.id, role: 'admin' })
+      const event = await createEvent({ title: 'evt' })
+      const mail = await createMailMessage({ triageStatus: 'unprocessed' })
+      await testDb
+        .update(mailMessages)
+        .set({ linkedEventId: event.id })
+        .where(eq(mailMessages.id, mail.id))
+
+      const result = await triggerExtractDraft(mail.id)
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.error).toMatch(/既存イベントに紐付け済み/)
+    })
+
     // Codex r2 should-fix: ai_processing 中の再 trigger は重複ジョブを生むので拒否する。
     it('ai_processing draft がある場合は重複ジョブを enqueue しない', async () => {
       const admin = await createAdmin()
@@ -1617,6 +1650,35 @@ describe('admin/mail-inbox actions', () => {
       })
     })
 
+    // Codex r3 blocker: 状態検証ガード。
+    it('既に processed のメールは linkMailToEvent できない', async () => {
+      const admin = await createAdmin()
+      await setAuthSession({ id: admin.id, role: 'admin' })
+      const event = await createEvent({ title: 'E' })
+      const mail = await createMailMessage({ triageStatus: 'processed' })
+
+      const result = await linkMailToEvent(mail.id, event.id)
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.error).toMatch(/既に処理済み/)
+    })
+
+    it('ai_processing draft があるメールは linkMailToEvent できない (AI 抽出と排他)', async () => {
+      const admin = await createAdmin()
+      await setAuthSession({ id: admin.id, role: 'admin' })
+      const event = await createEvent({ title: 'E' })
+      const mail = await createMailMessage({ triageStatus: 'unprocessed' })
+      await createTournamentDraft({
+        messageId: mail.id,
+        status: 'ai_processing',
+      })
+
+      const result = await linkMailToEvent(mail.id, event.id)
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.error).toMatch(/AI 抽出フロー中/)
+    })
+
     it('既に紐付け済みの mail は二重紐付け不可', async () => {
       const admin = await createAdmin()
       await setAuthSession({ id: admin.id, role: 'admin' })
@@ -1625,10 +1687,13 @@ describe('admin/mail-inbox actions', () => {
       const mail = await createMailMessage()
       await linkMailToEvent(mail.id, event.id)
 
+      // Codex r3 blocker: 状態検証ガード追加で、2 回目は triage=processed のため
+      // 「既に処理済み」エラーで先に弾かれる（旧仕様: 「既に別イベントに紐付け済」）。
+      // どちらにせよ二重紐付け不可という不変条件は満たされる。
       const result = await linkMailToEvent(mail.id, event2.id)
       expect(result.ok).toBe(false)
       if (result.ok) return
-      expect(result.error).toMatch(/既に別イベントに紐付け済/)
+      expect(result.error).toMatch(/既に処理済み/)
     })
 
     it('存在しない event は error を返す（mail は変更しない）', async () => {

--- a/apps/web/src/app/(app)/admin/mail-inbox/actions.test.ts
+++ b/apps/web/src/app/(app)/admin/mail-inbox/actions.test.ts
@@ -103,7 +103,6 @@ const {
   reextractDraft,
   triggerMailFetch,
   dismissMail,
-  deferMail,
   undoTriage,
 } = await import('./actions')
 
@@ -1381,22 +1380,13 @@ describe('admin/mail-inbox actions', () => {
       expect(after?.triagedByUserId).toBe(admin.id)
     })
 
-    it('deferMail: メールを deferred にする（未処理バッジには残る）', async () => {
-      const admin = await createAdmin()
-      await setAuthSession({ id: admin.id, role: 'admin' })
-      const mail = await createMailMessage({ triageStatus: 'unprocessed' })
-
-      await deferMail(mail.id)
-
-      const after = await getMail(mail.id)
-      expect(after?.triageStatus).toBe('deferred')
-      expect(after?.triagedByUserId).toBe(admin.id)
-    })
+    // mail-inbox-mailer: deferMail / deferred 状態は廃止。
+    // 「保留」は処理せず放置することが暗黙の保留である、というモデルに統合。
 
     it('undoTriage: unprocessed に戻し triaged_at/by をクリアする', async () => {
       const admin = await createAdmin()
       await setAuthSession({ id: admin.id, role: 'admin' })
-      const mail = await createMailMessage({ triageStatus: 'deferred' })
+      const mail = await createMailMessage({ triageStatus: 'processed' })
 
       await undoTriage(mail.id)
 
@@ -1410,7 +1400,6 @@ describe('admin/mail-inbox actions', () => {
       const admin = await createAdmin()
       await setAuthSession({ id: admin.id, role: 'admin' })
       await expect(dismissMail(999999)).rejects.toThrow('mail not found')
-      await expect(deferMail(999999)).rejects.toThrow('mail not found')
       await expect(undoTriage(999999)).rejects.toThrow('mail not found')
     })
 
@@ -1422,7 +1411,7 @@ describe('admin/mail-inbox actions', () => {
 
       const member = await createUser()
       await setAuthSession({ id: member.id, role: 'member' })
-      await expect(deferMail(mail.id)).rejects.toThrow('Forbidden')
+      await expect(dismissMail(mail.id)).rejects.toThrow('Forbidden')
     })
 
     it('approveDraft はメールを triage_status=processed にする', async () => {

--- a/apps/web/src/app/(app)/admin/mail-inbox/actions.test.ts
+++ b/apps/web/src/app/(app)/admin/mail-inbox/actions.test.ts
@@ -1386,6 +1386,48 @@ describe('admin/mail-inbox actions', () => {
     // mail-inbox-mailer: deferMail / deferred 状態は廃止。
     // 「保留」は処理せず放置することが暗黙の保留である、というモデルに統合。
 
+    // Codex r4 blocker: dismissMail は未完了 draft があるメールを processed に
+    // しない (AI 抽出中 / レビュー待ち draft を未処理キューから隠さない)。
+    it.each([
+      ['ai_processing'],
+      ['pending_review'],
+      ['ai_failed'],
+    ] as const)(
+      'dismissMail は %s draft があるメールでは拒否される',
+      async (status) => {
+        const admin = await createAdmin()
+        await setAuthSession({ id: admin.id, role: 'admin' })
+        const mail = await createMailMessage({ triageStatus: 'unprocessed' })
+        await createTournamentDraft({
+          messageId: mail.id,
+          status,
+        })
+
+        await expect(dismissMail(mail.id)).rejects.toThrow(
+          /未完了の AI 抽出 draft/,
+        )
+
+        // triage は unprocessed のまま。
+        const after = await getMail(mail.id)
+        expect(after?.triageStatus).toBe('unprocessed')
+      },
+    )
+
+    it('dismissMail は terminal draft (approved/rejected/superseded) なら通る', async () => {
+      const admin = await createAdmin()
+      await setAuthSession({ id: admin.id, role: 'admin' })
+      const mail = await createMailMessage({ triageStatus: 'unprocessed' })
+      await createTournamentDraft({
+        messageId: mail.id,
+        status: 'rejected',
+      })
+
+      await dismissMail(mail.id)
+
+      const after = await getMail(mail.id)
+      expect(after?.triageStatus).toBe('processed')
+    })
+
     it('undoTriage: unprocessed に戻し triaged_at/by をクリアする', async () => {
       const admin = await createAdmin()
       await setAuthSession({ id: admin.id, role: 'admin' })

--- a/apps/web/src/app/(app)/admin/mail-inbox/actions.test.ts
+++ b/apps/web/src/app/(app)/admin/mail-inbox/actions.test.ts
@@ -1538,6 +1538,26 @@ describe('admin/mail-inbox actions', () => {
       expect(result.error).toMatch(/既に AI 抽出済み/)
     })
 
+    // Codex r2 should-fix: ai_processing 中の再 trigger は重複ジョブを生むので拒否する。
+    it('ai_processing draft がある場合は重複ジョブを enqueue しない', async () => {
+      const admin = await createAdmin()
+      await setAuthSession({ id: admin.id, role: 'admin' })
+      const mail = await createMailMessage()
+      await createTournamentDraft({
+        messageId: mail.id,
+        status: 'ai_processing',
+      })
+
+      const result = await triggerExtractDraft(mail.id)
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.error).toMatch(/既に AI 抽出中/)
+
+      // 新規 job は作られない（pending な manual_extract が積まれていない）。
+      const jobs = await testDb.select().from(mailWorkerJobs)
+      expect(jobs).toHaveLength(0)
+    })
+
     it('存在しない mail は error を返す', async () => {
       const admin = await createAdmin()
       await setAuthSession({ id: admin.id, role: 'admin' })

--- a/apps/web/src/app/(app)/admin/mail-inbox/actions.ts
+++ b/apps/web/src/app/(app)/admin/mail-inbox/actions.ts
@@ -812,10 +812,54 @@ async function setTriage(
   revalidatePath(`/admin/mail-inbox/mail/${mailId}`)
 }
 
-/** 対応不要として片付ける（→ processed、未処理バッジから除外）。 */
+/**
+ * 対応不要として片付ける（→ processed、未処理バッジから除外）。
+ *
+ * Codex r4 blocker: 未完了 draft (ai_processing / pending_review / ai_failed)
+ * があるメールを processed にすると、AI 抽出中またはレビュー待ちの draft が
+ * 未処理キューから消えて見落とされる。transaction 化して FOR UPDATE で
+ * 拒否する。draft が無いか、terminal status (approved / rejected / superseded)
+ * のメールのみ「対応不要」可能。
+ */
 export async function dismissMail(mailId: number) {
   const session = await requireAdminSession()
-  await setTriage(mailId, 'processed', session.user.id)
+
+  await db.transaction(async (tx) => {
+    const mailRows = await tx
+      .select({
+        id: mailMessages.id,
+        triageStatus: mailMessages.triageStatus,
+      })
+      .from(mailMessages)
+      .where(eq(mailMessages.id, mailId))
+      .for('update')
+    if (mailRows.length === 0) throw new Error('mail not found')
+
+    const draftRows = await tx
+      .select({ status: tournamentDrafts.status })
+      .from(tournamentDrafts)
+      .where(eq(tournamentDrafts.messageId, mailId))
+      .for('update')
+    if (draftRows.length > 0) {
+      const ds = draftRows[0]!.status
+      if (ds === 'ai_processing' || ds === 'pending_review' || ds === 'ai_failed') {
+        throw new Error('未完了の AI 抽出 draft があるため対応不要にできません')
+      }
+    }
+
+    await tx
+      .update(mailMessages)
+      .set({
+        triageStatus: 'processed',
+        triagedAt: sql`now()`,
+        triagedByUserId: session.user.id,
+        updatedAt: sql`now()`,
+      })
+      .where(eq(mailMessages.id, mailId))
+  })
+
+  revalidatePath('/admin/mail-inbox')
+  revalidatePath(`/admin/mail-inbox/mail/${mailId}`)
 }
 
 /** 処理取り消し（→ unprocessed、処理者をクリア）。 */

--- a/apps/web/src/app/(app)/admin/mail-inbox/actions.ts
+++ b/apps/web/src/app/(app)/admin/mail-inbox/actions.ts
@@ -774,9 +774,14 @@ export async function linkDraftToEvent(draftId: number, eventId: number) {
 // ─────────────────────────────────────────────────────────────────────────
 // mail-triage-badge: 全メールの手動トリアージ。
 //
-// ドラフトの有無に関わらず任意の mail_messages 行を processed / deferred /
-// unprocessed に遷移させる。未処理バッジ件数は `triage_status != 'processed'`
-// (unprocessed + deferred) で数えるので、deferMail は意図的にバッジに残す。
+// ドラフトの有無に関わらず任意の mail_messages 行を processed / unprocessed に
+// 遷移させる。未処理バッジ件数は `triage_status != 'processed'`（= unprocessed）
+// で数える。
+//
+// mail-inbox-mailer (2026-06-07): 「保留 (deferred)」状態は廃止し 2 状態化。
+// 処理せず放置することが暗黙の保留である、というモデルに統合した。`deferMail`
+// は削除済み。3 アクション（AI 抽出 / 既存イベント結びつけ / 対応不要）の
+// 実体は後続タスク（タスク3 で triggerExtractDraft / linkMailToEvent 等を追加）。
 //
 // approve/reject/link は status='archived' も伴う「ドラフト処理」だが、以下は
 // triage_status だけを動かす軽量操作で status(AI/技術状態)は保持する。
@@ -786,7 +791,7 @@ export async function linkDraftToEvent(draftId: number, eventId: number) {
 
 async function setTriage(
   mailId: number,
-  triageStatus: 'processed' | 'deferred' | 'unprocessed',
+  triageStatus: 'processed' | 'unprocessed',
   triagedByUserId: string | null,
 ) {
   const updated = await db
@@ -813,13 +818,7 @@ export async function dismissMail(mailId: number) {
   await setTriage(mailId, 'processed', session.user.id)
 }
 
-/** 保留（→ deferred、未処理バッジには残す）。 */
-export async function deferMail(mailId: number) {
-  const session = await requireAdminSession()
-  await setTriage(mailId, 'deferred', session.user.id)
-}
-
-/** 処理取り消し / 保留解除（→ unprocessed、処理者をクリア）。 */
+/** 処理取り消し（→ unprocessed、処理者をクリア）。 */
 export async function undoTriage(mailId: number) {
   await requireAdminSession()
   await setTriage(mailId, 'unprocessed', null)

--- a/apps/web/src/app/(app)/admin/mail-inbox/actions.ts
+++ b/apps/web/src/app/(app)/admin/mail-inbox/actions.ts
@@ -842,14 +842,17 @@ export async function undoTriage(mailId: number) {
  *   - draft 無し                  → INSERT (status='ai_processing')
  *   - draft.status='ai_failed'    → UPDATE で status='ai_processing' に戻し
  *                                   prompt_version / ai_model / payload をクリア
- *   - draft.status='ai_processing' → 同上（前回ジョブが落ちた等の再起動）
+ *   - draft.status='ai_processing' → エラー「既に AI 抽出中」(Codex r2
+ *                                   should-fix: 二重クリック / 複数タブで重複
+ *                                   ジョブが入るのを防ぐ。極めて稀な「ジョブが
+ *                                   落ちた」復旧経路は stale-claim recovery
+ *                                   (jobs.ts) と manual_extract の終端強制で
+ *                                   別途カバー)
  *   - その他 (pending_review/approved/rejected/superseded) → エラー
  *
  * UNIQUE 制約と draft の status 更新を **同一トランザクション** で行うので、
- * 並行押下も最後の UPDATE 勝ち（draft 行は 1 つ、job は複数キューされる可能性
- * があるが dispatcher が順に処理しても classifyMail + persistOutcome が冪等な
- * ので outcome は同じ）。クライアントは確認ダイアログ＋ボタン disable で
- * 二重起動を抑止する（要件 §3.2.5）。
+ * 並行押下も SELECT FOR UPDATE で直列化される。クライアントは確認ダイアログ＋
+ * ボタン disable で二重起動を抑止する（要件 §3.2.5）。
  */
 export async function triggerExtractDraft(
   mailId: number,
@@ -892,7 +895,14 @@ export async function triggerExtractDraft(
         draftId = inserted[0]!.id
       } else {
         const cur = existing[0]!
-        if (cur.status !== 'ai_processing' && cur.status !== 'ai_failed') {
+        if (cur.status === 'ai_processing') {
+          // Codex r2 should-fix: ai_processing 中の再 trigger は重複ジョブを
+          // 生むので拒否。クライアント側でも ExtractionInProgressCard が出る
+          // 間は AIExtractConfirmDialog ボタンを出さないので、二重押下や複数
+          // タブからの直叩きを防ぐサーバー側ガード。
+          throw new Error('既に AI 抽出中です')
+        }
+        if (cur.status !== 'ai_failed') {
           // pending_review / approved / rejected / superseded: 既に状態が確定
           // しているので無条件再抽出は危険。タスク4 で reextract 経路を別 UI に
           // 出す想定。

--- a/apps/web/src/app/(app)/admin/mail-inbox/actions.ts
+++ b/apps/web/src/app/(app)/admin/mail-inbox/actions.ts
@@ -20,6 +20,10 @@ import {
 } from '@/lib/form-schemas'
 import { broadcastMailToEvent, loadActiveBinding } from '@/lib/line-broadcast'
 import {
+  linkableEventCutoffStr,
+  validateLinkableEvent,
+} from './linkable-events'
+import {
   classifyMail,
   persistOutcome,
 } from '@kagetra/mail-worker/classify/classifier'
@@ -1032,12 +1036,27 @@ export async function linkMailToEvent(
 
   try {
     await db.transaction(async (tx) => {
-      const event = await tx
-        .select({ id: events.id })
+      // Codex r5 should-fix: UI 側 loadLinkableEvents は status='cancelled' を
+      // 除外し、開催日が過去 30 日以内であることを要求する。Server Action 側
+      // でも同じ条件を verify しないと、画面表示後に event が cancelled へ
+      // 変わった or Server Action を直接叩かれたケースで許容範囲外の event に
+      // 紐付けて broadcastMailToEvent まで起動できてしまう。
+      const eventRows = await tx
+        .select({
+          id: events.id,
+          status: events.status,
+          eventDate: events.eventDate,
+        })
         .from(events)
         .where(eq(events.id, eventId))
         .limit(1)
-      if (event.length === 0) throw new Error('Event not found')
+      if (eventRows.length === 0) throw new Error('Event not found')
+      const eventRow = eventRows[0]!
+      const eventInvalid = validateLinkableEvent(
+        { status: eventRow.status, eventDate: eventRow.eventDate },
+        linkableEventCutoffStr(),
+      )
+      if (eventInvalid) throw new Error(eventInvalid)
 
       const mail = await tx
         .select({

--- a/apps/web/src/app/(app)/admin/mail-inbox/actions.ts
+++ b/apps/web/src/app/(app)/admin/mail-inbox/actions.ts
@@ -824,6 +824,249 @@ export async function undoTriage(mailId: number) {
   await setTriage(mailId, 'unprocessed', null)
 }
 
+// ─────────────────────────────────────────────────────────────────────────
+// mail-inbox-mailer タスク3: 3 アクション Server Actions
+//
+// (a) triggerExtractDraft  — 「会で流す（AI 抽出）」: draft 行 INSERT (ai_processing)
+//                            + manual_extract ジョブ enqueue。30 秒 timer が拾う。
+// (b) linkMailToEvent      — 「既存イベントに紐付ける」: linked_event_id 更新 +
+//                            triage processed + broadcastMailToEvent (after)。
+// (c) unlinkMailFromEvent  — 処理済画面 undo の補助: linked_event_id を NULL に
+//                            戻す。LINE 配信済メッセージの取り消しは不可。
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * 「会で流す（AI 抽出）」ボタンの本体。
+ *
+ * tournament_drafts.message_id は UNIQUE なので、既存 draft の有無で分岐する:
+ *   - draft 無し                  → INSERT (status='ai_processing')
+ *   - draft.status='ai_failed'    → UPDATE で status='ai_processing' に戻し
+ *                                   prompt_version / ai_model / payload をクリア
+ *   - draft.status='ai_processing' → 同上（前回ジョブが落ちた等の再起動）
+ *   - その他 (pending_review/approved/rejected/superseded) → エラー
+ *
+ * UNIQUE 制約と draft の status 更新を **同一トランザクション** で行うので、
+ * 並行押下も最後の UPDATE 勝ち（draft 行は 1 つ、job は複数キューされる可能性
+ * があるが dispatcher が順に処理しても classifyMail + persistOutcome が冪等な
+ * ので outcome は同じ）。クライアントは確認ダイアログ＋ボタン disable で
+ * 二重起動を抑止する（要件 §3.2.5）。
+ */
+export async function triggerExtractDraft(
+  mailId: number,
+): Promise<
+  | { ok: true; draftId: number; jobId: number }
+  | { ok: false; error: string }
+> {
+  const session = await requireAdminSession()
+
+  try {
+    const result = await db.transaction(async (tx) => {
+      const mail = await tx.query.mailMessages.findFirst({
+        where: eq(mailMessages.id, mailId),
+        columns: { id: true },
+      })
+      if (!mail) throw new Error('mail not found')
+
+      // FOR UPDATE で並行 trigger と直列化（実害は少ないが UPSERT 競合を避ける）。
+      const existing = await tx
+        .select({
+          id: tournamentDrafts.id,
+          status: tournamentDrafts.status,
+        })
+        .from(tournamentDrafts)
+        .where(eq(tournamentDrafts.messageId, mailId))
+        .for('update')
+
+      let draftId: number
+      if (existing.length === 0) {
+        const inserted = await tx
+          .insert(tournamentDrafts)
+          .values({
+            messageId: mailId,
+            status: 'ai_processing',
+            extractedPayload: sql`'{}'::jsonb`,
+            promptVersion: '',
+            aiModel: '',
+          })
+          .returning({ id: tournamentDrafts.id })
+        draftId = inserted[0]!.id
+      } else {
+        const cur = existing[0]!
+        if (cur.status !== 'ai_processing' && cur.status !== 'ai_failed') {
+          // pending_review / approved / rejected / superseded: 既に状態が確定
+          // しているので無条件再抽出は危険。タスク4 で reextract 経路を別 UI に
+          // 出す想定。
+          throw new Error('既に AI 抽出済みです')
+        }
+        await tx
+          .update(tournamentDrafts)
+          .set({
+            status: 'ai_processing',
+            extractedPayload: sql`'{}'::jsonb`,
+            promptVersion: '',
+            aiModel: '',
+            confidence: null,
+            aiRawResponse: null,
+            aiTokensInput: null,
+            aiTokensOutput: null,
+            aiCostUsd: null,
+            updatedAt: sql`now()`,
+          })
+          .where(eq(tournamentDrafts.id, cur.id))
+        draftId = cur.id
+      }
+
+      const insertedJob = await tx
+        .insert(mailWorkerJobs)
+        .values({
+          requestedByUserId: session.user.id,
+          status: 'pending',
+          kind: 'manual_extract',
+          payload: { mail_message_id: mailId },
+        })
+        .returning({ id: mailWorkerJobs.id })
+      const jobId = insertedJob[0]!.id
+
+      return { draftId, jobId }
+    })
+
+    revalidatePath('/admin/mail-inbox')
+    revalidatePath(`/admin/mail-inbox/mail/${mailId}`)
+    return { ok: true, draftId: result.draftId, jobId: result.jobId }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return { ok: false, error: message }
+  }
+}
+
+/**
+ * 「組合せ表」「会場案内」「訂正版」などを既存大会に紐付ける。
+ *
+ * 1 メール = 1 イベントの単純 FK。紐付け確定で:
+ *   - mail_messages.linked_event_id = eventId
+ *   - triage_status='processed', triaged_at, triaged_by_user_id
+ *   - after() で broadcastMailToEvent（既存イベントが LINE グループ linked
+ *     済なら LINE 配信、未紐付なら no-op）
+ *
+ * 紐付け済 mail に対する二重操作は禁止（一度 unlinkMailFromEvent で外してから）。
+ * UI 側でもボタンを出さない想定だが、サーバー側でも検証する。
+ */
+export async function linkMailToEvent(
+  mailId: number,
+  eventId: number,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const session = await requireAdminSession()
+
+  let linkedMailMessageId: number | null = null
+
+  try {
+    await db.transaction(async (tx) => {
+      const event = await tx
+        .select({ id: events.id })
+        .from(events)
+        .where(eq(events.id, eventId))
+        .limit(1)
+      if (event.length === 0) throw new Error('Event not found')
+
+      const mail = await tx
+        .select({
+          id: mailMessages.id,
+          linkedEventId: mailMessages.linkedEventId,
+        })
+        .from(mailMessages)
+        .where(eq(mailMessages.id, mailId))
+        .for('update')
+      if (mail.length === 0) throw new Error('mail not found')
+      if (mail[0]!.linkedEventId !== null) {
+        throw new Error('既に別イベントに紐付け済みです')
+      }
+
+      await tx
+        .update(mailMessages)
+        .set({
+          linkedEventId: eventId,
+          triageStatus: 'processed',
+          triagedAt: sql`now()`,
+          triagedByUserId: session.user.id,
+          updatedAt: sql`now()`,
+        })
+        .where(eq(mailMessages.id, mailId))
+
+      linkedMailMessageId = mailId
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return { ok: false, error: message }
+  }
+
+  revalidatePath('/admin/mail-inbox')
+  revalidatePath(`/admin/mail-inbox/mail/${mailId}`)
+  revalidatePath(`/events/${eventId}`)
+
+  // 既存 broadcastMailToEvent をそのまま再利用（linkDraftToEvent と同じ流れ）。
+  // 「訂正版」フラグは tournament_drafts.is_correction の話で、linked_event_id
+  // 経由の補足メールは常に isCorrection=false 扱い（通常の補足配信）。
+  if (linkedMailMessageId != null) {
+    const messageId = linkedMailMessageId
+    after(async () => {
+      try {
+        await broadcastMailToEvent(db, {
+          eventId,
+          mailMessageId: messageId,
+          isCorrection: false,
+        })
+      } catch (err) {
+        console.error('[linkMailToEvent] broadcastMailToEvent failed', err)
+      }
+    })
+  }
+
+  return { ok: true }
+}
+
+/**
+ * 既存イベント結びつけの取り消し（処理済画面の undo から呼ばれる）。
+ *
+ * LINE 配信済メッセージは LINE Messaging API 仕様上取り消せないので、
+ * 「紐付けだけ外す」操作（要件 §3.1.8）。triage_status も unprocessed に戻すので、
+ * 未処理バッジに再度カウントされる。
+ */
+export async function unlinkMailFromEvent(mailId: number) {
+  await requireAdminSession()
+
+  let previousEventId: number | null = null
+
+  await db.transaction(async (tx) => {
+    const mail = await tx
+      .select({
+        id: mailMessages.id,
+        linkedEventId: mailMessages.linkedEventId,
+      })
+      .from(mailMessages)
+      .where(eq(mailMessages.id, mailId))
+      .for('update')
+    if (mail.length === 0) throw new Error('mail not found')
+    previousEventId = mail[0]!.linkedEventId
+
+    await tx
+      .update(mailMessages)
+      .set({
+        linkedEventId: null,
+        triageStatus: 'unprocessed',
+        triagedAt: null,
+        triagedByUserId: null,
+        updatedAt: sql`now()`,
+      })
+      .where(eq(mailMessages.id, mailId))
+  })
+
+  revalidatePath('/admin/mail-inbox')
+  revalidatePath(`/admin/mail-inbox/mail/${mailId}`)
+  if (previousEventId != null) {
+    revalidatePath(`/events/${previousEventId}`)
+  }
+}
+
 // PR5 Phase 4a — manual mail-fetch job queue.
 //
 // The Server Action is INSERT-only into `mail_worker_jobs`; the systemd-timer

--- a/apps/web/src/app/(app)/admin/mail-inbox/actions.ts
+++ b/apps/web/src/app/(app)/admin/mail-inbox/actions.ts
@@ -864,11 +864,28 @@ export async function triggerExtractDraft(
 
   try {
     const result = await db.transaction(async (tx) => {
-      const mail = await tx.query.mailMessages.findFirst({
-        where: eq(mailMessages.id, mailId),
-        columns: { id: true },
-      })
-      if (!mail) throw new Error('mail not found')
+      // Codex r3 blocker: 詳細画面は「unprocessed + draft なし」のときだけ
+      // AI 抽出ボタンを出すが、複数タブ / 別管理者操作で stale 状態のまま
+      // ボタンが効くと、processed/linked 済 mail にもジョブを積めてしまう。
+      // mail を FOR UPDATE で取り、triage と linked_event_id を tx 内で
+      // verify する。
+      const mailRows = await tx
+        .select({
+          id: mailMessages.id,
+          triageStatus: mailMessages.triageStatus,
+          linkedEventId: mailMessages.linkedEventId,
+        })
+        .from(mailMessages)
+        .where(eq(mailMessages.id, mailId))
+        .for('update')
+      if (mailRows.length === 0) throw new Error('mail not found')
+      const mail = mailRows[0]!
+      if (mail.triageStatus !== 'unprocessed') {
+        throw new Error('既に処理済みのメールです')
+      }
+      if (mail.linkedEventId !== null) {
+        throw new Error('既存イベントに紐付け済みのメールです')
+      }
 
       // FOR UPDATE で並行 trigger と直列化（実害は少ないが UPSERT 競合を避ける）。
       const existing = await tx
@@ -981,14 +998,38 @@ export async function linkMailToEvent(
       const mail = await tx
         .select({
           id: mailMessages.id,
+          triageStatus: mailMessages.triageStatus,
           linkedEventId: mailMessages.linkedEventId,
         })
         .from(mailMessages)
         .where(eq(mailMessages.id, mailId))
         .for('update')
       if (mail.length === 0) throw new Error('mail not found')
+      // Codex r3 blocker: 詳細画面は「unprocessed + draft なし」のときだけ
+      // 結びつけボタンを出すが、画面表示後に worker が pending_review を作る
+      // 可能性があるので transaction 内で再 verify する。
+      if (mail[0]!.triageStatus !== 'unprocessed') {
+        throw new Error('既に処理済みのメールです')
+      }
       if (mail[0]!.linkedEventId !== null) {
         throw new Error('既に別イベントに紐付け済みです')
+      }
+
+      // 未完了 draft (ai_processing / pending_review / ai_failed) があるメール
+      // を既存イベントに紐付けると、後で承認操作が走った時に二重配信や状態
+      // 矛盾を起こす。AI 抽出フローと既存結びつけは互いに排他にする。
+      const conflictingDraft = await tx
+        .select({ status: tournamentDrafts.status })
+        .from(tournamentDrafts)
+        .where(eq(tournamentDrafts.messageId, mailId))
+        .for('update')
+      if (
+        conflictingDraft.length > 0 &&
+        (conflictingDraft[0]!.status === 'ai_processing' ||
+          conflictingDraft[0]!.status === 'pending_review' ||
+          conflictingDraft[0]!.status === 'ai_failed')
+      ) {
+        throw new Error('AI 抽出フロー中のメールは結びつけできません')
       }
 
       await tx

--- a/apps/web/src/app/(app)/admin/mail-inbox/components/AIExtractConfirmDialog.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/components/AIExtractConfirmDialog.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { Btn } from '@/components/ui'
+import { triggerExtractDraft } from '../actions'
+
+/**
+ * mail-inbox-mailer タスク4: 「会で流す（AI 抽出）」確認ダイアログ。
+ *
+ * 要件 §3.2.5 のコスト管理: 確認ダイアログで誤タップ防止。
+ *
+ * 「会で流す」ボタンを押す → ダイアログ表示 → 「はい」で triggerExtractDraft、
+ * 「いいえ」でクローズ。確定後は router.refresh() で詳細画面の RSC を再取得し、
+ * ExtractionInProgressCard 表示に切り替わる。失敗時はインライン error 表示。
+ */
+export function AIExtractConfirmDialog({
+  mailId,
+  buttonLabel = '会で流す（AI 抽出）',
+  buttonKind = 'primary',
+}: {
+  mailId: number
+  buttonLabel?: string
+  buttonKind?: 'primary' | 'secondary'
+}) {
+  const [open, setOpen] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [pending, startTransition] = useTransition()
+  const router = useRouter()
+
+  const onConfirm = () => {
+    setError(null)
+    startTransition(async () => {
+      const result = await triggerExtractDraft(mailId)
+      if (!result.ok) {
+        setError(result.error)
+        return
+      }
+      setOpen(false)
+      router.refresh()
+    })
+  }
+
+  return (
+    <>
+      <Btn kind={buttonKind} size="md" onClick={() => setOpen(true)} disabled={pending}>
+        {buttonLabel}
+      </Btn>
+      {open && (
+        // mail-inbox-mailer: shadcn/ui の Dialog がまだ無いので、最小限の overlay
+        // で組む。inert 属性は使わず、aria-modal / role=dialog で読み上げに対応。
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="ai-extract-confirm-title"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          onClick={() => !pending && setOpen(false)}
+        >
+          <div
+            className="w-full max-w-sm rounded-lg bg-surface p-4 shadow-lg"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 id="ai-extract-confirm-title" className="font-display text-base font-bold text-ink">
+              AI で抽出します
+            </h2>
+            <p className="mt-2 text-sm text-ink-2">
+              このメールを大会案内として AI で抽出し、ドラフトを作ります。よろしいですか？
+              （完了後に通知します）
+            </p>
+            {error && (
+              <p className="mt-2 text-xs text-danger" role="alert">
+                {error}
+              </p>
+            )}
+            <div className="mt-4 flex justify-end gap-2">
+              <Btn
+                kind="ghost"
+                size="sm"
+                onClick={() => setOpen(false)}
+                disabled={pending}
+              >
+                いいえ
+              </Btn>
+              <Btn kind="primary" size="sm" onClick={onConfirm} disabled={pending}>
+                {pending ? '送信中…' : 'はい'}
+              </Btn>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/apps/web/src/app/(app)/admin/mail-inbox/components/DraftCard.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/components/DraftCard.tsx
@@ -4,12 +4,17 @@ import { ConfidenceBadge } from './ConfidenceBadge'
 
 export interface DraftCardProps {
   draft: {
+    // mail-inbox-mailer: 'ai_processing' は AI 抽出ジョブ起動〜完了の間だけ
+    // 立つ中間状態。一覧 (page.tsx) で DraftCard を表示する場面ではほぼ
+    // 出現しないが、ジョブ実行中に一覧を開けば見える可能性があるため型に含める。
+    // 表示は StatusPill 側で「AI 抽出中」として扱う。
     status:
       | 'pending_review'
       | 'approved'
       | 'rejected'
       | 'ai_failed'
       | 'superseded'
+      | 'ai_processing'
     confidence: string | null // numeric(3,2) → string from drizzle
     isCorrection: boolean
     referencesSubject: string | null
@@ -134,6 +139,15 @@ function StatusPill({
       return (
         <Pill tone="neutral" size="sm">
           差替済
+        </Pill>
+      )
+    case 'ai_processing':
+      // mail-inbox-mailer: AI 抽出ジョブ起動〜完了の中間状態。
+      // 詳細画面側 (タスク4) で本格的な進捗カード（ExtractionInProgressCard）
+      // に切り替える。一覧では汎用ピルで状態だけ伝える。
+      return (
+        <Pill tone="info" size="sm">
+          AI 抽出中
         </Pill>
       )
   }

--- a/apps/web/src/app/(app)/admin/mail-inbox/components/ExistingEventLinkSheet.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/components/ExistingEventLinkSheet.tsx
@@ -92,8 +92,11 @@ export function ExistingEventLinkSheet({
             <h2 id="link-event-sheet-title" className="font-display text-base font-bold text-ink">
               既存イベントに紐付ける
             </h2>
+            {/* Codex r8 nit: 旧文言「受信日降順」は実装の event_date desc と
+                ずれていたため修正。候補は loadLinkableEvents が開催日降順で
+                返す（コード上もコメントもこちらが正）。 */}
             <p className="mt-1 text-xs text-ink-meta">
-              未開催のイベント + 過去 30 日以内を受信日降順で表示します。
+              未開催のイベント + 過去 30 日以内を開催日の新しい順で表示します。
             </p>
 
             <input

--- a/apps/web/src/app/(app)/admin/mail-inbox/components/ExistingEventLinkSheet.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/components/ExistingEventLinkSheet.tsx
@@ -1,0 +1,176 @@
+'use client'
+
+import { useEffect, useMemo, useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { Btn, Card } from '@/components/ui'
+import { linkMailToEvent } from '../actions'
+
+/**
+ * mail-inbox-mailer タスク4: 既存イベント結びつけ用のボトムシート。
+ *
+ * 要件 §3.1.6:
+ * - デフォルト表示: 未開催 + 過去 30 日以内、受信日降順
+ * - 検索ボックスで大会名フィルタ
+ * - 選択 → 「結びつける」→ linkMailToEvent
+ *
+ * 候補は parent から `events` props で受け取る（Server Component で計算した
+ * 結果を渡す）。検索はクライアントサイドで title contains フィルタ（候補数が
+ * 高々数十なのでネットワーク往復不要）。
+ */
+export interface LinkableEventOption {
+  id: number
+  title: string
+  eventDate: string
+  status: 'draft' | 'published' | 'cancelled' | 'done'
+}
+
+export function ExistingEventLinkSheet({
+  mailId,
+  events,
+  buttonLabel = '既存イベントに紐付ける',
+  buttonKind = 'secondary',
+}: {
+  mailId: number
+  events: LinkableEventOption[]
+  buttonLabel?: string
+  buttonKind?: 'primary' | 'secondary'
+}) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [selectedId, setSelectedId] = useState<number | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [pending, startTransition] = useTransition()
+  const router = useRouter()
+
+  // Sheet を開いた時に状態をリセット。再オープン時に前回の選択が残らないように。
+  useEffect(() => {
+    if (open) {
+      setQuery('')
+      setSelectedId(null)
+      setError(null)
+    }
+  }, [open])
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) return events
+    const q = query.trim().toLowerCase()
+    return events.filter((e) => e.title.toLowerCase().includes(q))
+  }, [events, query])
+
+  const onConfirm = () => {
+    if (selectedId == null) return
+    const eventId = selectedId
+    setError(null)
+    startTransition(async () => {
+      const result = await linkMailToEvent(mailId, eventId)
+      if (!result.ok) {
+        setError(result.error)
+        return
+      }
+      setOpen(false)
+      router.push('/admin/mail-inbox')
+    })
+  }
+
+  return (
+    <>
+      <Btn kind={buttonKind} size="md" onClick={() => setOpen(true)} disabled={pending}>
+        {buttonLabel}
+      </Btn>
+      {open && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="link-event-sheet-title"
+          className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 sm:items-center sm:p-4"
+          onClick={() => !pending && setOpen(false)}
+        >
+          <div
+            className="flex max-h-[80vh] w-full flex-col rounded-t-lg bg-surface p-4 shadow-lg sm:max-w-md sm:rounded-lg"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 id="link-event-sheet-title" className="font-display text-base font-bold text-ink">
+              既存イベントに紐付ける
+            </h2>
+            <p className="mt-1 text-xs text-ink-meta">
+              未開催のイベント + 過去 30 日以内を受信日降順で表示します。
+            </p>
+
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="大会名で絞り込み"
+              className="mt-3 rounded border border-border-soft bg-surface px-2 py-1.5 text-sm text-ink placeholder:text-ink-meta"
+              autoFocus
+            />
+
+            <div className="mt-2 flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto">
+              {filtered.length === 0 ? (
+                <Card>
+                  <div className="py-4 text-center text-xs text-ink-meta">
+                    候補がありません
+                  </div>
+                </Card>
+              ) : (
+                filtered.map((ev) => {
+                  const checked = selectedId === ev.id
+                  return (
+                    <label
+                      key={ev.id}
+                      className={`flex cursor-pointer items-start gap-2 rounded border p-2 text-sm ${
+                        checked
+                          ? 'border-brand bg-brand-bg'
+                          : 'border-border-soft bg-surface'
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name="link-event"
+                        value={ev.id}
+                        checked={checked}
+                        onChange={() => setSelectedId(ev.id)}
+                        className="mt-1"
+                      />
+                      <div className="flex flex-1 flex-col">
+                        <span className="font-medium text-ink">{ev.title}</span>
+                        <span className="text-xs text-ink-meta">
+                          {ev.eventDate} / {ev.status}
+                        </span>
+                      </div>
+                    </label>
+                  )
+                })
+              )}
+            </div>
+
+            {error && (
+              <p className="mt-2 text-xs text-danger" role="alert">
+                {error}
+              </p>
+            )}
+
+            <div className="mt-3 flex justify-end gap-2">
+              <Btn
+                kind="ghost"
+                size="sm"
+                onClick={() => setOpen(false)}
+                disabled={pending}
+              >
+                キャンセル
+              </Btn>
+              <Btn
+                kind="primary"
+                size="sm"
+                onClick={onConfirm}
+                disabled={pending || selectedId == null}
+              >
+                {pending ? '送信中…' : '結びつける'}
+              </Btn>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/apps/web/src/app/(app)/admin/mail-inbox/components/ExtractionInProgressCard.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/components/ExtractionInProgressCard.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { useRouter } from 'next/navigation'
+import { Card } from '@/components/ui'
+
+/**
+ * mail-inbox-mailer タスク4: AI 抽出ジョブ進行中の表示。
+ *
+ * 3 秒間隔で `/api/admin/mail-inbox/[id]/draft-status` を polling し、
+ * draft.status が `'pending_review'` または `'ai_failed'` に変わったら
+ * `router.refresh()` でサーバー側 RSC を再取得（DraftCard / 再試行カードに切替）。
+ *
+ * polling は visible 中のみ動かす（背景タブで無駄な fetch をしない）。
+ * unmount / 状態確定で停止。
+ */
+export function ExtractionInProgressCard({ mailId }: { mailId: number }) {
+  const router = useRouter()
+  // dev 環境の React StrictMode で 2 重 effect になっても polling は idempotent
+  // なので ref ガードは付けない。代わりに setInterval を 1 つだけ作って unmount
+  // で確実に clear する。
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const stoppedRef = useRef(false)
+
+  useEffect(() => {
+    stoppedRef.current = false
+
+    async function tick() {
+      if (stoppedRef.current) return
+      try {
+        const res = await fetch(`/api/admin/mail-inbox/${mailId}/draft-status`, {
+          cache: 'no-store',
+        })
+        if (!res.ok) return
+        const body = (await res.json()) as {
+          draft: { status: string } | null
+        }
+        if (!body.draft) return
+        if (
+          body.draft.status === 'pending_review' ||
+          body.draft.status === 'ai_failed' ||
+          body.draft.status === 'approved' ||
+          body.draft.status === 'rejected'
+        ) {
+          stoppedRef.current = true
+          if (timerRef.current) clearInterval(timerRef.current)
+          router.refresh()
+        }
+      } catch {
+        // 失敗は一時的なネットワーク断扱い。次の tick でリトライ。
+      }
+    }
+
+    timerRef.current = setInterval(tick, 3000)
+    // immediate first poll (page open 直後の状態をすぐ取りに行く)
+    void tick()
+
+    return () => {
+      stoppedRef.current = true
+      if (timerRef.current) clearInterval(timerRef.current)
+    }
+  }, [mailId, router])
+
+  return (
+    <Card>
+      <div className="flex items-center gap-3 py-2">
+        <span
+          aria-hidden="true"
+          className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-brand border-t-transparent"
+        />
+        <div className="flex flex-col">
+          <span className="text-sm font-semibold text-ink">AI 抽出中…</span>
+          <span className="text-xs text-ink-meta">
+            完了したら通知します（数十秒）。
+          </span>
+        </div>
+      </div>
+    </Card>
+  )
+}

--- a/apps/web/src/app/(app)/admin/mail-inbox/components/MailDetailActions.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/components/MailDetailActions.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { Btn } from '@/components/ui'
+import { dismissMail } from '../actions'
+import { AIExtractConfirmDialog } from './AIExtractConfirmDialog'
+import {
+  ExistingEventLinkSheet,
+  type LinkableEventOption,
+} from './ExistingEventLinkSheet'
+
+/**
+ * mail-inbox-mailer タスク4: mail 詳細画面下部の 3 アクションエリア。
+ *
+ * 要件 §3.1.2:
+ *   - (a) 会で流す（AI 抽出） — 確認ダイアログ
+ *   - (b) 既存イベントに紐付ける — シート
+ *   - (c) 対応不要 — 即実行 → 一覧へ
+ *
+ * 表示条件: triage_status='unprocessed' かつ draft が無いとき。
+ * draft 状態に応じた切替は呼び出し側 (page.tsx) で行う（このコンポーネント
+ * は単純な 3 ボタン）。
+ */
+export function MailDetailActions({
+  mailId,
+  linkableEvents,
+}: {
+  mailId: number
+  linkableEvents: LinkableEventOption[]
+}) {
+  const [pending, startTransition] = useTransition()
+  const router = useRouter()
+
+  const onDismiss = () => {
+    startTransition(async () => {
+      await dismissMail(mailId)
+      router.push('/admin/mail-inbox')
+    })
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <AIExtractConfirmDialog mailId={mailId} />
+      <ExistingEventLinkSheet mailId={mailId} events={linkableEvents} />
+      <Btn kind="ghost" size="md" onClick={onDismiss} disabled={pending}>
+        {pending ? '処理中…' : '対応不要'}
+      </Btn>
+    </div>
+  )
+}

--- a/apps/web/src/app/(app)/admin/mail-inbox/components/TriageActions.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/components/TriageActions.tsx
@@ -2,22 +2,26 @@
 
 import { useTransition } from 'react'
 import { Btn } from '@/components/ui'
-import { deferMail, dismissMail, undoTriage } from '../actions'
+import { dismissMail, undoTriage } from '../actions'
 
-export type TriageStatus = 'unprocessed' | 'processed' | 'deferred'
+// mail-inbox-mailer: triage 2 状態化（unprocessed / processed）に伴い deferred 廃止。
+export type TriageStatus = 'unprocessed' | 'processed'
 
 /**
  * mail-triage-badge: メール1件のトリアージ操作ボタン群（client）。
  *
  * 一覧カード・詳細ページの双方から使う。triage_status に応じて出すボタンを
  * 切り替える:
- *   - unprocessed → [対応不要][保留]
- *   - deferred    → [対応不要][未処理に戻す]
+ *   - unprocessed → [対応不要]
  *   - processed   → [未処理に戻す]
  *
  * Server Action 実行中は useTransition で二度押しを防ぐ。Server Action 側で
  * revalidatePath('/admin/mail-inbox') を呼ぶので、完了後に一覧/詳細が再検証され
  * バッジ（フォアグラウンド更新）もタスク4 のクライアントが拾い直す。
+ *
+ * mail-inbox-mailer: 「保留」ボタンは廃止（処理せず放置 = 暗黙の保留）。
+ * 詳細画面の 3 アクション（AI 抽出 / 既存イベント結びつけ / 対応不要）は
+ * タスク4 で MailDetailActions に再構成する予定。
  */
 export function TriageActions({
   mailId,
@@ -47,11 +51,6 @@ export function TriageActions({
       {triageStatus !== 'processed' && (
         <Btn kind="secondary" size={size} disabled={pending} onClick={run(dismissMail)}>
           対応不要
-        </Btn>
-      )}
-      {triageStatus === 'unprocessed' && (
-        <Btn kind="secondary" size={size} disabled={pending} onClick={run(deferMail)}>
-          保留
         </Btn>
       )}
       {triageStatus !== 'unprocessed' && (

--- a/apps/web/src/app/(app)/admin/mail-inbox/components/UndoTriageButton.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/components/UndoTriageButton.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { Btn } from '@/components/ui'
+import { undoTriage, unlinkMailFromEvent } from '../actions'
+
+/**
+ * mail-inbox-mailer タスク4: 処理済画面の「未処理に戻す」ボタン。
+ *
+ * 要件 §3.1.8:
+ *   - triage_status を 'processed' → 'unprocessed'
+ *   - linked_event_id がある場合は NULL に戻す（LINE 配信済メッセージの取消は
+ *     LINE API 仕様上不可なので、紐付けだけ外す）
+ *   - AI 抽出済み draft は残す（再度開けば編集可）
+ *
+ * undoTriage（triage のみ）と unlinkMailFromEvent（linked_event_id 含む）の
+ * 使い分けは呼び出し側で行う: linked_event_id があれば unlinkMailFromEvent、
+ * それ以外は undoTriage。
+ */
+export function UndoTriageButton({
+  mailId,
+  hasLinkedEvent,
+}: {
+  mailId: number
+  hasLinkedEvent: boolean
+}) {
+  const [pending, startTransition] = useTransition()
+  const router = useRouter()
+
+  const onUndo = () => {
+    startTransition(async () => {
+      if (hasLinkedEvent) {
+        await unlinkMailFromEvent(mailId)
+      } else {
+        await undoTriage(mailId)
+      }
+      router.refresh()
+    })
+  }
+
+  return (
+    <Btn kind="secondary" size="md" onClick={onUndo} disabled={pending}>
+      {pending ? '処理中…' : '未処理に戻す'}
+    </Btn>
+  )
+}

--- a/apps/web/src/app/(app)/admin/mail-inbox/linkable-events.ts
+++ b/apps/web/src/app/(app)/admin/mail-inbox/linkable-events.ts
@@ -1,0 +1,38 @@
+/**
+ * mail-inbox-mailer: 既存イベント結びつけシートの「リンク許容条件」を
+ * UI クエリ (loadLinkableEvents) と Server Action (linkMailToEvent) 双方で
+ * 共有するための helper。
+ *
+ * 要件 §3.1.6 (Codex r5 should-fix): UI が「cancelled 除外 / 開催日が過去 30 日
+ * 以降」で候補を絞っていても、Server Action 側で event の存在しか見ないと、
+ * 画面表示後に status が cancelled に変わった場合や Server Action を直接
+ * 叩かれた場合に許容範囲外のイベントへ紐付けられてしまう。条件をここに
+ * 一本化し、サーバー側でも同じ判定を回す。
+ */
+
+/** 「過去 30 日以内」cutoff の YYYY-MM-DD 文字列を返す（JST 基準）。 */
+export function linkableEventCutoffStr(now: Date = new Date()): string {
+  const todayJst = new Date(
+    now.toLocaleString('en-US', { timeZone: 'Asia/Tokyo' }),
+  )
+  const cutoff = new Date(todayJst.getTime() - 30 * 24 * 3600 * 1000)
+  return `${cutoff.getFullYear()}-${String(cutoff.getMonth() + 1).padStart(2, '0')}-${String(cutoff.getDate()).padStart(2, '0')}`
+}
+
+/**
+ * Server Action 側で event 行が「リンク候補に出してよい状態か」を判定する。
+ * UI の loadLinkableEvents と同じ条件: cancelled でないこと + 開催日が
+ * cutoff 以降であること。`undefined` 返却なら OK、文字列ならエラーメッセージ。
+ */
+export function validateLinkableEvent(
+  event: { eventDate: string; status: 'draft' | 'published' | 'cancelled' | 'done' },
+  cutoffStr: string,
+): string | undefined {
+  if (event.status === 'cancelled') {
+    return 'キャンセル済みのイベントには紐付けできません'
+  }
+  if (event.eventDate < cutoffStr) {
+    return 'リンク候補の範囲外（過去 30 日より古い）のイベントです'
+  }
+  return undefined
+}

--- a/apps/web/src/app/(app)/admin/mail-inbox/mail/[id]/page.test.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/mail/[id]/page.test.tsx
@@ -94,6 +94,62 @@ describe('admin/mail-inbox/mail/[id] detail page', () => {
     expect(screen.queryByText('対応不要')).toBeNull()
   })
 
+  it('mail-inbox-mailer: 未処理＋draft なしは 3 アクションエリアを表示', async () => {
+    const admin = await createAdmin()
+    await setAuthSession({ id: admin.id, role: 'admin' })
+    const mail = await createMailMessage({
+      subject: 'fresh mail',
+      bodyText: '本文サンプル',
+      triageStatus: 'unprocessed',
+    })
+
+    await renderDetail(mail.id)
+
+    expect(screen.getByText('会で流す（AI 抽出）')).toBeTruthy()
+    expect(screen.getByText('既存イベントに紐付ける')).toBeTruthy()
+    expect(screen.getByText('対応不要')).toBeTruthy()
+    // 本文は details トグルではなく即時表示。
+    expect(screen.getByText('本文サンプル')).toBeTruthy()
+  })
+
+  it('mail-inbox-mailer: draft.status=ai_processing で進行中カードを表示', async () => {
+    const admin = await createAdmin()
+    await setAuthSession({ id: admin.id, role: 'admin' })
+    const mail = await createMailMessage({
+      subject: 'extracting',
+      triageStatus: 'unprocessed',
+    })
+    await createTournamentDraft({
+      messageId: mail.id,
+      status: 'ai_processing',
+    })
+
+    await renderDetail(mail.id)
+
+    expect(screen.getByText('AI 抽出中…')).toBeTruthy()
+    // 3 ボタン MailDetailActions は出ない（draft があるので分岐済み）。
+    expect(screen.queryByText('会で流す（AI 抽出）')).toBeNull()
+  })
+
+  it('mail-inbox-mailer: draft.status=ai_failed で再試行と手動作成ボタンを表示', async () => {
+    const admin = await createAdmin()
+    await setAuthSession({ id: admin.id, role: 'admin' })
+    const mail = await createMailMessage({
+      subject: 'failed',
+      triageStatus: 'unprocessed',
+    })
+    await createTournamentDraft({
+      messageId: mail.id,
+      status: 'ai_failed',
+    })
+
+    await renderDetail(mail.id)
+
+    expect(screen.getByText('AI 抽出に失敗しました')).toBeTruthy()
+    expect(screen.getByText('AI 抽出を再試行')).toBeTruthy()
+    expect(screen.getByText('手動でイベントを作成')).toBeTruthy()
+  })
+
   it('存在しない mail は notFound', async () => {
     const admin = await createAdmin()
     await setAuthSession({ id: admin.id, role: 'admin' })

--- a/apps/web/src/app/(app)/admin/mail-inbox/mail/[id]/page.test.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/mail/[id]/page.test.tsx
@@ -131,7 +131,7 @@ describe('admin/mail-inbox/mail/[id] detail page', () => {
     expect(screen.queryByText('会で流す（AI 抽出）')).toBeNull()
   })
 
-  it('mail-inbox-mailer: draft.status=ai_failed で再試行と手動作成ボタンを表示', async () => {
+  it('mail-inbox-mailer: draft.status=ai_failed で再試行ボタンを表示', async () => {
     const admin = await createAdmin()
     await setAuthSession({ id: admin.id, role: 'admin' })
     const mail = await createMailMessage({
@@ -147,7 +147,9 @@ describe('admin/mail-inbox/mail/[id] detail page', () => {
 
     expect(screen.getByText('AI 抽出に失敗しました')).toBeTruthy()
     expect(screen.getByText('AI 抽出を再試行')).toBeTruthy()
-    expect(screen.getByText('手動でイベントを作成')).toBeTruthy()
+    // Codex r6 blocker: 「手動でイベントを作成」リンクは /admin/events/new
+    // 不在のため撤去。専用フロー実装まで非表示。
+    expect(screen.queryByText('手動でイベントを作成')).toBeNull()
   })
 
   it('存在しない mail は notFound', async () => {

--- a/apps/web/src/app/(app)/admin/mail-inbox/mail/[id]/page.test.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/mail/[id]/page.test.tsx
@@ -56,7 +56,7 @@ describe('admin/mail-inbox/mail/[id] detail page', () => {
     expect(screen.getByText('detail subject')).toBeTruthy()
     expect(screen.getByText('未処理')).toBeTruthy()
     expect(screen.getByText('対応不要')).toBeTruthy()
-    expect(screen.getByText('保留')).toBeTruthy()
+    // mail-inbox-mailer: 「保留」ボタンは廃止（処理せず放置 = 暗黙の保留）。
   })
 
   it('draft があれば承認動線 [id] へのリンクを出す', async () => {

--- a/apps/web/src/app/(app)/admin/mail-inbox/mail/[id]/page.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/mail/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound, redirect } from 'next/navigation'
 import Link from 'next/link'
-import { and, eq, gte, or } from 'drizzle-orm'
+import { and, desc, eq, gte, ne } from 'drizzle-orm'
 import { auth } from '@/auth'
 import { db } from '@/lib/db'
 import { events, mailMessages } from '@kagetra/shared/schema'
@@ -53,9 +53,16 @@ function formatJst(date: Date): string {
 }
 
 /**
- * 既存イベント結びつけシートの候補: 未開催 (event_date >= 今日) + 過去 30 日。
- * 受信日降順ではなく event_date 降順で並べる（候補ソートとしては開催日順が
- * 直感的。シート内検索でタイトル絞り込みもできる）。
+ * 既存イベント結びつけシートの候補。
+ *
+ * 要件 §3.1.6: 「未開催（=今日以降）+ 過去 30 日以内」を受信日降順ではなく
+ * 開催日降順で表示（候補一覧としては開催日順の方が直感的、シート内検索で
+ * タイトル絞り込みも可能）。
+ *
+ * Codex r1 should-fix: 旧実装は「過去 30 日側を status='done' に限定」して
+ * いたが、開催日が過ぎても status が published のままの大会は運用上ありえる
+ * ので領収書/事後連絡が拾えなくなっていた。status は cancelled だけ除外して
+ * 残りは全部候補に出す（並び順も降順に修正）。
  */
 async function loadLinkableEvents(): Promise<LinkableEventOption[]> {
   const todayJst = new Date(
@@ -63,7 +70,6 @@ async function loadLinkableEvents(): Promise<LinkableEventOption[]> {
   )
   const cutoff = new Date(todayJst.getTime() - 30 * 24 * 3600 * 1000)
   const cutoffStr = `${cutoff.getFullYear()}-${String(cutoff.getMonth() + 1).padStart(2, '0')}-${String(cutoff.getDate()).padStart(2, '0')}`
-  const todayStr = `${todayJst.getFullYear()}-${String(todayJst.getMonth() + 1).padStart(2, '0')}-${String(todayJst.getDate()).padStart(2, '0')}`
 
   const rows = await db
     .select({
@@ -74,12 +80,12 @@ async function loadLinkableEvents(): Promise<LinkableEventOption[]> {
     })
     .from(events)
     .where(
-      or(
-        gte(events.eventDate, todayStr),
-        and(gte(events.eventDate, cutoffStr), eq(events.status, 'done')),
+      and(
+        gte(events.eventDate, cutoffStr),
+        ne(events.status, 'cancelled'),
       ),
     )
-    .orderBy(events.eventDate)
+    .orderBy(desc(events.eventDate))
   return rows
 }
 
@@ -175,12 +181,21 @@ export default async function MailDetailPage({
           </div>
           <AttachmentList items={mail.attachments} />
 
-          {/* mail-inbox-mailer: 本文は details トグルではなく即時表示。 */}
-          {mail.bodyText && (
-            <pre className="mt-2 max-h-96 overflow-y-auto whitespace-pre-wrap break-words rounded border border-border-soft bg-surface-alt p-2 text-xs text-ink">
-              {mail.bodyText}
-            </pre>
-          )}
+          {/* mail-inbox-mailer: 本文は details トグルではなく即時表示。
+              Codex r1 blocker: bodyText のみだと HTML-only メール (text/plain
+              代替を持たない) の本文が表示されない。bodyText が無ければ bodyHtml
+              にフォールバックする。HTML は dangerouslySetInnerHTML せず、
+              <pre> 内に生テキストとして見せる（タグも一緒に見えるが、
+              本文を取りこぼさない方が要件「全件確認」上は重要）。 */}
+          {(() => {
+            const body = mail.bodyText ?? mail.bodyHtml
+            if (!body) return null
+            return (
+              <pre className="mt-2 max-h-96 overflow-y-auto whitespace-pre-wrap break-words rounded border border-border-soft bg-surface-alt p-2 text-xs text-ink">
+                {body}
+              </pre>
+            )
+          })()}
         </div>
       </Card>
 

--- a/apps/web/src/app/(app)/admin/mail-inbox/mail/[id]/page.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/mail/[id]/page.tsx
@@ -235,7 +235,9 @@ export default async function MailDetailPage({
               AI 抽出に失敗しました
             </h2>
             <p className="text-xs text-ink-meta">
-              再試行するか、手動でイベントを作成してください。
+              再試行してください。手動でイベント作成する場合は
+              この画面から AI 抽出を諦めた上で、メニューから新規イベント作成へ
+              進んでください（mail との自動紐付けは将来対応）。
             </p>
             <div className="flex flex-col gap-2">
               <AIExtractConfirmDialog
@@ -243,15 +245,11 @@ export default async function MailDetailPage({
                 buttonLabel="AI 抽出を再試行"
                 buttonKind="primary"
               />
-              {/* 手動イベント作成は既存 /admin/events/new に mailMessageId を渡す
-                  形が筋。実画面は別 PR（タスク7 までに整備予定）。今は placeholder
-                  リンクで導線だけ示す。 */}
-              <Link
-                href={`/admin/events/new?mailMessageId=${mail.id}`}
-                className="inline-flex items-center justify-center rounded border border-border-soft bg-surface px-3 py-1.5 text-sm font-medium text-ink hover:bg-surface-alt"
-              >
-                手動でイベントを作成
-              </Link>
+              {/* mail-inbox-mailer (Codex r6 blocker): /admin/events/new は実在
+                  しないため 404 を回避するためリンクを撤去。要件 §3.1.5 の
+                  「手動でイベント作成」フロー (空 EventForm を mail 詳細に展開
+                  + draft.status='approved' で締める) は専用 Server Action +
+                  画面を別 PR で実装してから再度有効化する想定。 */}
             </div>
           </div>
         </Card>

--- a/apps/web/src/app/(app)/admin/mail-inbox/mail/[id]/page.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/mail/[id]/page.tsx
@@ -24,9 +24,9 @@ const CLASSIFICATION_LABEL: Record<string, { label: string; tone: PillTone }> = 
   unknown: { label: '不明', tone: 'neutral' },
 }
 
+// mail-inbox-mailer: triage 2 状態化（unprocessed / processed）。「保留」廃止。
 const TRIAGE_LABEL: Record<TriageStatus, { label: string; tone: PillTone }> = {
   unprocessed: { label: '未処理', tone: 'warn' },
-  deferred: { label: '保留', tone: 'info' },
   processed: { label: '処理済み', tone: 'success' },
 }
 

--- a/apps/web/src/app/(app)/admin/mail-inbox/mail/[id]/page.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/mail/[id]/page.tsx
@@ -1,20 +1,31 @@
 import { notFound, redirect } from 'next/navigation'
 import Link from 'next/link'
-import { eq } from 'drizzle-orm'
+import { and, eq, gte, or } from 'drizzle-orm'
 import { auth } from '@/auth'
 import { db } from '@/lib/db'
-import { mailMessages } from '@kagetra/shared/schema'
+import { events, mailMessages } from '@kagetra/shared/schema'
 import { Card, Pill, type PillTone } from '@/components/ui'
 import { AttachmentList } from '../../components/AttachmentList'
-import { TriageActions, type TriageStatus } from '../../components/TriageActions'
+import { type TriageStatus } from '../../components/TriageActions'
+import { MailDetailActions } from '../../components/MailDetailActions'
+import { ExtractionInProgressCard } from '../../components/ExtractionInProgressCard'
+import { DraftCard } from '../../components/DraftCard'
+import { UndoTriageButton } from '../../components/UndoTriageButton'
+import { AIExtractConfirmDialog } from '../../components/AIExtractConfirmDialog'
+import type { LinkableEventOption } from '../../components/ExistingEventLinkSheet'
 
 /**
- * /admin/mail-inbox/mail/[id] — mail-triage-badge: 全メールの詳細 + トリアージ。
+ * /admin/mail-inbox/mail/[id] — mail-inbox-mailer タスク4: 「メーラー詳細」画面。
  *
- * 既存の /admin/mail-inbox/[id] は tournament_drafts.id ベースで「AI が大会案内と
- * 判定したメール」の承認画面。本ページは mail_messages.id ベースで、ノイズ/非大会
- * を含む全メールの本文・添付・AI 分類を表示し、triage アクション（対応不要/保留/
- * 取消）を提供する。draft があるメールは承認動線（[id]）へのリンクを出す。
+ * 旧仕様（mail-triage-badge）から大きく変更:
+ *   - 本文は details トグル → **即時表示**（要件 §3.1.2）
+ *   - 「保留」アクション廃止
+ *   - draft の状態に応じてアクションエリアを切り替え:
+ *       draft なし                  → MailDetailActions (3 ボタン)
+ *       draft.status='ai_processing' → ExtractionInProgressCard (polling)
+ *       draft.status='ai_failed'     → 再試行 + 「手動でイベント作成」
+ *       draft.status='pending_review' → DraftCard + 承認動線リンク
+ *       draft.status='approved'/'rejected'/'superseded' → 状態表示 + undo
  */
 export const dynamic = 'force-dynamic'
 
@@ -41,6 +52,37 @@ function formatJst(date: Date): string {
   })
 }
 
+/**
+ * 既存イベント結びつけシートの候補: 未開催 (event_date >= 今日) + 過去 30 日。
+ * 受信日降順ではなく event_date 降順で並べる（候補ソートとしては開催日順が
+ * 直感的。シート内検索でタイトル絞り込みもできる）。
+ */
+async function loadLinkableEvents(): Promise<LinkableEventOption[]> {
+  const todayJst = new Date(
+    new Date().toLocaleString('en-US', { timeZone: 'Asia/Tokyo' }),
+  )
+  const cutoff = new Date(todayJst.getTime() - 30 * 24 * 3600 * 1000)
+  const cutoffStr = `${cutoff.getFullYear()}-${String(cutoff.getMonth() + 1).padStart(2, '0')}-${String(cutoff.getDate()).padStart(2, '0')}`
+  const todayStr = `${todayJst.getFullYear()}-${String(todayJst.getMonth() + 1).padStart(2, '0')}-${String(todayJst.getDate()).padStart(2, '0')}`
+
+  const rows = await db
+    .select({
+      id: events.id,
+      title: events.title,
+      eventDate: events.eventDate,
+      status: events.status,
+    })
+    .from(events)
+    .where(
+      or(
+        gte(events.eventDate, todayStr),
+        and(gte(events.eventDate, cutoffStr), eq(events.status, 'done')),
+      ),
+    )
+    .orderBy(events.eventDate)
+  return rows
+}
+
 export default async function MailDetailPage({
   params,
 }: {
@@ -59,7 +101,8 @@ export default async function MailDetailPage({
   }
 
   // bytea attachment `data` は projection から除外（一覧と同じく一覧/詳細では
-  // バイナリを載せない）。本文は bodyText のみ使う。
+  // バイナリを載せない）。本文は bodyText / bodyHtml を両方使う（プレーンテキスト
+  // を優先し、無ければ HTML を pre 表示）。
   const mail = await db.query.mailMessages.findFirst({
     where: eq(mailMessages.id, mailId),
     with: {
@@ -71,8 +114,17 @@ export default async function MailDetailPage({
           extractionStatus: true,
         },
       },
-      // 1:0..1。draft があれば承認動線（[id]）へ誘導する。
-      draft: { columns: { id: true, status: true } },
+      // 1:0..1。draft の状態によってアクションエリアを切替。
+      draft: {
+        columns: {
+          id: true,
+          status: true,
+          confidence: true,
+          isCorrection: true,
+          referencesSubject: true,
+          extractedPayload: true,
+        },
+      },
     },
   })
   if (!mail) notFound()
@@ -84,6 +136,11 @@ export default async function MailDetailPage({
   const classification = mail.classification
     ? CLASSIFICATION_LABEL[mail.classification]
     : null
+
+  const linkableEvents =
+    !mail.draft && mail.triageStatus === 'unprocessed'
+      ? await loadLinkableEvents()
+      : []
 
   return (
     <div className="flex flex-col gap-4">
@@ -117,40 +174,94 @@ export default async function MailDetailPage({
               : mail.fromAddress}
           </div>
           <AttachmentList items={mail.attachments} />
+
+          {/* mail-inbox-mailer: 本文は details トグルではなく即時表示。 */}
           {mail.bodyText && (
-            <details className="mt-1">
-              <summary className="cursor-pointer text-xs font-medium text-ink-meta">
-                本文プレビュー
-              </summary>
-              <pre className="mt-2 whitespace-pre-wrap break-words rounded border border-border-soft bg-surface-alt p-2 text-xs text-ink">
-                {mail.bodyText}
-              </pre>
-            </details>
+            <pre className="mt-2 max-h-96 overflow-y-auto whitespace-pre-wrap break-words rounded border border-border-soft bg-surface-alt p-2 text-xs text-ink">
+              {mail.bodyText}
+            </pre>
           )}
         </div>
       </Card>
 
-      <Card>
-        <div className="flex flex-col gap-2">
-          <h2 className="font-display text-sm font-semibold text-ink-2">処理</h2>
-          <TriageActions mailId={mail.id} triageStatus={mail.triageStatus} size="md" />
-          <p className="text-xs text-ink-meta">
-            「対応不要」で処理済み（未処理バッジから除外）、「保留」は後で対応（バッジには残る）。
-          </p>
-        </div>
-      </Card>
-
-      {mail.draft && (
-        <Card className="border-brand/30 bg-brand-bg">
-          <div className="flex flex-wrap items-center gap-2 text-sm">
-            <span className="font-semibold text-ink">
-              AI が大会案内として抽出済み
-            </span>
+      {/* アクションエリアは triage_status + draft.status の組み合わせで分岐。 */}
+      {mail.triageStatus === 'processed' ? (
+        <Card>
+          <div className="flex flex-col gap-2">
+            <h2 className="font-display text-sm font-semibold text-ink-2">処理済み</h2>
+            <p className="text-xs text-ink-meta">
+              このメールは処理済みです。誤って処理した場合は未処理に戻せます。
+              {mail.linkedEventId != null &&
+                ' 紐付け済みイベントの解除も同時に行われます（LINE 配信済みメッセージの取り消しはできません）。'}
+            </p>
+            <UndoTriageButton
+              mailId={mail.id}
+              hasLinkedEvent={mail.linkedEventId != null}
+            />
+          </div>
+        </Card>
+      ) : !mail.draft ? (
+        <Card>
+          <div className="flex flex-col gap-3">
+            <h2 className="font-display text-sm font-semibold text-ink-2">処理</h2>
+            <MailDetailActions mailId={mail.id} linkableEvents={linkableEvents} />
+            <p className="text-xs text-ink-meta">
+              「会で流す」は AI 抽出を実行。「既存イベントに紐付ける」は組合せ表
+              などの補足情報を既存大会に紐付けて LINE で配信。「対応不要」は未処理
+              バッジから外すだけ。
+            </p>
+          </div>
+        </Card>
+      ) : mail.draft.status === 'ai_processing' ? (
+        <ExtractionInProgressCard mailId={mail.id} />
+      ) : mail.draft.status === 'ai_failed' ? (
+        <Card>
+          <div className="flex flex-col gap-3">
+            <h2 className="font-display text-sm font-semibold text-ink-2">
+              AI 抽出に失敗しました
+            </h2>
+            <p className="text-xs text-ink-meta">
+              再試行するか、手動でイベントを作成してください。
+            </p>
+            <div className="flex flex-col gap-2">
+              <AIExtractConfirmDialog
+                mailId={mail.id}
+                buttonLabel="AI 抽出を再試行"
+                buttonKind="primary"
+              />
+              {/* 手動イベント作成は既存 /admin/events/new に mailMessageId を渡す
+                  形が筋。実画面は別 PR（タスク7 までに整備予定）。今は placeholder
+                  リンクで導線だけ示す。 */}
+              <Link
+                href={`/admin/events/new?mailMessageId=${mail.id}`}
+                className="inline-flex items-center justify-center rounded border border-border-soft bg-surface px-3 py-1.5 text-sm font-medium text-ink hover:bg-surface-alt"
+              >
+                手動でイベントを作成
+              </Link>
+            </div>
+          </div>
+        </Card>
+      ) : mail.draft.status === 'pending_review' ? (
+        <Card>
+          <div className="flex flex-col gap-2">
+            <DraftCard draft={mail.draft} />
             <Link
               href={`/admin/mail-inbox/${mail.draft.id}`}
-              className="text-brand-fg underline"
+              className="text-sm text-brand-fg underline"
             >
               承認 / 却下 / 紐付けへ →
+            </Link>
+          </div>
+        </Card>
+      ) : (
+        <Card>
+          <div className="flex flex-col gap-2">
+            <DraftCard draft={mail.draft} />
+            <Link
+              href={`/admin/mail-inbox/${mail.draft.id}`}
+              className="text-sm text-brand-fg underline"
+            >
+              draft 詳細を開く →
             </Link>
           </div>
         </Card>

--- a/apps/web/src/app/(app)/admin/mail-inbox/mail/[id]/page.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/mail/[id]/page.tsx
@@ -13,6 +13,7 @@ import { DraftCard } from '../../components/DraftCard'
 import { UndoTriageButton } from '../../components/UndoTriageButton'
 import { AIExtractConfirmDialog } from '../../components/AIExtractConfirmDialog'
 import type { LinkableEventOption } from '../../components/ExistingEventLinkSheet'
+import { linkableEventCutoffStr } from '../../linkable-events'
 
 /**
  * /admin/mail-inbox/mail/[id] — mail-inbox-mailer タスク4: 「メーラー詳細」画面。
@@ -65,11 +66,9 @@ function formatJst(date: Date): string {
  * 残りは全部候補に出す（並び順も降順に修正）。
  */
 async function loadLinkableEvents(): Promise<LinkableEventOption[]> {
-  const todayJst = new Date(
-    new Date().toLocaleString('en-US', { timeZone: 'Asia/Tokyo' }),
-  )
-  const cutoff = new Date(todayJst.getTime() - 30 * 24 * 3600 * 1000)
-  const cutoffStr = `${cutoff.getFullYear()}-${String(cutoff.getMonth() + 1).padStart(2, '0')}-${String(cutoff.getDate()).padStart(2, '0')}`
+  // mail-inbox-mailer (Codex r5 should-fix): cutoff 算出は linkable-events.ts
+  // に集約し、Server Action 側 (linkMailToEvent) と完全同期させる。
+  const cutoffStr = linkableEventCutoffStr()
 
   const rows = await db
     .select({

--- a/apps/web/src/app/(app)/admin/mail-inbox/page.test.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/page.test.tsx
@@ -121,13 +121,11 @@ describe('admin/mail-inbox list page (mail-triage-badge)', () => {
     expect(screen.getByText('その他 (1)')).toBeTruthy()
   })
 
-  it('deferred は「保留」、processed は「処理済み」セクションに入る', async () => {
+  // mail-inbox-mailer: 保留 (deferred) セクションは廃止（2 状態化に伴い）。
+
+  it('processed は「処理済み」セクションに入る', async () => {
     const admin = await createAdmin()
     await setAuthSession({ id: admin.id, role: 'admin' })
-    await createMailMessage({
-      subject: 'DEFERRED_MAIL',
-      triageStatus: 'deferred',
-    })
     await createMailMessage({
       subject: 'PROCESSED_MAIL',
       triageStatus: 'processed',
@@ -135,13 +133,11 @@ describe('admin/mail-inbox list page (mail-triage-badge)', () => {
 
     await renderPage()
 
-    expect(screen.getByText(/^保留 \(1\)$/)).toBeTruthy()
-    expect(screen.getByText('DEFERRED_MAIL')).toBeTruthy()
     expect(screen.getByText(/処理済み（最新 1 件）/)).toBeTruthy()
     expect(screen.getByText('PROCESSED_MAIL')).toBeTruthy()
   })
 
-  it('未処理カードに triage クイックアクション（対応不要/保留）が出る', async () => {
+  it('未処理カードに triage クイックアクション（対応不要）が出る', async () => {
     const admin = await createAdmin()
     await setAuthSession({ id: admin.id, role: 'admin' })
     await createMailMessage({
@@ -151,8 +147,8 @@ describe('admin/mail-inbox list page (mail-triage-badge)', () => {
 
     await renderPage()
 
+    // mail-inbox-mailer: 「保留」ボタンは廃止（処理せず放置 = 暗黙の保留）。
     expect(screen.getByText('対応不要')).toBeTruthy()
-    expect(screen.getByText('保留')).toBeTruthy()
   })
 
   it('未処理が 0 件なら「未処理のメールはありません」を表示する', async () => {

--- a/apps/web/src/app/(app)/admin/mail-inbox/page.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/page.tsx
@@ -143,8 +143,10 @@ export default async function MailInboxPage() {
   })
   type Row = (typeof activeRows)[number]
 
+  // mail-inbox-mailer: triage 2 状態化（unprocessed / processed）。activeRows は
+  // `ne(triageStatus, 'processed')` フィルタなので全て unprocessed と等価だが、
+  // 既存のコードフローを保ったまま明示的に絞り込んでおく。
   const unprocessed = activeRows.filter((r) => r.triageStatus === 'unprocessed')
-  const deferred = activeRows.filter((r) => r.triageStatus === 'deferred')
 
   // 未処理グループ内の tier 分け（従来ロジック）。
   //   tier 0「要対応」: pending_review かつ confidence >= 0.9
@@ -222,7 +224,7 @@ export default async function MailInboxPage() {
     )
   }
 
-  const hasAnyActive = unprocessed.length > 0 || deferred.length > 0
+  const hasAnyActive = unprocessed.length > 0
 
   return (
     <div className="flex flex-col gap-4">
@@ -325,17 +327,7 @@ export default async function MailInboxPage() {
         )}
       </section>
 
-      {/* 保留 */}
-      {deferred.length > 0 && (
-        <section className="flex flex-col gap-2">
-          <h2 className="font-display text-sm font-semibold text-ink-2">
-            保留 ({deferred.length})
-          </h2>
-          <div className="flex flex-col gap-2">
-            {deferred.map((row) => renderRow(row))}
-          </div>
-        </section>
-      )}
+      {/* mail-inbox-mailer: 保留セクション廃止（deferred 状態自体を削除）。 */}
 
       {/* 処理済み（参考・折りたたみ） */}
       {processedRows.length > 0 && (

--- a/apps/web/src/app/(app)/admin/mail-inbox/page.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/page.tsx
@@ -227,13 +227,19 @@ export default async function MailInboxPage() {
                 「未処理に戻す」が undoTriage 単独だと linked_event_id を解除
                 しない。UndoTriageButton に振り替えて、linkedEventId がある場合は
                 unlinkMailFromEvent を呼ぶ動線にする。unprocessed 行はそのまま
-                TriageActions（対応不要のクイックアクション）を維持。 */}
+                TriageActions（対応不要のクイックアクション）を維持。
+                Codex r6 should-fix: dismissMail はサーバー側で未完了 draft
+                (ai_processing/pending_review/ai_failed) があるメールを拒否する
+                ので、一覧でも該当 draft があれば「対応不要」を出さない。
+                draft 詳細 / 再試行は DraftCard リンク or 詳細画面に集約する。 */}
             {row.triageStatus === 'processed' ? (
               <UndoTriageButton
                 mailId={row.id}
                 hasLinkedEvent={row.linkedEventId != null}
               />
-            ) : (
+            ) : row.draft?.status === 'ai_processing' ||
+              row.draft?.status === 'pending_review' ||
+              row.draft?.status === 'ai_failed' ? null : (
               <TriageActions mailId={row.id} triageStatus={row.triageStatus} />
             )}
           </div>

--- a/apps/web/src/app/(app)/admin/mail-inbox/page.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/page.tsx
@@ -9,6 +9,7 @@ import { AttachmentList } from './components/AttachmentList'
 import { DraftCard } from './components/DraftCard'
 import { TriggerFetchButton } from './components/TriggerFetchButton'
 import { TriageActions } from './components/TriageActions'
+import { UndoTriageButton } from './components/UndoTriageButton'
 
 /**
  * /admin/mail-inbox — 受信メール一覧（mail-triage-badge で再構成）。
@@ -68,6 +69,11 @@ const LIST_COLUMNS = {
   status: true,
   classification: true,
   triageStatus: true,
+  // mail-inbox-mailer (Codex r3 blocker): 処理済セクションの「未処理に戻す」が
+  // linked_event_id を解除しないと、紐付け先イベントの関連メールに残り続けて
+  // 不整合になる。UndoTriageButton に linkedEventId の有無を伝えるため、
+  // 一覧クエリでも列を引いておく。
+  linkedEventId: true,
 } as const
 
 const LIST_WITH = {
@@ -217,7 +223,19 @@ export default async function MailInboxPage() {
             </Link>
           )}
           <div className="mt-1">
-            <TriageActions mailId={row.id} triageStatus={row.triageStatus} />
+            {/* mail-inbox-mailer (Codex r3 blocker): processed 行の
+                「未処理に戻す」が undoTriage 単独だと linked_event_id を解除
+                しない。UndoTriageButton に振り替えて、linkedEventId がある場合は
+                unlinkMailFromEvent を呼ぶ動線にする。unprocessed 行はそのまま
+                TriageActions（対応不要のクイックアクション）を維持。 */}
+            {row.triageStatus === 'processed' ? (
+              <UndoTriageButton
+                mailId={row.id}
+                hasLinkedEvent={row.linkedEventId != null}
+              />
+            ) : (
+              <TriageActions mailId={row.id} triageStatus={row.triageStatus} />
+            )}
           </div>
         </div>
       </Card>

--- a/apps/web/src/app/(app)/events/[id]/components/EventRelatedMails.test.tsx
+++ b/apps/web/src/app/(app)/events/[id]/components/EventRelatedMails.test.tsx
@@ -1,0 +1,154 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { eq } from 'drizzle-orm'
+import {
+  events,
+  mailMessages,
+  tournamentDrafts,
+} from '@kagetra/shared/schema'
+import { closeTestDb, testDb, truncateAll } from '@/test-utils/db'
+import {
+  createEvent,
+  createMailMessage,
+  createTournamentDraft,
+} from '@/test-utils/seed'
+import { EventRelatedMails } from './EventRelatedMails'
+
+/**
+ * mail-inbox-mailer タスク5: 関連メールセクションのテスト。
+ *
+ * 3 経路（A: linked_event_id / B: tournament_drafts.event_id / C: events.tournament_draft_id）
+ * のそれぞれを UNION で拾えること、重複しないこと、受信日降順になることを検証する。
+ */
+describe('EventRelatedMails (mail-inbox-mailer task5)', () => {
+  beforeEach(async () => {
+    await truncateAll()
+  })
+  afterAll(async () => {
+    await closeTestDb()
+  })
+
+  it('関連メールが 1 件も無ければ何も描画しない', async () => {
+    const ev = await createEvent({ title: 'no related' })
+    const ui = await EventRelatedMails({ eventId: ev.id })
+    expect(ui).toBeNull()
+  })
+
+  it('(A) linked_event_id 経由のメールを表示する', async () => {
+    const ev = await createEvent({ title: 'linked-event' })
+    const mail = await createMailMessage({ subject: '組合せ表 v1' })
+    await testDb
+      .update(mailMessages)
+      .set({ linkedEventId: ev.id })
+      .where(eq(mailMessages.id, mail.id))
+
+    const ui = await EventRelatedMails({ eventId: ev.id })
+    const { container } = render(ui!)
+
+    expect(screen.getByText('関連メール (1)')).toBeTruthy()
+    expect(screen.getByText('組合せ表 v1')).toBeTruthy()
+    const link = container.querySelector('a[href]')
+    expect(link?.getAttribute('href')).toBe(`/admin/mail-inbox/mail/${mail.id}`)
+  })
+
+  it('(B) tournament_drafts.event_id 経由のメールを表示する', async () => {
+    const ev = await createEvent({ title: 'linked-draft' })
+    const mail = await createMailMessage({ subject: '訂正版 mail' })
+    await createTournamentDraft({
+      messageId: mail.id,
+      status: 'approved',
+      eventId: ev.id,
+    })
+
+    const ui = await EventRelatedMails({ eventId: ev.id })
+    const { container } = render(ui!)
+
+    expect(screen.getByText('関連メール (1)')).toBeTruthy()
+    expect(screen.getByText('訂正版 mail')).toBeTruthy()
+    expect(container.querySelector('a[href]')?.getAttribute('href')).toBe(
+      `/admin/mail-inbox/mail/${mail.id}`,
+    )
+  })
+
+  it('(C) events.tournament_draft_id 経由のメールを表示する', async () => {
+    const mail = await createMailMessage({ subject: 'AI 抽出元 mail' })
+    const draft = await createTournamentDraft({
+      messageId: mail.id,
+      status: 'approved',
+    })
+    const ev = await createEvent({ title: 'AI 由来 event' })
+    // tournament_draft_id を後付けで紐付け（createEvent helper は draft 連携を
+    // サポートしていないので直接 UPDATE）。
+    await testDb
+      .update(events)
+      .set({ tournamentDraftId: draft.id })
+      .where(eq(events.id, ev.id))
+
+    const ui = await EventRelatedMails({ eventId: ev.id })
+    const { container } = render(ui!)
+
+    expect(screen.getByText('関連メール (1)')).toBeTruthy()
+    expect(screen.getByText('AI 抽出元 mail')).toBeTruthy()
+    expect(container.querySelector('a[href]')?.getAttribute('href')).toBe(
+      `/admin/mail-inbox/mail/${mail.id}`,
+    )
+  })
+
+  it('3 経路の重複は mail_id で dedup される', async () => {
+    const mail = await createMailMessage({ subject: '重複 mail' })
+    const draft = await createTournamentDraft({
+      messageId: mail.id,
+      status: 'approved',
+    })
+    const ev = await createEvent({ title: 'multi-route' })
+    // (A): linked_event_id
+    await testDb
+      .update(mailMessages)
+      .set({ linkedEventId: ev.id })
+      .where(eq(mailMessages.id, mail.id))
+    // (B): tournament_drafts.event_id
+    await testDb
+      .update(tournamentDrafts)
+      .set({ eventId: ev.id })
+      .where(eq(tournamentDrafts.id, draft.id))
+    // (C): events.tournament_draft_id
+    await testDb
+      .update(events)
+      .set({ tournamentDraftId: draft.id })
+      .where(eq(events.id, ev.id))
+
+    const ui = await EventRelatedMails({ eventId: ev.id })
+    render(ui!)
+
+    // 同じ mail が 3 経路で拾えても 1 件としてカウント。
+    expect(screen.getByText('関連メール (1)')).toBeTruthy()
+  })
+
+  it('受信日降順で並ぶ', async () => {
+    const ev = await createEvent({ title: 'order check' })
+    const old = await createMailMessage({
+      subject: 'older mail',
+      receivedAt: new Date('2026-01-01T00:00:00Z'),
+    })
+    const newer = await createMailMessage({
+      subject: 'newer mail',
+      receivedAt: new Date('2026-06-01T00:00:00Z'),
+    })
+    await testDb
+      .update(mailMessages)
+      .set({ linkedEventId: ev.id })
+      .where(eq(mailMessages.id, old.id))
+    await testDb
+      .update(mailMessages)
+      .set({ linkedEventId: ev.id })
+      .where(eq(mailMessages.id, newer.id))
+
+    const ui = await EventRelatedMails({ eventId: ev.id })
+    const { container } = render(ui!)
+
+    const subjects = Array.from(container.querySelectorAll('span.font-medium')).map(
+      (el) => el.textContent,
+    )
+    expect(subjects).toEqual(['newer mail', 'older mail'])
+  })
+})

--- a/apps/web/src/app/(app)/events/[id]/components/EventRelatedMails.tsx
+++ b/apps/web/src/app/(app)/events/[id]/components/EventRelatedMails.tsx
@@ -116,4 +116,3 @@ function formatJstShort(date: Date): string {
     minute: '2-digit',
   })
 }
-

--- a/apps/web/src/app/(app)/events/[id]/components/EventRelatedMails.tsx
+++ b/apps/web/src/app/(app)/events/[id]/components/EventRelatedMails.tsx
@@ -81,15 +81,24 @@ async function collectRelatedMailIds(eventId: number): Promise<number[]> {
 
   // (C) events.tournament_draft_id → drafts.message_id → mail_messages.id
   //     （tournament-title-grade-split 経路: 1 draft : N events、events 側に
-  //     tournament_draft_id が立つ）。
-  const synthRows = await db
-    .select({ id: tournamentDrafts.messageId })
+  //     tournament_draft_id が立つ）。Codex r7 blocker: 対象 event の
+  //     tournamentDraftId を先に取得し、それが non-null のときに draft を
+  //     直接 SELECT して messageId を取り出す形に書き換え。意図が明確になる
+  //     のと、JOIN ベースより index 利用が素直になる。
+  const eventDraftRows = await db
+    .select({ draftId: events.tournamentDraftId })
     .from(events)
-    .innerJoin(
-      tournamentDrafts,
-      eq(events.tournamentDraftId, tournamentDrafts.id),
-    )
     .where(eq(events.id, eventId))
+    .limit(1)
+  const targetDraftId = eventDraftRows[0]?.draftId ?? null
+  const synthRows: { id: number }[] = []
+  if (targetDraftId !== null) {
+    const rows = await db
+      .select({ id: tournamentDrafts.messageId })
+      .from(tournamentDrafts)
+      .where(eq(tournamentDrafts.id, targetDraftId))
+    for (const r of rows) synthRows.push(r)
+  }
 
   const set = new Set<number>()
   for (const r of linkedRows) set.add(r.id)

--- a/apps/web/src/app/(app)/events/[id]/components/EventRelatedMails.tsx
+++ b/apps/web/src/app/(app)/events/[id]/components/EventRelatedMails.tsx
@@ -1,0 +1,110 @@
+import Link from 'next/link'
+import { desc, eq, inArray } from 'drizzle-orm'
+import { db } from '@/lib/db'
+import { events, mailMessages, tournamentDrafts } from '@kagetra/shared/schema'
+import { Card } from '@/components/ui'
+
+/**
+ * mail-inbox-mailer タスク5: events 詳細「関連メール」セクション (Server Component)。
+ *
+ * 要件 §3.1.7 — 3 経路 UNION:
+ *   (A) `mail_messages.linked_event_id = :eventId`
+ *       既存イベント結びつけ経由（補足情報 / 訂正版 / 領収書等）
+ *   (B) `tournament_drafts.event_id = :eventId`
+ *       linkDraftToEvent 経由（旧フロー: 訂正版 draft → 既存イベント）
+ *   (C) `events.tournament_draft_id` 経由（AI 抽出 → 承認で生まれた event）
+ *       events.tournament_draft_id → tournament_drafts.id → message_id → mail
+ *
+ * 結果は受信日降順 + クリックで mail/[id] へ遷移。重複は mail_messages.id で dedup。
+ */
+export async function EventRelatedMails({ eventId }: { eventId: number }) {
+  const mailIds = await collectRelatedMailIds(eventId)
+  if (mailIds.length === 0) return null
+
+  const rows = await db
+    .select({
+      id: mailMessages.id,
+      subject: mailMessages.subject,
+      fromName: mailMessages.fromName,
+      fromAddress: mailMessages.fromAddress,
+      receivedAt: mailMessages.receivedAt,
+    })
+    .from(mailMessages)
+    .where(inArray(mailMessages.id, mailIds))
+    .orderBy(desc(mailMessages.receivedAt))
+
+  return (
+    <section className="flex flex-col gap-2">
+      <h2 className="font-display text-sm font-semibold text-ink-2">
+        関連メール ({rows.length})
+      </h2>
+      <div className="flex flex-col gap-1.5">
+        {rows.map((row) => (
+          <Link key={row.id} href={`/admin/mail-inbox/mail/${row.id}`}>
+            <Card className="hover:bg-surface-alt">
+              <div className="flex flex-col gap-0.5">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="truncate font-medium text-ink">
+                    {row.subject || '(件名なし)'}
+                  </span>
+                  <span className="shrink-0 text-xs text-ink-meta">
+                    {formatJstShort(row.receivedAt)}
+                  </span>
+                </div>
+                <span className="truncate text-xs text-ink-meta">
+                  {row.fromName
+                    ? `${row.fromName} <${row.fromAddress}>`
+                    : row.fromAddress}
+                </span>
+              </div>
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+async function collectRelatedMailIds(eventId: number): Promise<number[]> {
+  // (A) linked_event_id 直接。
+  const linkedRows = await db
+    .select({ id: mailMessages.id })
+    .from(mailMessages)
+    .where(eq(mailMessages.linkedEventId, eventId))
+
+  // (B) tournament_drafts.event_id = eventId 経由（linkDraftToEvent 経路）。
+  //     event_id → draft → message_id (= mail_messages.id)。
+  const draftLinkedRows = await db
+    .select({ id: tournamentDrafts.messageId })
+    .from(tournamentDrafts)
+    .where(eq(tournamentDrafts.eventId, eventId))
+
+  // (C) events.tournament_draft_id → drafts.message_id → mail_messages.id
+  //     （tournament-title-grade-split 経路: 1 draft : N events、events 側に
+  //     tournament_draft_id が立つ）。
+  const synthRows = await db
+    .select({ id: tournamentDrafts.messageId })
+    .from(events)
+    .innerJoin(
+      tournamentDrafts,
+      eq(events.tournamentDraftId, tournamentDrafts.id),
+    )
+    .where(eq(events.id, eventId))
+
+  const set = new Set<number>()
+  for (const r of linkedRows) set.add(r.id)
+  for (const r of draftLinkedRows) set.add(r.id)
+  for (const r of synthRows) set.add(r.id)
+  return Array.from(set)
+}
+
+function formatJstShort(date: Date): string {
+  return date.toLocaleString('ja-JP', {
+    timeZone: 'Asia/Tokyo',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+

--- a/apps/web/src/app/(app)/events/[id]/page.tsx
+++ b/apps/web/src/app/(app)/events/[id]/page.tsx
@@ -39,6 +39,7 @@ import {
   setPaymentType,
   submitAttendance,
 } from './actions'
+import { EventRelatedMails } from './components/EventRelatedMails'
 
 const ACTIVE_BROADCAST_STATUSES = [
   'invite_pending',
@@ -447,6 +448,11 @@ export default async function EventDetailPage({
         revokeBroadcastAction={revokeBroadcast}
         manualBroadcastAction={manualBroadcast}
       />
+
+      {/* mail-inbox-mailer タスク5: 関連メール（AI 抽出経由 + 既存イベント結びつけ
+          経由）。リンク先が /admin/mail-inbox/mail/[id] (管理者専用) なので、
+          一般会員には表示しない。 */}
+      {isAdmin && <EventRelatedMails eventId={idNum} />}
 
       {eligibleAttendingList.length > 0 && (
         <Card>

--- a/apps/web/src/app/api/admin/mail-inbox/[id]/draft-status/route.ts
+++ b/apps/web/src/app/api/admin/mail-inbox/[id]/draft-status/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server'
+import { eq } from 'drizzle-orm'
+import { auth } from '@/auth'
+import { db } from '@/lib/db'
+import { tournamentDrafts } from '@kagetra/shared/schema'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * GET /api/admin/mail-inbox/[id]/draft-status
+ *
+ * mail-inbox-mailer タスク4: ExtractionInProgressCard が 3 秒間隔で叩く軽量
+ * polling エンドポイント。`[id]` は **mail_messages.id** の方（mail 詳細画面の URL
+ * に合わせる）。
+ *
+ * 返り値:
+ *   - 200 { draft: null }                                  : draft 未作成
+ *   - 200 { draft: { status: 'ai_processing' | ... } }     : 現在の draft.status
+ *   - 401/403                                              : 認可エラー
+ *
+ * クライアントは `pending_review` or `ai_failed` を観測したら router.refresh() で
+ * Server Component を再取得し、ExtractionInProgressCard が DraftCard / 再試行
+ * カードに切り替わる。
+ */
+export async function GET(
+  _req: Request,
+  context: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if (session.user.role !== 'admin' && session.user.role !== 'vice_admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { id } = await context.params
+  const mailId = Number(id)
+  if (!Number.isInteger(mailId) || mailId <= 0) {
+    return NextResponse.json({ error: 'invalid id' }, { status: 400 })
+  }
+
+  const draft = await db
+    .select({ status: tournamentDrafts.status })
+    .from(tournamentDrafts)
+    .where(eq(tournamentDrafts.messageId, mailId))
+    .limit(1)
+
+  if (draft.length === 0) {
+    return NextResponse.json({ draft: null })
+  }
+  return NextResponse.json({ draft: { status: draft[0]!.status } })
+}

--- a/apps/web/src/app/api/admin/mail/unprocessed-count/route.test.ts
+++ b/apps/web/src/app/api/admin/mail/unprocessed-count/route.test.ts
@@ -15,12 +15,13 @@ describe('GET /api/admin/mail/unprocessed-count', () => {
     await closeTestDb()
   })
 
-  it('未処理(unprocessed)+保留(deferred)を数え processed は除外する', async () => {
+  // mail-inbox-mailer: deferred 廃止。未処理は unprocessed のみで数える。
+  it('未処理(unprocessed)を数え processed は除外する', async () => {
     const admin = await createAdmin()
     await setAuthSession({ id: admin.id, role: 'admin' })
     await createMailMessage({ triageStatus: 'unprocessed' })
     await createMailMessage({ triageStatus: 'unprocessed' })
-    await createMailMessage({ triageStatus: 'deferred' })
+    await createMailMessage({ triageStatus: 'unprocessed' })
     await createMailMessage({ triageStatus: 'processed' })
 
     const res = await GET()

--- a/apps/web/src/app/api/admin/mail/unprocessed-count/route.ts
+++ b/apps/web/src/app/api/admin/mail/unprocessed-count/route.ts
@@ -9,9 +9,10 @@ export const dynamic = 'force-dynamic'
 /**
  * GET /api/admin/mail/unprocessed-count
  *
- * 未処理メール件数（`triage_status != 'processed'` = unprocessed + deferred）を返す。
+ * 未処理メール件数（`triage_status != 'processed'` = unprocessed）を返す。
  * PWA のフォアグラウンドバッジ同期（アプリ起動/可視化時、処理操作後の再取得）に使う。
  * admin / vice_admin のみ。
+ * mail-inbox-mailer: 2 状態化（unprocessed / processed）に伴い、deferred は廃止。
  */
 export async function GET(): Promise<Response> {
   const session = await auth()

--- a/docs/deploy/mail-worker.md
+++ b/docs/deploy/mail-worker.md
@@ -81,10 +81,18 @@ Lightsail 上に systemd timer で 30 分ごとに動かすまでの一通り。
 7. systemd unit 配置 + 有効化:
 
    ```bash
+   # IMAP fetch 用 (30 分間隔)。mail-inbox-mailer 以降は --mode=fetch-only で AI を呼ばない。
    sudo cp /opt/kagetra/apps/mail-worker/systemd/kagetra-mail-worker.service /etc/systemd/system/
    sudo cp /opt/kagetra/apps/mail-worker/systemd/kagetra-mail-worker.timer /etc/systemd/system/
+
+   # mail-inbox-mailer (タスク6): AI 抽出専用 (30 秒間隔、--mode=extract-only)。
+   # 「会で流す（AI 抽出）」ボタンから生成される manual_extract ジョブを処理する。
+   sudo cp /opt/kagetra/apps/mail-worker/systemd/kagetra-mail-worker-extract.service /etc/systemd/system/
+   sudo cp /opt/kagetra/apps/mail-worker/systemd/kagetra-mail-worker-extract.timer /etc/systemd/system/
+
    sudo systemctl daemon-reload
    sudo systemctl enable --now kagetra-mail-worker.timer
+   sudo systemctl enable --now kagetra-mail-worker-extract.timer
    ```
 
 ## 2. LINE Bot 初期登録

--- a/docs/features/mail-inbox-mailer/implementation-plan.md
+++ b/docs/features/mail-inbox-mailer/implementation-plan.md
@@ -100,7 +100,7 @@ status: completed
   - 既存 fetch timer は 30 分のまま、AI を呼ばない設定が反映されている
 
 ### タスク7: E2E テスト + 既存テスト修正 + DoD
-- [ ] 完了
+- [x] 完了
 - **概要:** AI 抽出→承認→LINE 配信の通し E2E、既存イベント結びつけ→LINE 配信の E2E、その他既存テストの修正。DoD チェックリスト消化
 - **変更対象ファイル:**
   - `apps/web/test/e2e/mail-inbox-ai-extract.spec.ts` — 新規 E2E

--- a/docs/features/mail-inbox-mailer/implementation-plan.md
+++ b/docs/features/mail-inbox-mailer/implementation-plan.md
@@ -23,7 +23,7 @@ status: completed
   - `pnpm typecheck` 通過
 
 ### タスク2: mail-worker の cron AI 廃止 + manual_extract dispatcher
-- [ ] 完了
+- [x] 完了
 - **概要:** cron 動作（kind='fetch'）では llmExtractor を渡さない運用に変更し、manual_extract ジョブを処理する dispatcher 分岐を追加。CLI に `--mode=extract-only` フラグも追加
 - **変更対象ファイル:**
   - `apps/mail-worker/src/pipeline.ts` — `RunPipelineOptions.llmExtractor` を呼び出し側で制御

--- a/docs/features/mail-inbox-mailer/implementation-plan.md
+++ b/docs/features/mail-inbox-mailer/implementation-plan.md
@@ -39,7 +39,7 @@ status: completed
   - cron 既定で AI 抽出が動かない（mock test）
 
 ### タスク3: Server Actions の追加・修正
-- [ ] 完了
+- [x] 完了
 - **概要:** 新規 `triggerExtractDraft` / `linkMailToEvent` / `unlinkMailFromEvent` を追加。既存 `undoTriage` から deferred 経路を削除
 - **変更対象ファイル:**
   - `apps/web/src/app/(app)/admin/mail-inbox/actions.ts` — 上記 3 アクション追加 + undoTriage 修正

--- a/docs/features/mail-inbox-mailer/implementation-plan.md
+++ b/docs/features/mail-inbox-mailer/implementation-plan.md
@@ -52,7 +52,7 @@ status: completed
   - linked_event_id 更新と triage_status='processed' が同一 tx 内
 
 ### タスク4: mail-inbox UI 改修（一覧 + 詳細 + polling）
-- [ ] 完了
+- [x] 完了
 - **概要:** 一覧画面の noise/deferred フィルタ削除、詳細画面の本文即時表示・3 ボタンアクション・AI 抽出中カード・polling 接続。新規コンポーネント 5 つを追加
 - **変更対象ファイル:**
   - `apps/web/src/app/(app)/admin/mail-inbox/page.tsx` — noise/deferred フィルタ削除

--- a/docs/features/mail-inbox-mailer/implementation-plan.md
+++ b/docs/features/mail-inbox-mailer/implementation-plan.md
@@ -1,0 +1,137 @@
+---
+status: completed
+---
+# mail-inbox-mailer 実装手順書
+
+## 実装タスク
+
+### タスク1: DB スキーマ変更 + migration
+- [x] 完了
+- **概要:** linked_event_id、tournament_drafts.status='ai_processing'、mail_worker_jobs.kind/payload、mail_triage_status から deferred 削除を含む drizzle スキーマ更新と migration ファイル作成。既存 deferred mails の unprocessed 化も含む
+- **変更対象ファイル:**
+  - `packages/shared/src/schema/mail-messages.ts` — `linkedEventId` カラム追加（FK to events.id, ON DELETE SET NULL）+ index
+  - `packages/shared/src/schema/tournament-drafts.ts` — 既存維持（enum 変更は enums.ts 側）
+  - `packages/shared/src/schema/mail-worker.ts` — `mailWorkerJobs` に `kind`, `payload` カラム追加
+  - `packages/shared/src/schema/enums.ts` — `tournamentDraftStatusEnum` に `'ai_processing'` 追加、`mailTriageStatusEnum` から `'deferred'` 削除、`mailWorkerJobKindEnum` 新規（'fetch' | 'manual_extract'）
+  - `packages/shared/drizzle/0022_mail_inbox_mailer.sql` — 新規生成 migration
+- **依存タスク:** なし
+- **対応Issue:** #120
+- **完了条件:**
+  - `pnpm --filter @kagetra/shared db:generate` で 0022 migration が生成される
+  - 既存 deferred 行を unprocessed に倒す UPDATE 句が migration に含まれる
+  - `pnpm --filter @kagetra/shared db:migrate` でテスト DB に適用できる
+  - `pnpm typecheck` 通過
+
+### タスク2: mail-worker の cron AI 廃止 + manual_extract dispatcher
+- [ ] 完了
+- **概要:** cron 動作（kind='fetch'）では llmExtractor を渡さない運用に変更し、manual_extract ジョブを処理する dispatcher 分岐を追加。CLI に `--mode=extract-only` フラグも追加
+- **変更対象ファイル:**
+  - `apps/mail-worker/src/pipeline.ts` — `RunPipelineOptions.llmExtractor` を呼び出し側で制御
+  - `apps/mail-worker/src/jobs.ts` — dispatcher に kind 分岐追加。`manual_extract` 時は `payload.mail_message_id` から mail 取得 → `classifyMail` + `persistOutcome` 呼び出し
+  - `apps/mail-worker/src/index.ts` — CLI に `--mode=extract-only` フラグ追加。extract-only は IMAP fetch をスキップ
+  - `apps/mail-worker/test/pipeline.test.ts` — cron 動作変更分のテスト修正
+  - `apps/mail-worker/test/jobs.test.ts` — dispatcher kind 分岐の新テスト追加
+- **依存タスク:** タスク1 (#120)
+- **対応Issue:** #121
+- **完了条件:**
+  - `pnpm --filter @kagetra/mail-worker test --no-file-parallelism` で全テスト pass
+  - `pnpm --filter @kagetra/mail-worker start --mode=extract-only` で manual_extract ジョブだけを処理することを確認
+  - cron 既定で AI 抽出が動かない（mock test）
+
+### タスク3: Server Actions の追加・修正
+- [ ] 完了
+- **概要:** 新規 `triggerExtractDraft` / `linkMailToEvent` / `unlinkMailFromEvent` を追加。既存 `undoTriage` から deferred 経路を削除
+- **変更対象ファイル:**
+  - `apps/web/src/app/(app)/admin/mail-inbox/actions.ts` — 上記 3 アクション追加 + undoTriage 修正
+  - `apps/web/src/app/(app)/admin/mail-inbox/actions.test.ts` — 新規アクションのテスト追加
+- **依存タスク:** タスク1 (#120), タスク2 (#121)
+- **対応Issue:** #122
+- **完了条件:**
+  - 3 アクションのテストが全 pass（正常系、認可エラー、race condition）
+  - linkMailToEvent が broadcastMailToEvent を after() で起動することを確認
+  - linked_event_id 更新と triage_status='processed' が同一 tx 内
+
+### タスク4: mail-inbox UI 改修（一覧 + 詳細 + polling）
+- [ ] 完了
+- **概要:** 一覧画面の noise/deferred フィルタ削除、詳細画面の本文即時表示・3 ボタンアクション・AI 抽出中カード・polling 接続。新規コンポーネント 5 つを追加
+- **変更対象ファイル:**
+  - `apps/web/src/app/(app)/admin/mail-inbox/page.tsx` — noise/deferred フィルタ削除
+  - `apps/web/src/app/(app)/admin/mail-inbox/[id]/page.tsx` — 本文即時表示、draft 状態分岐、3 ボタン
+  - `apps/web/src/app/api/admin/mail-inbox/[id]/draft-status/route.ts` — 新規 polling 用 GET エンドポイント
+  - `apps/web/src/app/(app)/admin/mail-inbox/components/AIExtractConfirmDialog.tsx` — 新規確認ダイアログ
+  - `apps/web/src/app/(app)/admin/mail-inbox/components/ExtractionInProgressCard.tsx` — 新規 spinner + polling
+  - `apps/web/src/app/(app)/admin/mail-inbox/components/ExistingEventLinkSheet.tsx` — 新規イベント選択シート（未開催 + 過去 30 日 + 検索）
+  - `apps/web/src/app/(app)/admin/mail-inbox/components/MailDetailActions.tsx` — 新規 3 ボタンエリア
+  - `apps/web/src/app/(app)/admin/mail-inbox/components/UndoTriageButton.tsx` — 新規 undo ボタン
+- **依存タスク:** タスク3 (#122)
+- **対応Issue:** #123
+- **完了条件:**
+  - dev server で全フロー（AI 抽出/結びつけ/対応不要/undo）が動く
+  - polling が 3 秒間隔で draft.status を fetch し、変化したら router.refresh()
+  - スマホ実機（iPhone PWA）で UI 確認
+
+### タスク5: events 詳細「関連メール」セクション
+- [ ] 完了
+- **概要:** events 詳細ページに「関連メール」セクションを追加。3 経路 UNION で紐付いた mail を抽出して受信日降順表示
+- **変更対象ファイル:**
+  - `apps/web/src/app/(app)/events/[id]/page.tsx` — 関連メールセクション追加
+  - `apps/web/src/app/(app)/events/[id]/components/EventRelatedMails.tsx` — 新規セクションコンポーネント
+- **依存タスク:** タスク3 (#122)
+- **対応Issue:** #124
+- **完了条件:**
+  - 既存イベント結びつけ（linked_event_id）経由のメールが表示される
+  - AI 抽出 → 承認経由のメール（events.tournament_draft_id）も表示される
+  - 訂正版 linkDraftToEvent 経由（tournament_drafts.event_id）も表示される
+  - 受信日降順、クリックで mail 詳細に遷移
+
+### タスク6: systemd timer + 運用設定
+- [ ] 完了
+- **概要:** 30 秒間隔の manual_extract 専用 systemd timer を追加。本番デプロイ手順に組み込む
+- **変更対象ファイル:**
+  - `infra/systemd/kagetra-mail-worker-extract.service` — 新規 unit file
+  - `infra/systemd/kagetra-mail-worker-extract.timer` — 新規 timer file
+  - `infra/scripts/setup-systemd.sh`（既存があれば）— 新 timer の enable/start 追加
+  - `.github/workflows/auto-deploy.yml` — deploy 時の timer reload を追加（必要なら）
+- **依存タスク:** タスク2 (#121)
+- **対応Issue:** #125
+- **完了条件:**
+  - 本番環境で `kagetra-mail-worker-extract.timer` が動作
+  - manual_extract ジョブが 30 秒以内に拾われる
+  - 既存 fetch timer は 30 分のまま、AI を呼ばない設定が反映されている
+
+### タスク7: E2E テスト + 既存テスト修正 + DoD
+- [ ] 完了
+- **概要:** AI 抽出→承認→LINE 配信の通し E2E、既存イベント結びつけ→LINE 配信の E2E、その他既存テストの修正。DoD チェックリスト消化
+- **変更対象ファイル:**
+  - `apps/web/test/e2e/mail-inbox-ai-extract.spec.ts` — 新規 E2E
+  - `apps/web/test/e2e/mail-inbox-link-event.spec.ts` — 新規 E2E
+  - 既存テストファイル — type error 修正
+- **依存タスク:** タスク1〜6 (#120〜#125)
+- **対応Issue:** #126
+- **完了条件:**
+  - 全 E2E pass（CI green）
+  - 既存テスト全 pass
+  - `/dod` でチェックリスト全項目クリア
+  - 本番デプロイ後、スマホ実機で AI 抽出→承認→LINE 受信を確認
+  - 本番デプロイ後、既存イベント結びつけ→LINE 受信を確認
+
+## 実装順序
+
+```
+タスク1 (#120, DB)
+    ↓
+タスク2 (#121, mail-worker) ──→ タスク6 (#125, systemd)
+    ↓
+タスク3 (#122, Server Actions)
+    ├──→ タスク4 (#123, mail-inbox UI)
+    └──→ タスク5 (#124, events 関連メール)
+                            ↓
+                        タスク7 (#126, E2E + DoD)
+```
+
+1. **タスク1** (#120): DB スキーマ変更 + migration（前提）
+2. **タスク2** (#121): mail-worker の cron AI 廃止 + manual_extract dispatcher
+3. **タスク3** (#122): Server Actions
+4. **タスク4, 5** (#123, #124): UI（並行可能、タスク3完了後）
+5. **タスク6** (#125): systemd timer（タスク2完了後でも可）
+6. **タスク7** (#126): E2E + 既存テスト修正 + DoD（最後）

--- a/docs/features/mail-inbox-mailer/implementation-plan.md
+++ b/docs/features/mail-inbox-mailer/implementation-plan.md
@@ -85,7 +85,7 @@ status: completed
   - 受信日降順、クリックで mail 詳細に遷移
 
 ### タスク6: systemd timer + 運用設定
-- [ ] 完了
+- [x] 完了
 - **概要:** 30 秒間隔の manual_extract 専用 systemd timer を追加。本番デプロイ手順に組み込む
 - **変更対象ファイル:**
   - `infra/systemd/kagetra-mail-worker-extract.service` — 新規 unit file

--- a/docs/features/mail-inbox-mailer/implementation-plan.md
+++ b/docs/features/mail-inbox-mailer/implementation-plan.md
@@ -71,7 +71,7 @@ status: completed
   - スマホ実機（iPhone PWA）で UI 確認
 
 ### タスク5: events 詳細「関連メール」セクション
-- [ ] 完了
+- [x] 完了
 - **概要:** events 詳細ページに「関連メール」セクションを追加。3 経路 UNION で紐付いた mail を抽出して受信日降順表示
 - **変更対象ファイル:**
   - `apps/web/src/app/(app)/events/[id]/page.tsx` — 関連メールセクション追加

--- a/docs/features/mail-inbox-mailer/requirements.md
+++ b/docs/features/mail-inbox-mailer/requirements.md
@@ -1,0 +1,348 @@
+---
+status: completed
+---
+# mail-inbox-mailer 要件定義書
+
+## 1. 概要
+
+### 目的
+現在の mail-inbox 画面を「AI が事前に大会案内を見つけて自動でドラフトを作っておく」モデルから、「**届いたメールは全部 inbox に並ぶ＝アプリがメーラー**」モデルに作り替える。AI 抽出は管理者が「これは会に流す」と明確に意思決定したメールに対してのみ起動する。
+
+### 背景・動機
+- 現状の AI 自動分類はメールの抜け漏れリスクがある（pre-filter のメルマガ誤判定、AI noise 判定の取りこぼし）
+- 管理者は「結局メールを全部見てから判断したい」状態。事前 AI が判断を奪っているのが逆にストレス
+- AI は「面倒な抽出作業の自動化道具」であるべきで、「振り分け判断者」ではない
+- コスト面でも、全メールを毎回 AI 通すより、管理者が指定したメールだけ抽出する方が圧倒的に安い
+
+## 2. ユーザーストーリー
+
+### 対象ユーザー
+- 会の管理者（poponta2020 さん）。副管理者も含む
+
+### ユーザーの目的
+- 受信したメールを取りこぼさず全件確認したい
+- 「これは会に流す大会案内だ」と判断したメールに対してだけ AI 抽出を起動して、楽に下書きを作りたい
+- 「組合せ表」「会場案内」のような既存大会への補足情報も、結びつけて LINE で流したい
+- 「会計の領収書」「個人連絡」のような会向け配信不要なメールは、未処理バッジから消すだけにしたい
+
+### 利用シナリオ
+1. 30 分ごとの IMAP fetch でメールが届く → Web Push でバッジ通知
+2. 管理者がアプリを開く → mail-inbox にメールが時系列で並んでいる（メーラー風）
+3. メールを開く → 内容を読む（本文はトグル不要で即座に表示）
+4. 3 つのうちひとつを選ぶ：
+   - **(a) AI 大会抽出**: 「会で流す」と決めたメール → AI 抽出をバックグラウンド起動 → 完了したら Web Push で通知 → draft フォームで確認 → 承認 → LINE 配信
+   - **(b) 既存イベント結びつけ**: 「組合せ表」「訂正版」などの補足情報 → 既存の大会を選んで紐付け → LINE で補足として配信
+   - **(c) 対応不要**: 「領収書」「個人連絡」など → 未処理バッジから外すだけ
+5. 「保留」は廃止（処理しないこと自体が保留を意味する）
+6. 処理を間違えたら処理済セクションで「未処理に戻す」ボタンで undo
+
+## 3. 機能要件
+
+### 3.1 画面仕様
+
+#### 3.1.1 mail-inbox 一覧画面（/admin/mail-inbox）
+- 現状の一覧レイアウトを維持
+- 並び順: 未処理セクションを上に集めて受信時間降順、処理済セクションはトグルで隠して最新 20 件を表示
+- カードレイアウト: 差出人、件名、本文プレビュー、受信日、添付バッジ（現状維持）
+- pre-filter で noise フラグ付きのメールも一覧に表示（現状の「noise 非表示」フィルタを外す）
+- 未処理カウントヘッダ + Web Push でリアルタイム更新（既存仕組み）
+
+#### 3.1.2 mail 詳細画面（/admin/mail-inbox/[id]）
+- 本文を即座に表示（現状のトグルボタンを廃止）
+- 上部: 件名 / 送信者 / 受信日 / 添付一覧
+- 中部: 本文（HTML or text）
+- 下部: アクションエリア（3 ボタン）
+  - **会で流す（AI 抽出）** — 確認ダイアログ「AI で抽出します、よろしいですか？」→ 「はい」で draft INSERT (status=ai_processing) → 「AI 抽出中…」のカード表示
+  - **既存イベントに紐付ける** — モーダル/シート起動 → 紐付け確定 → LINE 配信
+  - **対応不要** — triage_status='processed' → 一覧画面に自動戻り
+
+#### 3.1.3 AI 抽出処理中の表示
+- 同じ詳細画面に「AI 抽出中… 完了したら通知します」のカード表示（spinner 付き）
+- client side polling（3 秒間隔）で draft.status の変化を監視
+- 完了 (pending_review or ai_failed) でリアルタイム更新 → draft フォームまたは失敗カードに切り替え
+- バックグラウンド完了時に Web Push 通知も配信
+
+#### 3.1.4 AI 抽出完了後の draft フォーム
+- 現状の `/admin/mail-inbox/[id]` と同じレイアウト・フィールド
+- 抽出結果の編集 + 承認 / 却下
+- 承認 → events INSERT → LINE 配信（broadcastMailToEvent）
+- N 件分割（tournament-title-grade-split）ロジックそのまま流用
+
+#### 3.1.5 AI 抽出失敗時
+- draft.status='ai_failed' で表示
+- 「再試行」「手動でイベント作成」の 2 ボタン
+- **再試行**: 再度 manual_extract ジョブを enqueue
+- **手動でイベント作成**: 空の EventForm を mail 詳細画面に展開 → 入力 → events INSERT
+  - 完了時に draft.status='approved' で締めて mail.status='archived' + triage_status='processed'
+
+#### 3.1.6 既存イベント結びつけ UI
+- モーダル or ボトムシート
+- デフォルト表示: 未開催全て + 過去 30 日以内の events を受信日降順でリスト
+- 検索ボックスで大会名フィルタ
+- 選択 → 「結びつける」ボタン → 紐付け確定
+- 確定後: linked_event_id 更新、broadcastMailToEvent を起動、triage_status='processed' に倒す
+- 「訂正版」「補足情報」を区別せず、同じフローで処理
+
+#### 3.1.7 events 詳細画面の「関連メール」セクション
+- events 詳細ページ（/events/[id]）に新セクション「関連メール」を追加
+- 紐付いた mail を受信日降順で一覧表示
+- タイトル: 件名 / 送信者 / 受信日
+- クリック → mail 詳細画面に遷移
+- 3 経路を UNION で拾う：
+  - (A) `linked_event_id = :eventId`（既存イベント結びつけ経由）
+  - (B) `tournament_drafts.event_id = :eventId`（訂正版 draft → 既存イベント、linkDraftToEvent 経由）
+  - (C) `events.tournament_draft_id` 経由（AI 抽出 → 承認で生まれた event）
+
+#### 3.1.8 undo 機能（処理済→未処理に戻す）
+- 処理済セクションでメール詳細を開く
+- 「未処理に戻す」ボタンを表示
+- 押下で triage_status='unprocessed' に戻す
+- AI 抽出済み draft は残す（再度開けば編集可）
+- 既存イベント結びつけは linked_event_id を NULL にする（LINE 配信済みメッセージは取り消せないので「紐付けだけ外す」）
+
+### 3.2 ビジネスルール
+
+#### 3.2.1 triage_status の遷移
+- `unprocessed`（デフォルト）↔ `processed`
+- 「保留 (deferred)」状態は廃止
+- 既存の deferred 状態のメールは migration で unprocessed に移行
+
+#### 3.2.2 処理アクションと triage_status の関係
+- AI 抽出ボタン押下時点では `unprocessed` のまま（draft 作成 + status=ai_processing）
+- draft 承認 / 却下 / 対応不要 / 既存イベント結びつけのいずれかで `processed` に倒す
+- undo で `unprocessed` に戻せる
+
+#### 3.2.3 pre-filter（メルマガ自動判定）
+- コード保持。`classification='noise'` 付与は維持
+- inbox UI のフィルタは外す（全件表示）
+- 将来「ノイズタブ」を追加できる余地を残す
+
+#### 3.2.4 自動 AI 分類・抽出の廃止
+- mail-worker の cron からは llmExtractor を渡さない運用に変更
+- pipeline.ts の AI phase コードは保持（manual_extract ジョブから再利用）
+- 既存 pending_review な draft はそのまま残置、既存の承認/却下フローで処理
+
+#### 3.2.5 AI 抽出コスト管理
+- 確認ダイアログで誤タップ防止
+- 再試行は明示的なボタン押下のみ
+- バックグラウンドジョブとしてキューイング、cron からは呼ばれない
+
+#### 3.2.6 既存イベント結びつけのビジネスルール
+- 1 メールに対して 1 イベントのみ紐付け可能（FK 設計）
+- 紐付け済みメールを別イベントに紐付け直す場合は、一度 undo してから再操作
+- 同じイベントに複数メールが紐付くのは OK
+
+## 4. 技術設計
+
+### 4.1 API 設計（Server Actions）
+
+| Action | 状態 | 内容 |
+|---|---|---|
+| `triggerExtractDraft(mailId)` | **新規** | `tournament_drafts` INSERT (status='ai_processing', payload='{}'::jsonb, prompt_version='', ai_model='') + `mail_worker_jobs` INSERT (kind='manual_extract', payload={mail_message_id: mailId}) |
+| `linkMailToEvent(mailId, eventId)` | **新規** | `linked_event_id`, `triage_status='processed'`, `triaged_at`, `triaged_by_user_id` 更新 + after() で `broadcastMailToEvent` |
+| `unlinkMailFromEvent(mailId)` | **新規** | `linked_event_id=NULL` + `triage_status='unprocessed'` 戻し（LINE 配信済みメッセージは取り消し不可） |
+| `triggerMailFetch(sinceDate)` | 既存維持 | `kind='fetch'` を明示 |
+| `approveDraft(draftId, formData)` | 既存維持 | そのまま流用 |
+| `rejectDraft(draftId, reason)` | 既存維持 | そのまま流用 |
+| `dismissMail(mailId)` | 既存維持 | `triage_status='processed'` |
+| `undoTriage(mailId)` | 既存維持 | `deferred` 経路は migration で削除 |
+
+### 4.2 DB 設計
+
+#### 4.2.1 mail_messages テーブル
+追加カラム:
+```sql
+ALTER TABLE mail_messages
+  ADD COLUMN linked_event_id integer
+    REFERENCES events(id) ON DELETE SET NULL;
+
+CREATE INDEX mail_messages_linked_event_id_idx
+  ON mail_messages (linked_event_id)
+  WHERE linked_event_id IS NOT NULL;
+```
+
+#### 4.2.2 tournament_drafts.status enum 拡張
+新規 enum 値: `'ai_processing'`
+- 状態遷移: `ai_processing` → `pending_review`（成功）/ `ai_failed`（失敗）
+- 既存値: `pending_review` / `approved` / `rejected` / `ai_failed` / `superseded`
+
+#### 4.2.3 mail_triage_status enum 縮小
+削除 enum 値: `'deferred'`
+- migration: `UPDATE mail_messages SET triage_status='unprocessed' WHERE triage_status='deferred'`
+- enum 値削除は再作成方式（一時 enum 経由）
+
+#### 4.2.4 mail_worker_jobs テーブル変更
+追加カラム:
+```sql
+CREATE TYPE mail_worker_job_kind AS ENUM ('fetch', 'manual_extract');
+
+ALTER TABLE mail_worker_jobs
+  ADD COLUMN kind mail_worker_job_kind NOT NULL DEFAULT 'fetch',
+  ADD COLUMN payload jsonb;
+```
+- `payload` 構造: `{ mail_message_id?: number }`（manual_extract 時のみ必須）
+
+#### 4.2.5 migration ファイル
+- `packages/shared/drizzle/0022_mail_inbox_mailer.sql` (drizzle-kit generate)
+- 内容:
+  1. mail_worker_job_kind enum 作成
+  2. mail_worker_jobs.kind, payload 追加
+  3. mail_messages.linked_event_id 追加 + index
+  4. tournament_drafts.status enum 拡張（'ai_processing' 追加）
+  5. UPDATE mail_messages SET triage_status='unprocessed' WHERE triage_status='deferred'
+  6. mail_triage_status enum 再作成（deferred を削除）
+
+### 4.3 フロントエンド設計
+
+#### 4.3.1 既存コンポーネント変更
+- `apps/web/src/app/(app)/admin/mail-inbox/page.tsx`
+  - クエリの noise フィルタ削除（全件表示）
+  - triage_status `deferred` フィルタ削除
+- `apps/web/src/app/(app)/admin/mail-inbox/[id]/page.tsx`
+  - 本文を即表示（トグル廃止）
+  - draft 状態に応じた表示分岐:
+    - draft なし: アクション 3 ボタン表示
+    - draft.status='ai_processing': ExtractionInProgressCard
+    - draft.status='pending_review': 既存 DraftCard + EventApprovalForm
+    - draft.status='ai_failed': 再試行ボタン + 「手動でイベント作成」ボタン
+- `apps/web/src/app/(app)/events/[id]/page.tsx`
+  - 「関連メール」セクション追加
+
+#### 4.3.2 新規コンポーネント
+- `components/AIExtractConfirmDialog.tsx`: 「AI で抽出します、よろしいですか？」
+- `components/ExtractionInProgressCard.tsx`: spinner + ステータステキスト + polling
+- `components/ExistingEventLinkSheet.tsx`: 既存イベント選択ボトムシート（直近 30 日 + 検索）
+- `components/MailDetailActions.tsx`: 3 ボタンエリア
+- `components/UndoTriageButton.tsx`: 処理済画面用の戻すボタン
+- `components/EventRelatedMails.tsx`: events 詳細の「関連メール」セクション
+
+#### 4.3.3 状態管理
+- AI 抽出中のリアルタイム更新: client side polling（3 秒間隔）
+  - `/api/admin/mail-inbox/[id]/draft-status` で draft.status を返す
+  - status が `pending_review` / `ai_failed` に変わったら `router.refresh()` でサーバー側 RSC を再取得
+
+### 4.4 バックエンド設計
+
+#### 4.4.1 mail-worker (apps/mail-worker)
+- `src/pipeline.ts`:
+  - cron 動作（kind='fetch'）では `llmExtractor` を渡さない運用に変更（CLI 引数で制御）
+  - AI phase コード自体は残置、manual_extract から再利用
+- `src/jobs.ts`:
+  - dispatcher に kind 分岐追加
+    - 'fetch': 既存の runOnce 呼び出し
+    - 'manual_extract': payload.mail_message_id から mail を取得 → classifyMail + persistOutcome を呼び出し
+- `src/index.ts`:
+  - CLI に `--mode=extract-only` フラグ追加
+  - extract-only モードは IMAP fetch を skip して manual_extract ジョブだけ処理
+
+#### 4.4.2 systemd timer
+- 新規: `kagetra-mail-worker-extract.timer`（30 秒間隔、`--mode=extract-only`）
+- 既存: `kagetra-mail-worker.timer`（30 分間隔、fetch のみ、AI 抽出は呼ばない運用に変更）
+
+#### 4.4.3 LINE 配信
+- 既存 `broadcastMailToEvent` をそのまま再利用（変更なし）
+- 既存 `mail-body-as-image` をそのまま再利用（変更なし）
+- 既存 `event_broadcast_messages` テーブルもそのまま
+
+#### 4.4.4 API Routes
+- 新規 `apps/web/src/app/api/admin/mail-inbox/[id]/draft-status/route.ts`
+  - GET: `tournament_drafts.status` を返す軽量エンドポイント（polling 用）
+- 既存ルートは変更なし
+
+## 5. 影響範囲
+
+### 5.1 変更が必要な既存ファイル
+- `apps/mail-worker/src/pipeline.ts`: AI phase を opts.llmExtractor で制御
+- `apps/mail-worker/src/jobs.ts`: dispatcher の kind 分岐
+- `apps/mail-worker/src/index.ts`: --mode=extract-only 追加
+- `apps/web/src/app/(app)/admin/mail-inbox/page.tsx`: フィルタ条件変更
+- `apps/web/src/app/(app)/admin/mail-inbox/[id]/page.tsx`: 詳細画面の再構成
+- `apps/web/src/app/(app)/admin/mail-inbox/actions.ts`: Server Actions 追加・修正
+- `apps/web/src/app/(app)/events/[id]/page.tsx`: 関連メールセクション追加
+- `packages/shared/src/schema/mail-messages.ts`: linked_event_id 追加
+- `packages/shared/src/schema/tournament-drafts.ts`: status enum 拡張
+- `packages/shared/src/schema/mail-worker.ts`: kind, payload 追加
+- `packages/shared/src/schema/enums.ts`: enum 定義変更
+- `packages/shared/drizzle/0022_mail_inbox_mailer.sql`: 新規 migration
+- `infra/systemd/kagetra-mail-worker-extract.timer`: 新規 systemd unit ファイル
+
+### 5.2 既存機能への影響
+- 既存 pending_review draft: 影響なし、現状の承認/却下フローで処理可能
+- 既存 events に紐付いた draft: 影響なし
+- 既存 LINE 配信 (broadcastMailToEvent): 影響なし
+- 既存 mail-body-as-image: 影響なし
+- 既存 event-lifecycle-notify / entry-notify-lottery-treasurer: events 経由なので影響なし
+- 既存 Web Push (mail-triage-badge): 影響なし、新規メール通知はそのまま動く
+- pre-filter: コード保持、UI フィルタを外すだけ
+
+### 5.3 共通コンポーネント・ユーティリティへの影響
+- EventForm: 影響なし、再利用
+- mail-worker の classifyMail/persistOutcome: 影響なし、再利用
+- broadcastMailToEvent: 影響なし、再利用
+
+### 5.4 API・DBスキーマの互換性
+- 後方互換性: 既存データはそのまま使える
+- 破壊的変更:
+  - `mail_triage_status` enum から 'deferred' 削除（migration で全件 unprocessed に倒すので実害なし）
+- 新規カラムは NOT NULL DEFAULT 付与で既存行に impact なし
+
+### 5.5 テスト影響
+- `apps/mail-worker/test/pipeline.test.ts`: cron 動作変更分のテスト修正
+- `apps/mail-worker/test/jobs.test.ts`: dispatcher kind 分岐の新テスト追加
+- `apps/web/src/app/(app)/admin/mail-inbox/actions.test.ts`: 新規 Server Action のテスト追加
+- 新規 E2E: AI 抽出→承認→LINE 配信の通しテスト
+- 新規 E2E: 既存イベント結びつけ→LINE 配信の通しテスト
+
+## 6. 設計判断の根拠
+
+### 6.1 ノイズ自動判定の廃止
+- メール抜け漏れリスクを最小化するため、AI 自動分類は廃止
+- ただし pre-filter のコード（ヘッダベースのメルマガ判定）は **残す**。inbox UI 側の「ノイズ非表示」フィルタを外すだけで全件見える状態にする
+- 将来「ノイズタブ」を作りたくなった時のためにフラグを残す
+
+### 6.2 AI 抽出のバックグラウンド化
+- Sonnet 4.6 で本文＋添付込みの抽出は 5〜30 秒。同期で待たせると UX 悪い
+- 「会で流す（AI 抽出）」ボタン押下 → 即座に draft 行 INSERT (status=ai_processing) → 画面遷移 → バックグラウンド完了後に Web Push で通知
+
+### 6.3 draft テーブルは残す
+- N 件分割（1 メール = 複数大会）、再抽出、承認 race 直列化、LINE 配信トリガー、訂正版管理の責務がある
+- 違いは「自動 INSERT」から「ボタン押下時 INSERT」への変更だけ
+
+### 6.4 triage_status の簡素化（3 状態 → 2 状態）
+- `unprocessed`（未処理）/ `processed`（処理済み）の 2 状態
+- 「保留」は廃止：処理せずに放置することが暗黙の保留である
+
+### 6.5 既存データ移行方針
+- 過去の `classification` カラムの値は残す（参照のみ）
+- 将来的に `classification` カラム自体は削除する migration を予定
+- 既存 deferred mails は unprocessed に倒す
+- 既存 pending_review draft はそのまま、現状の承認/却下フローで処理
+
+### 6.6 「訂正版」と「補足情報」を区別しない
+- どちらも「既存イベント結びつけ」アクションで統一処理
+- AI による is_correction 判定は廃止（手動判断に集約）
+- イベント本体の情報変更（開催日/会場等）は管理者が events テーブルを edit する手動運用
+
+### 6.7 既存イベント検索範囲（未開催 + 過去 30 日）
+- 未開催: 補足情報の主な対象（組合せ表など）
+- 過去 30 日: 領収書/事後連絡などの結びつけ用
+
+### 6.8 mail_messages.linked_event_id 直 FK（中間テーブルにしない）
+- 1 メール = 1 イベントのシンプル設計
+- AI 抽出経路（tournament_drafts.event_id / events.tournament_draft_id）と別 carrier
+- 将来 M:N が必要になれば中間テーブルに移行可能
+
+### 6.9 mail_worker_jobs に kind 追加（新規テーブルにしない）
+- 既存 dispatcher を流用できる
+- 既存 status, claimed_at, run_id などの仕組みも流用
+- 新規テーブルを作ると dispatcher/UI が二重化する
+
+### 6.10 polling 方式（SSE / WebSocket にしない）
+- SSE は Next.js App Router で動かすのに余計な設定が必要
+- 3 秒間隔の軽量 GET なら十分。AI 抽出は 5〜30 秒、平均 6 回程度の polling で完了する
+- 既存 fetch API と同じ仕組みで実装簡単
+
+### 6.11 systemd timer を別建て（既存 timer に乗らない）
+- 既存 30 分間隔 timer を変えると IMAP fetch 頻度も変わる
+- AI 抽出だけ高頻度（30 秒間隔）にしたいので別 timer
+- mail-worker 本体は 1 つのまま、CLI 引数で挙動を切り替える

--- a/packages/shared/drizzle/0022_mail_inbox_mailer.sql
+++ b/packages/shared/drizzle/0022_mail_inbox_mailer.sql
@@ -1,0 +1,18 @@
+CREATE TYPE "public"."mail_worker_job_kind" AS ENUM('fetch', 'manual_extract');--> statement-breakpoint
+ALTER TYPE "public"."tournament_draft_status" ADD VALUE 'ai_processing';--> statement-breakpoint
+ALTER TABLE "mail_messages" ALTER COLUMN "triage_status" SET DATA TYPE text;--> statement-breakpoint
+ALTER TABLE "mail_messages" ALTER COLUMN "triage_status" SET DEFAULT 'unprocessed'::text;--> statement-breakpoint
+DROP TYPE "public"."mail_triage_status";--> statement-breakpoint
+CREATE TYPE "public"."mail_triage_status" AS ENUM('unprocessed', 'processed');--> statement-breakpoint
+-- mail-inbox-mailer: 既存 deferred 行を unprocessed に倒してから新 enum へ ALTER。
+-- enum 値削除は drizzle-kit が「text に ALTER → DROP TYPE → CREATE TYPE → enum に再 ALTER」
+-- パターンで自動生成するが、UPDATE が抜けると次の USING キャストで
+-- 「invalid input value for enum mail_triage_status: "deferred"」が出るので手動追記。
+UPDATE "mail_messages" SET "triage_status" = 'unprocessed' WHERE "triage_status" = 'deferred';--> statement-breakpoint
+ALTER TABLE "mail_messages" ALTER COLUMN "triage_status" SET DEFAULT 'unprocessed'::"public"."mail_triage_status";--> statement-breakpoint
+ALTER TABLE "mail_messages" ALTER COLUMN "triage_status" SET DATA TYPE "public"."mail_triage_status" USING "triage_status"::"public"."mail_triage_status";--> statement-breakpoint
+ALTER TABLE "mail_messages" ADD COLUMN "linked_event_id" integer;--> statement-breakpoint
+ALTER TABLE "mail_worker_jobs" ADD COLUMN "kind" "mail_worker_job_kind" DEFAULT 'fetch' NOT NULL;--> statement-breakpoint
+ALTER TABLE "mail_worker_jobs" ADD COLUMN "payload" jsonb;--> statement-breakpoint
+ALTER TABLE "mail_messages" ADD CONSTRAINT "mail_messages_linked_event_id_events_id_fk" FOREIGN KEY ("linked_event_id") REFERENCES "public"."events"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "mail_messages_linked_event_id_idx" ON "mail_messages" USING btree ("linked_event_id") WHERE "mail_messages"."linked_event_id" IS NOT NULL;

--- a/packages/shared/drizzle/0023_mail_worker_jobs_kind_index.sql
+++ b/packages/shared/drizzle/0023_mail_worker_jobs_kind_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "idx_mail_worker_jobs_status_kind_requested_at" ON "mail_worker_jobs" USING btree ("status","kind","requested_at");

--- a/packages/shared/drizzle/0024_tournament_drafts_event_id_index.sql
+++ b/packages/shared/drizzle/0024_tournament_drafts_event_id_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "idx_drafts_event_id" ON "tournament_drafts" USING btree ("event_id") WHERE "tournament_drafts"."event_id" IS NOT NULL;

--- a/packages/shared/drizzle/meta/0022_snapshot.json
+++ b/packages/shared/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,2821 @@
+{
+  "id": "5ea6d07d-0da8-4fb2-8057-6487aa3ba310",
+  "prevId": "fc9c985b-520a-434a-a2d7-a57d1b333832",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_user_id": {
+          "name": "line_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "grade": {
+          "name": "grade",
+          "type": "grade",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_invited": {
+          "name": "is_invited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affiliation": {
+          "name": "affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dan": {
+          "name": "dan",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zen_nichikyo": {
+          "name": "zen_nichikyo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_linked_at": {
+          "name": "line_linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_link_method": {
+          "name": "line_link_method",
+          "type": "line_link_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notification_line_user_id": {
+          "name": "notification_line_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_name_unique": {
+          "name": "users_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_line_user_id_unique": {
+          "name": "users_line_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "line_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_dan_range": {
+          "name": "users_dan_range",
+          "value": "\"users\".\"dan\" BETWEEN 0 AND 9 OR \"users\".\"dan\" IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_groups": {
+      "name": "event_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_groups_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_groups_name_unique": {
+          "name": "event_groups_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "events_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formal_name": {
+          "name": "formal_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official": {
+          "name": "official",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'individual'"
+        },
+        "entry_deadline": {
+          "name": "entry_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_deadline": {
+          "name": "internal_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_group_id": {
+          "name": "event_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligible_grades": {
+          "name": "eligible_grades",
+          "type": "grade[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_jpy": {
+          "name": "fee_jpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_deadline": {
+          "name": "payment_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lottery_date": {
+          "name": "lottery_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_info": {
+          "name": "payment_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_method": {
+          "name": "entry_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizer": {
+          "name": "organizer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_a": {
+          "name": "capacity_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_b": {
+          "name": "capacity_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_c": {
+          "name": "capacity_c",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_d": {
+          "name": "capacity_d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_e": {
+          "name": "capacity_e",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_status": {
+          "name": "entry_status",
+          "type": "event_entry_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_applied'"
+        },
+        "entry_applied_at": {
+          "name": "entry_applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_type": {
+          "name": "payment_type",
+          "type": "event_payment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "event_payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unpaid'"
+        },
+        "payment_paid_at": {
+          "name": "payment_paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournament_draft_id": {
+          "name": "tournament_draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournament_draft_unit_key": {
+          "name": "tournament_draft_unit_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_tournament_draft_unit_key_uniq": {
+          "name": "events_tournament_draft_unit_key_uniq",
+          "columns": [
+            {
+              "expression": "tournament_draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tournament_draft_unit_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"events\".\"tournament_draft_id\" IS NOT NULL AND \"events\".\"tournament_draft_unit_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_created_by_users_id_fk": {
+          "name": "events_created_by_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_event_group_id_event_groups_id_fk": {
+          "name": "events_event_group_id_event_groups_id_fk",
+          "tableFrom": "events",
+          "tableTo": "event_groups",
+          "columnsFrom": [
+            "event_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_attendances": {
+      "name": "event_attendances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_attendances_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attend": {
+          "name": "attend",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_attendances_event_id_events_id_fk": {
+          "name": "event_attendances_event_id_events_id_fk",
+          "tableFrom": "event_attendances",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_attendances_user_id_users_id_fk": {
+          "name": "event_attendances_user_id_users_id_fk",
+          "tableFrom": "event_attendances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_attendances_event_id_user_id_unique": {
+          "name": "event_attendances_event_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_items": {
+      "name": "schedule_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "schedule_items_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "schedule_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_items_owner_id_users_id_fk": {
+          "name": "schedule_items_owner_id_users_id_fk",
+          "tableFrom": "schedule_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_messages": {
+      "name": "mail_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_messages_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_addresses": {
+          "name": "to_addresses",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_message_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "mail_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imap_uid": {
+          "name": "imap_uid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imap_box": {
+          "name": "imap_box",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "triage_status": {
+          "name": "triage_status",
+          "type": "mail_triage_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unprocessed'"
+        },
+        "triaged_at": {
+          "name": "triaged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triaged_by_user_id": {
+          "name": "triaged_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_event_id": {
+          "name": "linked_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_messages_received_at_desc_idx": {
+          "name": "mail_messages_received_at_desc_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_messages_triage_status_idx": {
+          "name": "mail_messages_triage_status_idx",
+          "columns": [
+            {
+              "expression": "triage_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_messages_linked_event_id_idx": {
+          "name": "mail_messages_linked_event_id_idx",
+          "columns": [
+            {
+              "expression": "linked_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"mail_messages\".\"linked_event_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_messages_triaged_by_user_id_users_id_fk": {
+          "name": "mail_messages_triaged_by_user_id_users_id_fk",
+          "tableFrom": "mail_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triaged_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mail_messages_linked_event_id_events_id_fk": {
+          "name": "mail_messages_linked_event_id_events_id_fk",
+          "tableFrom": "mail_messages",
+          "tableTo": "events",
+          "columnsFrom": [
+            "linked_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mail_messages_message_id_unique": {
+          "name": "mail_messages_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_attachments": {
+      "name": "mail_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_attachments_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "mail_message_id": {
+          "name": "mail_message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extracted_text": {
+          "name": "extracted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_status": {
+          "name": "extraction_status",
+          "type": "attachment_extraction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mail_attachments_mail_message_id_idx": {
+          "name": "mail_attachments_mail_message_id_idx",
+          "columns": [
+            {
+              "expression": "mail_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_attachments_mail_message_id_mail_messages_id_fk": {
+          "name": "mail_attachments_mail_message_id_mail_messages_id_fk",
+          "tableFrom": "mail_attachments",
+          "tableTo": "mail_messages",
+          "columnsFrom": [
+            "mail_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tournament_drafts": {
+      "name": "tournament_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tournament_drafts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tournament_draft_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_correction": {
+          "name": "is_correction",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "references_subject": {
+          "name": "references_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_by_draft_id": {
+          "name": "superseded_by_draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracted_payload": {
+          "name": "extracted_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ai_raw_response": {
+          "name": "ai_raw_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_tokens_input": {
+          "name": "ai_tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_tokens_output": {
+          "name": "ai_tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_cost_usd": {
+          "name": "ai_cost_usd",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by_user_id": {
+          "name": "rejected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_drafts_status_created": {
+          "name": "idx_drafts_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tournament_drafts_message_id_mail_messages_id_fk": {
+          "name": "tournament_drafts_message_id_mail_messages_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "mail_messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tournament_drafts_event_id_events_id_fk": {
+          "name": "tournament_drafts_event_id_events_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tournament_drafts_approved_by_user_id_users_id_fk": {
+          "name": "tournament_drafts_approved_by_user_id_users_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tournament_drafts_rejected_by_user_id_users_id_fk": {
+          "name": "tournament_drafts_rejected_by_user_id_users_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "rejected_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tournament_drafts_message_id_unique": {
+          "name": "tournament_drafts_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tournament_drafts_confidence_range": {
+          "name": "tournament_drafts_confidence_range",
+          "value": "\"tournament_drafts\".\"confidence\" BETWEEN 0 AND 1 OR \"tournament_drafts\".\"confidence\" IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.line_channels": {
+      "name": "line_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "line_channels_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_secret": {
+          "name": "channel_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_access_token": {
+          "name": "channel_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "line_channel_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "line_channel_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system_notify'"
+        },
+        "assigned_user_id": {
+          "name": "assigned_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_event_id": {
+          "name": "assigned_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_destination_id": {
+          "name": "webhook_destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_line_user_id": {
+          "name": "notification_line_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "line_channels_assigned_user_id_users_id_fk": {
+          "name": "line_channels_assigned_user_id_users_id_fk",
+          "tableFrom": "line_channels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "line_channels_assigned_event_id_events_id_fk": {
+          "name": "line_channels_assigned_event_id_events_id_fk",
+          "tableFrom": "line_channels",
+          "tableTo": "events",
+          "columnsFrom": [
+            "assigned_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "line_channels_channel_id_unique": {
+          "name": "line_channels_channel_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "channel_id"
+          ]
+        },
+        "line_channels_assigned_user_id_unique": {
+          "name": "line_channels_assigned_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "assigned_user_id"
+          ]
+        },
+        "line_channels_assigned_event_id_unique": {
+          "name": "line_channels_assigned_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "assigned_event_id"
+          ]
+        },
+        "line_channels_webhook_destination_id_unique": {
+          "name": "line_channels_webhook_destination_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "webhook_destination_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_worker_jobs": {
+      "name": "mail_worker_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_worker_jobs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "since": {
+          "name": "since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_worker_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "mail_worker_job_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fetch'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_mail_worker_jobs_status_requested_at": {
+          "name": "idx_mail_worker_jobs_status_requested_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_worker_jobs_requested_by_user_id_users_id_fk": {
+          "name": "mail_worker_jobs_requested_by_user_id_users_id_fk",
+          "tableFrom": "mail_worker_jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mail_worker_jobs_run_id_mail_worker_runs_id_fk": {
+          "name": "mail_worker_jobs_run_id_mail_worker_runs_id_fk",
+          "tableFrom": "mail_worker_jobs",
+          "tableTo": "mail_worker_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_worker_runs": {
+      "name": "mail_worker_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_worker_runs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "mail_worker_run_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_worker_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_user_id": {
+          "name": "triggered_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "since": {
+          "name": "since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_worker_runs_triggered_by_user_id_users_id_fk": {
+          "name": "mail_worker_runs_triggered_by_user_id_users_id_fk",
+          "tableFrom": "mail_worker_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggered_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_line_broadcasts": {
+      "name": "event_line_broadcasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_line_broadcasts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_channel_id": {
+          "name": "line_channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code_expires_at": {
+          "name": "invite_code_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_group_id": {
+          "name": "line_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_line_broadcast_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invite_pending'"
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extended_until": {
+          "name": "extended_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoke_reason": {
+          "name": "revoke_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_line_broadcasts_invite_code_active_uq": {
+          "name": "event_line_broadcasts_invite_code_active_uq",
+          "columns": [
+            {
+              "expression": "invite_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"event_line_broadcasts\".\"invite_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_line_broadcasts_event_id_events_id_fk": {
+          "name": "event_line_broadcasts_event_id_events_id_fk",
+          "tableFrom": "event_line_broadcasts",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "event_line_broadcasts_line_channel_id_line_channels_id_fk": {
+          "name": "event_line_broadcasts_line_channel_id_line_channels_id_fk",
+          "tableFrom": "event_line_broadcasts",
+          "tableTo": "line_channels",
+          "columnsFrom": [
+            "line_channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_line_broadcasts_event_id_unique": {
+          "name": "event_line_broadcasts_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_broadcast_messages": {
+      "name": "event_broadcast_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_broadcast_messages_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_line_broadcast_id": {
+          "name": "event_line_broadcast_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mail_message_id": {
+          "name": "mail_message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "event_broadcast_message_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "is_correction": {
+          "name": "is_correction",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sent_text_count": {
+          "name": "sent_text_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_image_count": {
+          "name": "sent_image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "fallback_link_count": {
+          "name": "fallback_link_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_broadcast_messages_event_line_broadcast_id_event_line_broadcasts_id_fk": {
+          "name": "event_broadcast_messages_event_line_broadcast_id_event_line_broadcasts_id_fk",
+          "tableFrom": "event_broadcast_messages",
+          "tableTo": "event_line_broadcasts",
+          "columnsFrom": [
+            "event_line_broadcast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_broadcast_messages_mail_message_id_mail_messages_id_fk": {
+          "name": "event_broadcast_messages_mail_message_id_mail_messages_id_fk",
+          "tableFrom": "event_broadcast_messages",
+          "tableTo": "mail_messages",
+          "columnsFrom": [
+            "mail_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_broadcast_messages_broadcast_mail_uq": {
+          "name": "event_broadcast_messages_broadcast_mail_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_line_broadcast_id",
+            "mail_message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachment_share_tokens": {
+      "name": "attachment_share_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "attachment_share_tokens_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "mail_attachment_id": {
+          "name": "mail_attachment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attachment_share_tokens_attachment_idx": {
+          "name": "attachment_share_tokens_attachment_idx",
+          "columns": [
+            {
+              "expression": "mail_attachment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachment_share_tokens_expires_at_idx": {
+          "name": "attachment_share_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attachment_share_tokens_mail_attachment_id_mail_attachments_id_fk": {
+          "name": "attachment_share_tokens_mail_attachment_id_mail_attachments_id_fk",
+          "tableFrom": "attachment_share_tokens",
+          "tableTo": "mail_attachments",
+          "columnsFrom": [
+            "mail_attachment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "attachment_share_tokens_mail_attachment_id_unique": {
+          "name": "attachment_share_tokens_mail_attachment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mail_attachment_id"
+          ]
+        },
+        "attachment_share_tokens_token_unique": {
+          "name": "attachment_share_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_lifecycle_notifications": {
+      "name": "event_lifecycle_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_lifecycle_notifications_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "event_lifecycle_notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "event_lifecycle_notification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sent'"
+        },
+        "line_group_id": {
+          "name": "line_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_lifecycle_notifications_event_type_uq": {
+          "name": "event_lifecycle_notifications_event_type_uq",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_lifecycle_notifications_event_id_events_id_fk": {
+          "name": "event_lifecycle_notifications_event_id_events_id_fk",
+          "tableFrom": "event_lifecycle_notifications",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "push_subscriptions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_id_idx": {
+          "name": "push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_id_fk": {
+          "name": "push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_subscriptions_endpoint_unique": {
+          "name": "push_subscriptions_endpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "endpoint"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attachment_extraction_status": {
+      "name": "attachment_extraction_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "extracted",
+        "failed",
+        "unsupported"
+      ]
+    },
+    "public.event_broadcast_message_status": {
+      "name": "event_broadcast_message_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sending",
+        "sent",
+        "partial",
+        "failed"
+      ]
+    },
+    "public.event_entry_status": {
+      "name": "event_entry_status",
+      "schema": "public",
+      "values": [
+        "not_applied",
+        "applied"
+      ]
+    },
+    "public.event_kind": {
+      "name": "event_kind",
+      "schema": "public",
+      "values": [
+        "individual",
+        "team"
+      ]
+    },
+    "public.event_lifecycle_notification_status": {
+      "name": "event_lifecycle_notification_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.event_lifecycle_notification_type": {
+      "name": "event_lifecycle_notification_type",
+      "schema": "public",
+      "values": [
+        "entry_applied",
+        "entry_deadline_advance",
+        "entry_deadline_day",
+        "payment_paid",
+        "payment_deadline_advance",
+        "payment_deadline_day",
+        "onsite_payment_advance",
+        "onsite_payment_day",
+        "entry_applied_treasurer"
+      ]
+    },
+    "public.event_line_broadcast_status": {
+      "name": "event_line_broadcast_status",
+      "schema": "public",
+      "values": [
+        "invite_pending",
+        "joined_waiting_code",
+        "linked",
+        "revoked",
+        "released"
+      ]
+    },
+    "public.event_payment_status": {
+      "name": "event_payment_status",
+      "schema": "public",
+      "values": [
+        "unpaid",
+        "paid"
+      ]
+    },
+    "public.event_payment_type": {
+      "name": "event_payment_type",
+      "schema": "public",
+      "values": [
+        "advance",
+        "onsite"
+      ]
+    },
+    "public.event_status": {
+      "name": "event_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "cancelled",
+        "done"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female"
+      ]
+    },
+    "public.grade": {
+      "name": "grade",
+      "schema": "public",
+      "values": [
+        "A",
+        "B",
+        "C",
+        "D",
+        "E"
+      ]
+    },
+    "public.line_channel_purpose": {
+      "name": "line_channel_purpose",
+      "schema": "public",
+      "values": [
+        "system_notify",
+        "event_broadcast"
+      ]
+    },
+    "public.line_channel_status": {
+      "name": "line_channel_status",
+      "schema": "public",
+      "values": [
+        "available",
+        "assigned",
+        "active",
+        "system",
+        "disabled"
+      ]
+    },
+    "public.line_link_method": {
+      "name": "line_link_method",
+      "schema": "public",
+      "values": [
+        "self_identify",
+        "admin_link",
+        "account_switch"
+      ]
+    },
+    "public.mail_classification": {
+      "name": "mail_classification",
+      "schema": "public",
+      "values": [
+        "tournament",
+        "noise",
+        "unknown"
+      ]
+    },
+    "public.mail_message_status": {
+      "name": "mail_message_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "fetched",
+        "parse_failed",
+        "fetch_failed",
+        "ai_processing",
+        "ai_done",
+        "ai_failed",
+        "oversize_skipped",
+        "archived"
+      ]
+    },
+    "public.mail_triage_status": {
+      "name": "mail_triage_status",
+      "schema": "public",
+      "values": [
+        "unprocessed",
+        "processed"
+      ]
+    },
+    "public.mail_worker_job_kind": {
+      "name": "mail_worker_job_kind",
+      "schema": "public",
+      "values": [
+        "fetch",
+        "manual_extract"
+      ]
+    },
+    "public.mail_worker_job_status": {
+      "name": "mail_worker_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "claimed",
+        "done",
+        "failed"
+      ]
+    },
+    "public.mail_worker_run_kind": {
+      "name": "mail_worker_run_kind",
+      "schema": "public",
+      "values": [
+        "cron",
+        "manual"
+      ]
+    },
+    "public.mail_worker_run_status": {
+      "name": "mail_worker_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "imap_failed",
+        "ai_failed",
+        "partial"
+      ]
+    },
+    "public.schedule_kind": {
+      "name": "schedule_kind",
+      "schema": "public",
+      "values": [
+        "practice",
+        "meeting",
+        "social",
+        "other"
+      ]
+    },
+    "public.tournament_draft_status": {
+      "name": "tournament_draft_status",
+      "schema": "public",
+      "values": [
+        "pending_review",
+        "approved",
+        "rejected",
+        "ai_failed",
+        "superseded",
+        "ai_processing"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "vice_admin",
+        "member"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/shared/drizzle/meta/0023_snapshot.json
+++ b/packages/shared/drizzle/meta/0023_snapshot.json
@@ -1,0 +1,2848 @@
+{
+  "id": "1258a085-ef61-4768-9f73-7cd97c7f437e",
+  "prevId": "5ea6d07d-0da8-4fb2-8057-6487aa3ba310",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_user_id": {
+          "name": "line_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "grade": {
+          "name": "grade",
+          "type": "grade",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_invited": {
+          "name": "is_invited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affiliation": {
+          "name": "affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dan": {
+          "name": "dan",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zen_nichikyo": {
+          "name": "zen_nichikyo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_linked_at": {
+          "name": "line_linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_link_method": {
+          "name": "line_link_method",
+          "type": "line_link_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notification_line_user_id": {
+          "name": "notification_line_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_name_unique": {
+          "name": "users_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_line_user_id_unique": {
+          "name": "users_line_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "line_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_dan_range": {
+          "name": "users_dan_range",
+          "value": "\"users\".\"dan\" BETWEEN 0 AND 9 OR \"users\".\"dan\" IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_groups": {
+      "name": "event_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_groups_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_groups_name_unique": {
+          "name": "event_groups_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "events_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formal_name": {
+          "name": "formal_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official": {
+          "name": "official",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'individual'"
+        },
+        "entry_deadline": {
+          "name": "entry_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_deadline": {
+          "name": "internal_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_group_id": {
+          "name": "event_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligible_grades": {
+          "name": "eligible_grades",
+          "type": "grade[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_jpy": {
+          "name": "fee_jpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_deadline": {
+          "name": "payment_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lottery_date": {
+          "name": "lottery_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_info": {
+          "name": "payment_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_method": {
+          "name": "entry_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizer": {
+          "name": "organizer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_a": {
+          "name": "capacity_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_b": {
+          "name": "capacity_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_c": {
+          "name": "capacity_c",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_d": {
+          "name": "capacity_d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_e": {
+          "name": "capacity_e",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_status": {
+          "name": "entry_status",
+          "type": "event_entry_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_applied'"
+        },
+        "entry_applied_at": {
+          "name": "entry_applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_type": {
+          "name": "payment_type",
+          "type": "event_payment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "event_payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unpaid'"
+        },
+        "payment_paid_at": {
+          "name": "payment_paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournament_draft_id": {
+          "name": "tournament_draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournament_draft_unit_key": {
+          "name": "tournament_draft_unit_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_tournament_draft_unit_key_uniq": {
+          "name": "events_tournament_draft_unit_key_uniq",
+          "columns": [
+            {
+              "expression": "tournament_draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tournament_draft_unit_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"events\".\"tournament_draft_id\" IS NOT NULL AND \"events\".\"tournament_draft_unit_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_created_by_users_id_fk": {
+          "name": "events_created_by_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_event_group_id_event_groups_id_fk": {
+          "name": "events_event_group_id_event_groups_id_fk",
+          "tableFrom": "events",
+          "tableTo": "event_groups",
+          "columnsFrom": [
+            "event_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_attendances": {
+      "name": "event_attendances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_attendances_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attend": {
+          "name": "attend",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_attendances_event_id_events_id_fk": {
+          "name": "event_attendances_event_id_events_id_fk",
+          "tableFrom": "event_attendances",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_attendances_user_id_users_id_fk": {
+          "name": "event_attendances_user_id_users_id_fk",
+          "tableFrom": "event_attendances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_attendances_event_id_user_id_unique": {
+          "name": "event_attendances_event_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_items": {
+      "name": "schedule_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "schedule_items_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "schedule_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_items_owner_id_users_id_fk": {
+          "name": "schedule_items_owner_id_users_id_fk",
+          "tableFrom": "schedule_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_messages": {
+      "name": "mail_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_messages_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_addresses": {
+          "name": "to_addresses",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_message_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "mail_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imap_uid": {
+          "name": "imap_uid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imap_box": {
+          "name": "imap_box",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "triage_status": {
+          "name": "triage_status",
+          "type": "mail_triage_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unprocessed'"
+        },
+        "triaged_at": {
+          "name": "triaged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triaged_by_user_id": {
+          "name": "triaged_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_event_id": {
+          "name": "linked_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_messages_received_at_desc_idx": {
+          "name": "mail_messages_received_at_desc_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_messages_triage_status_idx": {
+          "name": "mail_messages_triage_status_idx",
+          "columns": [
+            {
+              "expression": "triage_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_messages_linked_event_id_idx": {
+          "name": "mail_messages_linked_event_id_idx",
+          "columns": [
+            {
+              "expression": "linked_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"mail_messages\".\"linked_event_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_messages_triaged_by_user_id_users_id_fk": {
+          "name": "mail_messages_triaged_by_user_id_users_id_fk",
+          "tableFrom": "mail_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triaged_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mail_messages_linked_event_id_events_id_fk": {
+          "name": "mail_messages_linked_event_id_events_id_fk",
+          "tableFrom": "mail_messages",
+          "tableTo": "events",
+          "columnsFrom": [
+            "linked_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mail_messages_message_id_unique": {
+          "name": "mail_messages_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_attachments": {
+      "name": "mail_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_attachments_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "mail_message_id": {
+          "name": "mail_message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extracted_text": {
+          "name": "extracted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_status": {
+          "name": "extraction_status",
+          "type": "attachment_extraction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mail_attachments_mail_message_id_idx": {
+          "name": "mail_attachments_mail_message_id_idx",
+          "columns": [
+            {
+              "expression": "mail_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_attachments_mail_message_id_mail_messages_id_fk": {
+          "name": "mail_attachments_mail_message_id_mail_messages_id_fk",
+          "tableFrom": "mail_attachments",
+          "tableTo": "mail_messages",
+          "columnsFrom": [
+            "mail_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tournament_drafts": {
+      "name": "tournament_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tournament_drafts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tournament_draft_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_correction": {
+          "name": "is_correction",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "references_subject": {
+          "name": "references_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_by_draft_id": {
+          "name": "superseded_by_draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracted_payload": {
+          "name": "extracted_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ai_raw_response": {
+          "name": "ai_raw_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_tokens_input": {
+          "name": "ai_tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_tokens_output": {
+          "name": "ai_tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_cost_usd": {
+          "name": "ai_cost_usd",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by_user_id": {
+          "name": "rejected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_drafts_status_created": {
+          "name": "idx_drafts_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tournament_drafts_message_id_mail_messages_id_fk": {
+          "name": "tournament_drafts_message_id_mail_messages_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "mail_messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tournament_drafts_event_id_events_id_fk": {
+          "name": "tournament_drafts_event_id_events_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tournament_drafts_approved_by_user_id_users_id_fk": {
+          "name": "tournament_drafts_approved_by_user_id_users_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tournament_drafts_rejected_by_user_id_users_id_fk": {
+          "name": "tournament_drafts_rejected_by_user_id_users_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "rejected_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tournament_drafts_message_id_unique": {
+          "name": "tournament_drafts_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tournament_drafts_confidence_range": {
+          "name": "tournament_drafts_confidence_range",
+          "value": "\"tournament_drafts\".\"confidence\" BETWEEN 0 AND 1 OR \"tournament_drafts\".\"confidence\" IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.line_channels": {
+      "name": "line_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "line_channels_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_secret": {
+          "name": "channel_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_access_token": {
+          "name": "channel_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "line_channel_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "line_channel_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system_notify'"
+        },
+        "assigned_user_id": {
+          "name": "assigned_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_event_id": {
+          "name": "assigned_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_destination_id": {
+          "name": "webhook_destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_line_user_id": {
+          "name": "notification_line_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "line_channels_assigned_user_id_users_id_fk": {
+          "name": "line_channels_assigned_user_id_users_id_fk",
+          "tableFrom": "line_channels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "line_channels_assigned_event_id_events_id_fk": {
+          "name": "line_channels_assigned_event_id_events_id_fk",
+          "tableFrom": "line_channels",
+          "tableTo": "events",
+          "columnsFrom": [
+            "assigned_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "line_channels_channel_id_unique": {
+          "name": "line_channels_channel_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "channel_id"
+          ]
+        },
+        "line_channels_assigned_user_id_unique": {
+          "name": "line_channels_assigned_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "assigned_user_id"
+          ]
+        },
+        "line_channels_assigned_event_id_unique": {
+          "name": "line_channels_assigned_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "assigned_event_id"
+          ]
+        },
+        "line_channels_webhook_destination_id_unique": {
+          "name": "line_channels_webhook_destination_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "webhook_destination_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_worker_jobs": {
+      "name": "mail_worker_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_worker_jobs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "since": {
+          "name": "since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_worker_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "mail_worker_job_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fetch'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_mail_worker_jobs_status_requested_at": {
+          "name": "idx_mail_worker_jobs_status_requested_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mail_worker_jobs_status_kind_requested_at": {
+          "name": "idx_mail_worker_jobs_status_kind_requested_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_worker_jobs_requested_by_user_id_users_id_fk": {
+          "name": "mail_worker_jobs_requested_by_user_id_users_id_fk",
+          "tableFrom": "mail_worker_jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mail_worker_jobs_run_id_mail_worker_runs_id_fk": {
+          "name": "mail_worker_jobs_run_id_mail_worker_runs_id_fk",
+          "tableFrom": "mail_worker_jobs",
+          "tableTo": "mail_worker_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_worker_runs": {
+      "name": "mail_worker_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_worker_runs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "mail_worker_run_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_worker_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_user_id": {
+          "name": "triggered_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "since": {
+          "name": "since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_worker_runs_triggered_by_user_id_users_id_fk": {
+          "name": "mail_worker_runs_triggered_by_user_id_users_id_fk",
+          "tableFrom": "mail_worker_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggered_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_line_broadcasts": {
+      "name": "event_line_broadcasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_line_broadcasts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_channel_id": {
+          "name": "line_channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code_expires_at": {
+          "name": "invite_code_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_group_id": {
+          "name": "line_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_line_broadcast_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invite_pending'"
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extended_until": {
+          "name": "extended_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoke_reason": {
+          "name": "revoke_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_line_broadcasts_invite_code_active_uq": {
+          "name": "event_line_broadcasts_invite_code_active_uq",
+          "columns": [
+            {
+              "expression": "invite_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"event_line_broadcasts\".\"invite_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_line_broadcasts_event_id_events_id_fk": {
+          "name": "event_line_broadcasts_event_id_events_id_fk",
+          "tableFrom": "event_line_broadcasts",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "event_line_broadcasts_line_channel_id_line_channels_id_fk": {
+          "name": "event_line_broadcasts_line_channel_id_line_channels_id_fk",
+          "tableFrom": "event_line_broadcasts",
+          "tableTo": "line_channels",
+          "columnsFrom": [
+            "line_channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_line_broadcasts_event_id_unique": {
+          "name": "event_line_broadcasts_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_broadcast_messages": {
+      "name": "event_broadcast_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_broadcast_messages_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_line_broadcast_id": {
+          "name": "event_line_broadcast_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mail_message_id": {
+          "name": "mail_message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "event_broadcast_message_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "is_correction": {
+          "name": "is_correction",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sent_text_count": {
+          "name": "sent_text_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_image_count": {
+          "name": "sent_image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "fallback_link_count": {
+          "name": "fallback_link_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_broadcast_messages_event_line_broadcast_id_event_line_broadcasts_id_fk": {
+          "name": "event_broadcast_messages_event_line_broadcast_id_event_line_broadcasts_id_fk",
+          "tableFrom": "event_broadcast_messages",
+          "tableTo": "event_line_broadcasts",
+          "columnsFrom": [
+            "event_line_broadcast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_broadcast_messages_mail_message_id_mail_messages_id_fk": {
+          "name": "event_broadcast_messages_mail_message_id_mail_messages_id_fk",
+          "tableFrom": "event_broadcast_messages",
+          "tableTo": "mail_messages",
+          "columnsFrom": [
+            "mail_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_broadcast_messages_broadcast_mail_uq": {
+          "name": "event_broadcast_messages_broadcast_mail_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_line_broadcast_id",
+            "mail_message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachment_share_tokens": {
+      "name": "attachment_share_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "attachment_share_tokens_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "mail_attachment_id": {
+          "name": "mail_attachment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attachment_share_tokens_attachment_idx": {
+          "name": "attachment_share_tokens_attachment_idx",
+          "columns": [
+            {
+              "expression": "mail_attachment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachment_share_tokens_expires_at_idx": {
+          "name": "attachment_share_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attachment_share_tokens_mail_attachment_id_mail_attachments_id_fk": {
+          "name": "attachment_share_tokens_mail_attachment_id_mail_attachments_id_fk",
+          "tableFrom": "attachment_share_tokens",
+          "tableTo": "mail_attachments",
+          "columnsFrom": [
+            "mail_attachment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "attachment_share_tokens_mail_attachment_id_unique": {
+          "name": "attachment_share_tokens_mail_attachment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mail_attachment_id"
+          ]
+        },
+        "attachment_share_tokens_token_unique": {
+          "name": "attachment_share_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_lifecycle_notifications": {
+      "name": "event_lifecycle_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_lifecycle_notifications_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "event_lifecycle_notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "event_lifecycle_notification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sent'"
+        },
+        "line_group_id": {
+          "name": "line_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_lifecycle_notifications_event_type_uq": {
+          "name": "event_lifecycle_notifications_event_type_uq",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_lifecycle_notifications_event_id_events_id_fk": {
+          "name": "event_lifecycle_notifications_event_id_events_id_fk",
+          "tableFrom": "event_lifecycle_notifications",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "push_subscriptions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_id_idx": {
+          "name": "push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_id_fk": {
+          "name": "push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_subscriptions_endpoint_unique": {
+          "name": "push_subscriptions_endpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "endpoint"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attachment_extraction_status": {
+      "name": "attachment_extraction_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "extracted",
+        "failed",
+        "unsupported"
+      ]
+    },
+    "public.event_broadcast_message_status": {
+      "name": "event_broadcast_message_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sending",
+        "sent",
+        "partial",
+        "failed"
+      ]
+    },
+    "public.event_entry_status": {
+      "name": "event_entry_status",
+      "schema": "public",
+      "values": [
+        "not_applied",
+        "applied"
+      ]
+    },
+    "public.event_kind": {
+      "name": "event_kind",
+      "schema": "public",
+      "values": [
+        "individual",
+        "team"
+      ]
+    },
+    "public.event_lifecycle_notification_status": {
+      "name": "event_lifecycle_notification_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.event_lifecycle_notification_type": {
+      "name": "event_lifecycle_notification_type",
+      "schema": "public",
+      "values": [
+        "entry_applied",
+        "entry_deadline_advance",
+        "entry_deadline_day",
+        "payment_paid",
+        "payment_deadline_advance",
+        "payment_deadline_day",
+        "onsite_payment_advance",
+        "onsite_payment_day",
+        "entry_applied_treasurer"
+      ]
+    },
+    "public.event_line_broadcast_status": {
+      "name": "event_line_broadcast_status",
+      "schema": "public",
+      "values": [
+        "invite_pending",
+        "joined_waiting_code",
+        "linked",
+        "revoked",
+        "released"
+      ]
+    },
+    "public.event_payment_status": {
+      "name": "event_payment_status",
+      "schema": "public",
+      "values": [
+        "unpaid",
+        "paid"
+      ]
+    },
+    "public.event_payment_type": {
+      "name": "event_payment_type",
+      "schema": "public",
+      "values": [
+        "advance",
+        "onsite"
+      ]
+    },
+    "public.event_status": {
+      "name": "event_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "cancelled",
+        "done"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female"
+      ]
+    },
+    "public.grade": {
+      "name": "grade",
+      "schema": "public",
+      "values": [
+        "A",
+        "B",
+        "C",
+        "D",
+        "E"
+      ]
+    },
+    "public.line_channel_purpose": {
+      "name": "line_channel_purpose",
+      "schema": "public",
+      "values": [
+        "system_notify",
+        "event_broadcast"
+      ]
+    },
+    "public.line_channel_status": {
+      "name": "line_channel_status",
+      "schema": "public",
+      "values": [
+        "available",
+        "assigned",
+        "active",
+        "system",
+        "disabled"
+      ]
+    },
+    "public.line_link_method": {
+      "name": "line_link_method",
+      "schema": "public",
+      "values": [
+        "self_identify",
+        "admin_link",
+        "account_switch"
+      ]
+    },
+    "public.mail_classification": {
+      "name": "mail_classification",
+      "schema": "public",
+      "values": [
+        "tournament",
+        "noise",
+        "unknown"
+      ]
+    },
+    "public.mail_message_status": {
+      "name": "mail_message_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "fetched",
+        "parse_failed",
+        "fetch_failed",
+        "ai_processing",
+        "ai_done",
+        "ai_failed",
+        "oversize_skipped",
+        "archived"
+      ]
+    },
+    "public.mail_triage_status": {
+      "name": "mail_triage_status",
+      "schema": "public",
+      "values": [
+        "unprocessed",
+        "processed"
+      ]
+    },
+    "public.mail_worker_job_kind": {
+      "name": "mail_worker_job_kind",
+      "schema": "public",
+      "values": [
+        "fetch",
+        "manual_extract"
+      ]
+    },
+    "public.mail_worker_job_status": {
+      "name": "mail_worker_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "claimed",
+        "done",
+        "failed"
+      ]
+    },
+    "public.mail_worker_run_kind": {
+      "name": "mail_worker_run_kind",
+      "schema": "public",
+      "values": [
+        "cron",
+        "manual"
+      ]
+    },
+    "public.mail_worker_run_status": {
+      "name": "mail_worker_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "imap_failed",
+        "ai_failed",
+        "partial"
+      ]
+    },
+    "public.schedule_kind": {
+      "name": "schedule_kind",
+      "schema": "public",
+      "values": [
+        "practice",
+        "meeting",
+        "social",
+        "other"
+      ]
+    },
+    "public.tournament_draft_status": {
+      "name": "tournament_draft_status",
+      "schema": "public",
+      "values": [
+        "pending_review",
+        "approved",
+        "rejected",
+        "ai_failed",
+        "superseded",
+        "ai_processing"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "vice_admin",
+        "member"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/shared/drizzle/meta/0024_snapshot.json
+++ b/packages/shared/drizzle/meta/0024_snapshot.json
@@ -1,0 +1,2864 @@
+{
+  "id": "6d43cf87-431f-4727-bb3a-3012c7b31d7f",
+  "prevId": "1258a085-ef61-4768-9f73-7cd97c7f437e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_user_id": {
+          "name": "line_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "grade": {
+          "name": "grade",
+          "type": "grade",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_invited": {
+          "name": "is_invited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affiliation": {
+          "name": "affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dan": {
+          "name": "dan",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zen_nichikyo": {
+          "name": "zen_nichikyo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_linked_at": {
+          "name": "line_linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_link_method": {
+          "name": "line_link_method",
+          "type": "line_link_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notification_line_user_id": {
+          "name": "notification_line_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_name_unique": {
+          "name": "users_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_line_user_id_unique": {
+          "name": "users_line_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "line_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_dan_range": {
+          "name": "users_dan_range",
+          "value": "\"users\".\"dan\" BETWEEN 0 AND 9 OR \"users\".\"dan\" IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_groups": {
+      "name": "event_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_groups_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_groups_name_unique": {
+          "name": "event_groups_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "events_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formal_name": {
+          "name": "formal_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official": {
+          "name": "official",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'individual'"
+        },
+        "entry_deadline": {
+          "name": "entry_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_deadline": {
+          "name": "internal_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_group_id": {
+          "name": "event_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligible_grades": {
+          "name": "eligible_grades",
+          "type": "grade[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_jpy": {
+          "name": "fee_jpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_deadline": {
+          "name": "payment_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lottery_date": {
+          "name": "lottery_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_info": {
+          "name": "payment_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_method": {
+          "name": "entry_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizer": {
+          "name": "organizer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_a": {
+          "name": "capacity_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_b": {
+          "name": "capacity_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_c": {
+          "name": "capacity_c",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_d": {
+          "name": "capacity_d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_e": {
+          "name": "capacity_e",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_status": {
+          "name": "entry_status",
+          "type": "event_entry_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_applied'"
+        },
+        "entry_applied_at": {
+          "name": "entry_applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_type": {
+          "name": "payment_type",
+          "type": "event_payment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "event_payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unpaid'"
+        },
+        "payment_paid_at": {
+          "name": "payment_paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournament_draft_id": {
+          "name": "tournament_draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournament_draft_unit_key": {
+          "name": "tournament_draft_unit_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_tournament_draft_unit_key_uniq": {
+          "name": "events_tournament_draft_unit_key_uniq",
+          "columns": [
+            {
+              "expression": "tournament_draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tournament_draft_unit_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"events\".\"tournament_draft_id\" IS NOT NULL AND \"events\".\"tournament_draft_unit_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_created_by_users_id_fk": {
+          "name": "events_created_by_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_event_group_id_event_groups_id_fk": {
+          "name": "events_event_group_id_event_groups_id_fk",
+          "tableFrom": "events",
+          "tableTo": "event_groups",
+          "columnsFrom": [
+            "event_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_attendances": {
+      "name": "event_attendances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_attendances_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attend": {
+          "name": "attend",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_attendances_event_id_events_id_fk": {
+          "name": "event_attendances_event_id_events_id_fk",
+          "tableFrom": "event_attendances",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_attendances_user_id_users_id_fk": {
+          "name": "event_attendances_user_id_users_id_fk",
+          "tableFrom": "event_attendances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_attendances_event_id_user_id_unique": {
+          "name": "event_attendances_event_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_items": {
+      "name": "schedule_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "schedule_items_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "schedule_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_items_owner_id_users_id_fk": {
+          "name": "schedule_items_owner_id_users_id_fk",
+          "tableFrom": "schedule_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_messages": {
+      "name": "mail_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_messages_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_addresses": {
+          "name": "to_addresses",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_message_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "mail_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imap_uid": {
+          "name": "imap_uid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imap_box": {
+          "name": "imap_box",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "triage_status": {
+          "name": "triage_status",
+          "type": "mail_triage_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unprocessed'"
+        },
+        "triaged_at": {
+          "name": "triaged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triaged_by_user_id": {
+          "name": "triaged_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_event_id": {
+          "name": "linked_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_messages_received_at_desc_idx": {
+          "name": "mail_messages_received_at_desc_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_messages_triage_status_idx": {
+          "name": "mail_messages_triage_status_idx",
+          "columns": [
+            {
+              "expression": "triage_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_messages_linked_event_id_idx": {
+          "name": "mail_messages_linked_event_id_idx",
+          "columns": [
+            {
+              "expression": "linked_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"mail_messages\".\"linked_event_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_messages_triaged_by_user_id_users_id_fk": {
+          "name": "mail_messages_triaged_by_user_id_users_id_fk",
+          "tableFrom": "mail_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triaged_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mail_messages_linked_event_id_events_id_fk": {
+          "name": "mail_messages_linked_event_id_events_id_fk",
+          "tableFrom": "mail_messages",
+          "tableTo": "events",
+          "columnsFrom": [
+            "linked_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mail_messages_message_id_unique": {
+          "name": "mail_messages_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_attachments": {
+      "name": "mail_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_attachments_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "mail_message_id": {
+          "name": "mail_message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extracted_text": {
+          "name": "extracted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_status": {
+          "name": "extraction_status",
+          "type": "attachment_extraction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mail_attachments_mail_message_id_idx": {
+          "name": "mail_attachments_mail_message_id_idx",
+          "columns": [
+            {
+              "expression": "mail_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_attachments_mail_message_id_mail_messages_id_fk": {
+          "name": "mail_attachments_mail_message_id_mail_messages_id_fk",
+          "tableFrom": "mail_attachments",
+          "tableTo": "mail_messages",
+          "columnsFrom": [
+            "mail_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tournament_drafts": {
+      "name": "tournament_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tournament_drafts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tournament_draft_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_correction": {
+          "name": "is_correction",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "references_subject": {
+          "name": "references_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_by_draft_id": {
+          "name": "superseded_by_draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracted_payload": {
+          "name": "extracted_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ai_raw_response": {
+          "name": "ai_raw_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_tokens_input": {
+          "name": "ai_tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_tokens_output": {
+          "name": "ai_tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_cost_usd": {
+          "name": "ai_cost_usd",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by_user_id": {
+          "name": "rejected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_drafts_status_created": {
+          "name": "idx_drafts_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_drafts_event_id": {
+          "name": "idx_drafts_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"tournament_drafts\".\"event_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tournament_drafts_message_id_mail_messages_id_fk": {
+          "name": "tournament_drafts_message_id_mail_messages_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "mail_messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tournament_drafts_event_id_events_id_fk": {
+          "name": "tournament_drafts_event_id_events_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tournament_drafts_approved_by_user_id_users_id_fk": {
+          "name": "tournament_drafts_approved_by_user_id_users_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tournament_drafts_rejected_by_user_id_users_id_fk": {
+          "name": "tournament_drafts_rejected_by_user_id_users_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "rejected_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tournament_drafts_message_id_unique": {
+          "name": "tournament_drafts_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tournament_drafts_confidence_range": {
+          "name": "tournament_drafts_confidence_range",
+          "value": "\"tournament_drafts\".\"confidence\" BETWEEN 0 AND 1 OR \"tournament_drafts\".\"confidence\" IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.line_channels": {
+      "name": "line_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "line_channels_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_secret": {
+          "name": "channel_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_access_token": {
+          "name": "channel_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "line_channel_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "line_channel_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system_notify'"
+        },
+        "assigned_user_id": {
+          "name": "assigned_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_event_id": {
+          "name": "assigned_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_destination_id": {
+          "name": "webhook_destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_line_user_id": {
+          "name": "notification_line_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "line_channels_assigned_user_id_users_id_fk": {
+          "name": "line_channels_assigned_user_id_users_id_fk",
+          "tableFrom": "line_channels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "line_channels_assigned_event_id_events_id_fk": {
+          "name": "line_channels_assigned_event_id_events_id_fk",
+          "tableFrom": "line_channels",
+          "tableTo": "events",
+          "columnsFrom": [
+            "assigned_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "line_channels_channel_id_unique": {
+          "name": "line_channels_channel_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "channel_id"
+          ]
+        },
+        "line_channels_assigned_user_id_unique": {
+          "name": "line_channels_assigned_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "assigned_user_id"
+          ]
+        },
+        "line_channels_assigned_event_id_unique": {
+          "name": "line_channels_assigned_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "assigned_event_id"
+          ]
+        },
+        "line_channels_webhook_destination_id_unique": {
+          "name": "line_channels_webhook_destination_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "webhook_destination_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_worker_jobs": {
+      "name": "mail_worker_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_worker_jobs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "since": {
+          "name": "since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_worker_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "mail_worker_job_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fetch'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_mail_worker_jobs_status_requested_at": {
+          "name": "idx_mail_worker_jobs_status_requested_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mail_worker_jobs_status_kind_requested_at": {
+          "name": "idx_mail_worker_jobs_status_kind_requested_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_worker_jobs_requested_by_user_id_users_id_fk": {
+          "name": "mail_worker_jobs_requested_by_user_id_users_id_fk",
+          "tableFrom": "mail_worker_jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mail_worker_jobs_run_id_mail_worker_runs_id_fk": {
+          "name": "mail_worker_jobs_run_id_mail_worker_runs_id_fk",
+          "tableFrom": "mail_worker_jobs",
+          "tableTo": "mail_worker_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_worker_runs": {
+      "name": "mail_worker_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_worker_runs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "mail_worker_run_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_worker_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_user_id": {
+          "name": "triggered_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "since": {
+          "name": "since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_worker_runs_triggered_by_user_id_users_id_fk": {
+          "name": "mail_worker_runs_triggered_by_user_id_users_id_fk",
+          "tableFrom": "mail_worker_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggered_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_line_broadcasts": {
+      "name": "event_line_broadcasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_line_broadcasts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_channel_id": {
+          "name": "line_channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code_expires_at": {
+          "name": "invite_code_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_group_id": {
+          "name": "line_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_line_broadcast_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invite_pending'"
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extended_until": {
+          "name": "extended_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoke_reason": {
+          "name": "revoke_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_line_broadcasts_invite_code_active_uq": {
+          "name": "event_line_broadcasts_invite_code_active_uq",
+          "columns": [
+            {
+              "expression": "invite_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"event_line_broadcasts\".\"invite_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_line_broadcasts_event_id_events_id_fk": {
+          "name": "event_line_broadcasts_event_id_events_id_fk",
+          "tableFrom": "event_line_broadcasts",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "event_line_broadcasts_line_channel_id_line_channels_id_fk": {
+          "name": "event_line_broadcasts_line_channel_id_line_channels_id_fk",
+          "tableFrom": "event_line_broadcasts",
+          "tableTo": "line_channels",
+          "columnsFrom": [
+            "line_channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_line_broadcasts_event_id_unique": {
+          "name": "event_line_broadcasts_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_broadcast_messages": {
+      "name": "event_broadcast_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_broadcast_messages_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_line_broadcast_id": {
+          "name": "event_line_broadcast_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mail_message_id": {
+          "name": "mail_message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "event_broadcast_message_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "is_correction": {
+          "name": "is_correction",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sent_text_count": {
+          "name": "sent_text_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_image_count": {
+          "name": "sent_image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "fallback_link_count": {
+          "name": "fallback_link_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_broadcast_messages_event_line_broadcast_id_event_line_broadcasts_id_fk": {
+          "name": "event_broadcast_messages_event_line_broadcast_id_event_line_broadcasts_id_fk",
+          "tableFrom": "event_broadcast_messages",
+          "tableTo": "event_line_broadcasts",
+          "columnsFrom": [
+            "event_line_broadcast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_broadcast_messages_mail_message_id_mail_messages_id_fk": {
+          "name": "event_broadcast_messages_mail_message_id_mail_messages_id_fk",
+          "tableFrom": "event_broadcast_messages",
+          "tableTo": "mail_messages",
+          "columnsFrom": [
+            "mail_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_broadcast_messages_broadcast_mail_uq": {
+          "name": "event_broadcast_messages_broadcast_mail_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_line_broadcast_id",
+            "mail_message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachment_share_tokens": {
+      "name": "attachment_share_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "attachment_share_tokens_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "mail_attachment_id": {
+          "name": "mail_attachment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attachment_share_tokens_attachment_idx": {
+          "name": "attachment_share_tokens_attachment_idx",
+          "columns": [
+            {
+              "expression": "mail_attachment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachment_share_tokens_expires_at_idx": {
+          "name": "attachment_share_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attachment_share_tokens_mail_attachment_id_mail_attachments_id_fk": {
+          "name": "attachment_share_tokens_mail_attachment_id_mail_attachments_id_fk",
+          "tableFrom": "attachment_share_tokens",
+          "tableTo": "mail_attachments",
+          "columnsFrom": [
+            "mail_attachment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "attachment_share_tokens_mail_attachment_id_unique": {
+          "name": "attachment_share_tokens_mail_attachment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mail_attachment_id"
+          ]
+        },
+        "attachment_share_tokens_token_unique": {
+          "name": "attachment_share_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_lifecycle_notifications": {
+      "name": "event_lifecycle_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_lifecycle_notifications_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "event_lifecycle_notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "event_lifecycle_notification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sent'"
+        },
+        "line_group_id": {
+          "name": "line_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_lifecycle_notifications_event_type_uq": {
+          "name": "event_lifecycle_notifications_event_type_uq",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_lifecycle_notifications_event_id_events_id_fk": {
+          "name": "event_lifecycle_notifications_event_id_events_id_fk",
+          "tableFrom": "event_lifecycle_notifications",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "push_subscriptions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_id_idx": {
+          "name": "push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_id_fk": {
+          "name": "push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_subscriptions_endpoint_unique": {
+          "name": "push_subscriptions_endpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "endpoint"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attachment_extraction_status": {
+      "name": "attachment_extraction_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "extracted",
+        "failed",
+        "unsupported"
+      ]
+    },
+    "public.event_broadcast_message_status": {
+      "name": "event_broadcast_message_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sending",
+        "sent",
+        "partial",
+        "failed"
+      ]
+    },
+    "public.event_entry_status": {
+      "name": "event_entry_status",
+      "schema": "public",
+      "values": [
+        "not_applied",
+        "applied"
+      ]
+    },
+    "public.event_kind": {
+      "name": "event_kind",
+      "schema": "public",
+      "values": [
+        "individual",
+        "team"
+      ]
+    },
+    "public.event_lifecycle_notification_status": {
+      "name": "event_lifecycle_notification_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.event_lifecycle_notification_type": {
+      "name": "event_lifecycle_notification_type",
+      "schema": "public",
+      "values": [
+        "entry_applied",
+        "entry_deadline_advance",
+        "entry_deadline_day",
+        "payment_paid",
+        "payment_deadline_advance",
+        "payment_deadline_day",
+        "onsite_payment_advance",
+        "onsite_payment_day",
+        "entry_applied_treasurer"
+      ]
+    },
+    "public.event_line_broadcast_status": {
+      "name": "event_line_broadcast_status",
+      "schema": "public",
+      "values": [
+        "invite_pending",
+        "joined_waiting_code",
+        "linked",
+        "revoked",
+        "released"
+      ]
+    },
+    "public.event_payment_status": {
+      "name": "event_payment_status",
+      "schema": "public",
+      "values": [
+        "unpaid",
+        "paid"
+      ]
+    },
+    "public.event_payment_type": {
+      "name": "event_payment_type",
+      "schema": "public",
+      "values": [
+        "advance",
+        "onsite"
+      ]
+    },
+    "public.event_status": {
+      "name": "event_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "cancelled",
+        "done"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female"
+      ]
+    },
+    "public.grade": {
+      "name": "grade",
+      "schema": "public",
+      "values": [
+        "A",
+        "B",
+        "C",
+        "D",
+        "E"
+      ]
+    },
+    "public.line_channel_purpose": {
+      "name": "line_channel_purpose",
+      "schema": "public",
+      "values": [
+        "system_notify",
+        "event_broadcast"
+      ]
+    },
+    "public.line_channel_status": {
+      "name": "line_channel_status",
+      "schema": "public",
+      "values": [
+        "available",
+        "assigned",
+        "active",
+        "system",
+        "disabled"
+      ]
+    },
+    "public.line_link_method": {
+      "name": "line_link_method",
+      "schema": "public",
+      "values": [
+        "self_identify",
+        "admin_link",
+        "account_switch"
+      ]
+    },
+    "public.mail_classification": {
+      "name": "mail_classification",
+      "schema": "public",
+      "values": [
+        "tournament",
+        "noise",
+        "unknown"
+      ]
+    },
+    "public.mail_message_status": {
+      "name": "mail_message_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "fetched",
+        "parse_failed",
+        "fetch_failed",
+        "ai_processing",
+        "ai_done",
+        "ai_failed",
+        "oversize_skipped",
+        "archived"
+      ]
+    },
+    "public.mail_triage_status": {
+      "name": "mail_triage_status",
+      "schema": "public",
+      "values": [
+        "unprocessed",
+        "processed"
+      ]
+    },
+    "public.mail_worker_job_kind": {
+      "name": "mail_worker_job_kind",
+      "schema": "public",
+      "values": [
+        "fetch",
+        "manual_extract"
+      ]
+    },
+    "public.mail_worker_job_status": {
+      "name": "mail_worker_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "claimed",
+        "done",
+        "failed"
+      ]
+    },
+    "public.mail_worker_run_kind": {
+      "name": "mail_worker_run_kind",
+      "schema": "public",
+      "values": [
+        "cron",
+        "manual"
+      ]
+    },
+    "public.mail_worker_run_status": {
+      "name": "mail_worker_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "imap_failed",
+        "ai_failed",
+        "partial"
+      ]
+    },
+    "public.schedule_kind": {
+      "name": "schedule_kind",
+      "schema": "public",
+      "values": [
+        "practice",
+        "meeting",
+        "social",
+        "other"
+      ]
+    },
+    "public.tournament_draft_status": {
+      "name": "tournament_draft_status",
+      "schema": "public",
+      "values": [
+        "pending_review",
+        "approved",
+        "rejected",
+        "ai_failed",
+        "superseded",
+        "ai_processing"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "vice_admin",
+        "member"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/shared/drizzle/meta/_journal.json
+++ b/packages/shared/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1780758760007,
       "tag": "0022_mail_inbox_mailer",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1780769011703,
+      "tag": "0023_mail_worker_jobs_kind_index",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/drizzle/meta/_journal.json
+++ b/packages/shared/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1780589405725,
       "tag": "0021_amazing_mentor",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1780758760007,
+      "tag": "0022_mail_inbox_mailer",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/drizzle/meta/_journal.json
+++ b/packages/shared/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1780769011703,
       "tag": "0023_mail_worker_jobs_kind_index",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1780773748148,
+      "tag": "0024_tournament_drafts_event_id_index",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/schema/enums.ts
+++ b/packages/shared/src/schema/enums.ts
@@ -43,12 +43,16 @@ export const attachmentExtractionStatusEnum = pgEnum('attachment_extraction_stat
 ])
 
 // mail-tournament-import (PR3)
+// mail-inbox-mailer: AI 抽出を手動起動化したことで、起動〜完了の間だけ表示する
+// 中間状態 `ai_processing` を追加。状態遷移は `ai_processing` → `pending_review`
+// （成功）または `ai_failed`（失敗）。
 export const tournamentDraftStatusEnum = pgEnum('tournament_draft_status', [
   'pending_review',
   'approved',
   'rejected',
   'ai_failed',
   'superseded',
+  'ai_processing',
 ])
 
 // PR5 (mail-tournament-import)
@@ -73,6 +77,10 @@ export const mailWorkerJobStatusEnum = pgEnum('mail_worker_job_status', [
   'done',
   'failed',
 ])
+// mail-inbox-mailer: mail_worker_jobs.kind で fetch / manual_extract を識別する。
+// fetch は cron/手動の IMAP 取得、manual_extract は inbox 詳細から起動する
+// 個別メール抽出ジョブ（payload.mail_message_id 必須）。
+export const mailWorkerJobKindEnum = pgEnum('mail_worker_job_kind', ['fetch', 'manual_extract'])
 
 // event-line-broadcast
 export const lineChannelPurposeEnum = pgEnum('line_channel_purpose', [
@@ -121,9 +129,7 @@ export const eventLifecycleNotificationStatusEnum = pgEnum('event_lifecycle_noti
 
 // mail-triage-badge: 受信メールの人手処理状態。AI/技術状態の mailMessageStatusEnum
 // とは独立（status='ai_done' でも未処理＝管理者が未対応、はあり得る）。未処理バッジは
-// triage_status != 'processed'（unprocessed + deferred）で算出する。
-export const mailTriageStatusEnum = pgEnum('mail_triage_status', [
-  'unprocessed',
-  'processed',
-  'deferred',
-])
+// triage_status != 'processed'（= unprocessed）で算出する。
+// mail-inbox-mailer (2026-06-07): `deferred` を廃止して 2 状態化。「保留」は
+// 処理せず放置することが暗黙の保留である、というモデルに統合。
+export const mailTriageStatusEnum = pgEnum('mail_triage_status', ['unprocessed', 'processed'])

--- a/packages/shared/src/schema/mail-messages.ts
+++ b/packages/shared/src/schema/mail-messages.ts
@@ -1,6 +1,8 @@
 import { index, integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core'
+import { sql } from 'drizzle-orm'
 import { mailMessageStatusEnum, mailClassificationEnum, mailTriageStatusEnum } from './enums'
 import { users } from './auth'
+import { events } from './events'
 
 /**
  * mail_messages: 1 received e-mail = 1 row.
@@ -35,11 +37,19 @@ export const mailMessages = pgTable(
     updatedAt: timestamp('updated_at', { mode: 'date', withTimezone: true }).notNull().defaultNow(),
     // mail-triage-badge: 人手の処理状態。AI/技術状態の `status` とは直交する
     // （status='ai_done' でも未処理＝管理者が未対応、はあり得る）。未処理バッジ
-    // 件数は triageStatus != 'processed'（unprocessed + deferred）で算出。
+    // 件数は triageStatus != 'processed'（= unprocessed）で算出。
+    // mail-inbox-mailer: 2 状態化（unprocessed / processed）。
     triageStatus: mailTriageStatusEnum('triage_status').notNull().default('unprocessed'),
     triagedAt: timestamp('triaged_at', { mode: 'date', withTimezone: true }),
     // 処理者。ユーザー削除でもメール履歴は残すので onDelete: set null。
     triagedByUserId: text('triaged_by_user_id').references(() => users.id, { onDelete: 'set null' }),
+    // mail-inbox-mailer: 「組合せ表」「会場案内」「訂正版」などを既存大会に紐付ける
+    // 際の FK。1 メール = 1 イベントの単純設計（中間テーブルにしない）。
+    // AI 抽出経路（tournament_drafts.event_id / events.tournament_draft_id）
+    // とは別 carrier。events 削除時は紐付けだけ外す（メール本体は履歴として残す）。
+    linkedEventId: integer('linked_event_id').references(() => events.id, {
+      onDelete: 'set null',
+    }),
   },
   (t) => [
     // Inbox UI lists newest-first; without this index the sort scans the full
@@ -49,5 +59,10 @@ export const mailMessages = pgTable(
     // mail-triage-badge: 未処理カウント / 区分フィルタ用。inbox の未処理バッジは
     // triageStatus で絞り込むので件数クエリが全表スキャンにならないよう index。
     index('mail_messages_triage_status_idx').on(t.triageStatus),
+    // mail-inbox-mailer: events 詳細の「関連メール」セクションは linked_event_id
+    // で逆引き。partial index で NULL 行を index から除外（NULL の方が多い前提）。
+    index('mail_messages_linked_event_id_idx')
+      .on(t.linkedEventId)
+      .where(sql`${t.linkedEventId} IS NOT NULL`),
   ],
 )

--- a/packages/shared/src/schema/mail-worker.ts
+++ b/packages/shared/src/schema/mail-worker.ts
@@ -1,5 +1,6 @@
 import { index, integer, jsonb, pgTable, text, timestamp } from 'drizzle-orm/pg-core'
 import {
+  mailWorkerJobKindEnum,
   mailWorkerJobStatusEnum,
   mailWorkerRunKindEnum,
   mailWorkerRunStatusEnum,
@@ -32,12 +33,19 @@ export const mailWorkerRuns = pgTable('mail_worker_runs', {
 })
 
 /**
- * mail_worker_jobs: queue of admin-requested mail fetch invocations.
+ * mail_worker_jobs: queue of admin-requested mail-worker invocations.
  *
  * Server Action inserts a row with `status='pending'`; the mail-worker
- * dispatcher claims it via `FOR UPDATE SKIP LOCKED`, executes a manual
- * `runOnce`, then UPDATEs the job to `done`/`failed` with `run_id` set to the
+ * dispatcher claims it via `FOR UPDATE SKIP LOCKED`, executes the job per
+ * `kind`, then UPDATEs the job to `done`/`failed` with `run_id` set to the
  * created `mail_worker_runs.id`.
+ *
+ * `kind` identifies what to execute (mail-inbox-mailer):
+ *   - 'fetch'           : IMAP fetch round (existing behaviour, default)
+ *   - 'manual_extract'  : extract a specific mail with AI; payload required
+ *
+ * `payload` carries kind-specific arguments. For `manual_extract` it must be
+ * `{ mail_message_id: number }`; for `fetch` it is unused (null).
  *
  * The `(status, requested_at)` index supports the dispatcher's "oldest pending
  * job first" claim query.
@@ -54,6 +62,11 @@ export const mailWorkerJobs = pgTable(
       .references(() => users.id, { onDelete: 'cascade' }),
     since: timestamp('since', { mode: 'date', withTimezone: true }),
     status: mailWorkerJobStatusEnum('status').notNull().default('pending'),
+    // mail-inbox-mailer: DEFAULT 'fetch' で既存行/既存 INSERT は無変更。
+    kind: mailWorkerJobKindEnum('kind').notNull().default('fetch'),
+    // mail-inbox-mailer: manual_extract 用 `{ mail_message_id: number }`。
+    // fetch ジョブでは null。
+    payload: jsonb('payload'),
     claimedAt: timestamp('claimed_at', { mode: 'date', withTimezone: true }),
     runId: integer('run_id').references(() => mailWorkerRuns.id, { onDelete: 'set null' }),
     error: text('error'),

--- a/packages/shared/src/schema/mail-worker.ts
+++ b/packages/shared/src/schema/mail-worker.ts
@@ -73,5 +73,15 @@ export const mailWorkerJobs = pgTable(
   },
   (table) => [
     index('idx_mail_worker_jobs_status_requested_at').on(table.status, table.requestedAt),
+    // mail-inbox-mailer (Codex r5 should-fix): claimNextJob は status + kind で
+    // pending job を絞るようになった。extract-only timer は 30 秒間隔でこの
+    // クエリを叩くので、pending fetch ジョブが溜まると manual_extract の claim
+    // が全表スキャンに近い実行計画になり、UI の体感速度を直接損なう。
+    // status + kind + requested_at の複合 index を追加する。
+    index('idx_mail_worker_jobs_status_kind_requested_at').on(
+      table.status,
+      table.kind,
+      table.requestedAt,
+    ),
   ],
 )

--- a/packages/shared/src/schema/tournament-drafts.ts
+++ b/packages/shared/src/schema/tournament-drafts.ts
@@ -89,5 +89,12 @@ export const tournamentDrafts = pgTable(
     // The inbox queue lists pending drafts newest-first; this composite index
     // keeps the listing fast as volume grows.
     index('idx_drafts_status_created').on(table.status, table.createdAt.desc()),
+    // mail-inbox-mailer (Codex r8 should-fix): events 詳細「関連メール」セク
+    // ションは admin 表示ごとに `event_id = :eventId` で逆引きする。partial
+    // index で NULL 行を除外（event_id が立つのは linkDraftToEvent 経由の
+    // 一部のみで NULL の方が圧倒的に多い）。
+    index('idx_drafts_event_id')
+      .on(table.eventId)
+      .where(sql`${table.eventId} IS NOT NULL`),
   ],
 )


### PR DESCRIPTION
## Summary

mail-inbox を「AI が事前に大会案内を判定」モデルから「**届いたメールは全部 inbox に並ぶ＝アプリがメーラー**」モデルに作り替え。AI 抽出は管理者が「会で流す」と意思決定したメールに対してのみ手動起動する。親 Issue #119、子 #120-#126。

### 主な変更

- **DB**: `mail_messages.linked_event_id` 追加、`tournament_drafts.status += 'ai_processing'`、`mail_worker_jobs.kind/payload` 追加、`mail_triage_status` から `'deferred'` 削除（2 状態化）。migration `0022_mail_inbox_mailer.sql`。
- **mail-worker**: cron AI 廃止（`--mode=fetch-only` 既定で `llmExtractor` を渡さない）。新規 `--mode=extract-only` モードで `manual_extract` ジョブのみ pick → `runManualExtract` (IMAP fetch なし、AI のみ)。
- **Server Actions** (3 つ):
  - `triggerExtractDraft(mailId)`: draft INSERT/UPDATE (ai_processing) + manual_extract job enqueue
  - `linkMailToEvent(mailId, eventId)`: linked_event_id + triage=processed + after() で broadcastMailToEvent
  - `unlinkMailFromEvent(mailId)`: linked_event_id=NULL + triage=unprocessed (LINE 配信済の取消は不可)
- **UI**: mail/[id] を本文即時表示 + draft 状態分岐に作り替え。新規 5 コンポーネント (AIExtractConfirmDialog / ExtractionInProgressCard / ExistingEventLinkSheet / MailDetailActions / UndoTriageButton)。新規 polling API route。
- **関連メール**: events/[id] に 3 経路 UNION（linked_event_id / tournament_drafts.event_id / events.tournament_draft_id）の関連メールセクションを追加。
- **systemd**: 30 秒間隔の `kagetra-mail-worker-extract.{service,timer}` を新設。既存 `kagetra-mail-worker.service` には `--mode=fetch-only` を明示。

## Test plan

- [x] typecheck repo-wide pass
- [x] Vitest 全 pass (web 408 / mail-worker 236 / api / shared)
- [x] 新規 actions テスト 12 件 (triggerExtractDraft / linkMailToEvent / unlinkMailFromEvent)
- [x] 新規 manual-extract.test.ts 4 件 (runManualExtract: 正常 / noise force / ai_failed / 不在 mailId)
- [x] 新規 EventRelatedMails.test.tsx 6 件 (3 経路 + dedup + 受信日降順)
- [x] 新規 mail/[id]/page.test.tsx 3 件 (3 ボタン / ai_processing / ai_failed)
- [x] 新規 E2E spec 2 本 (mail-inbox-ai-extract / mail-inbox-link-event) ※CI で実行
- [ ] 本番デプロイ後、systemd unit 反映 (cp + daemon-reload + enable kagetra-mail-worker-extract.timer)
- [ ] 本番実機で「会で流す」→ AI 抽出 → LINE 受信を目視確認
- [ ] 本番実機で「既存イベント結びつけ」→ LINE 受信を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)