### PR TITLE
fix: image-cache を globalThis pin して LINE 本文画像 404 を解消 (Issue #128)

### DIFF
--- a/apps/web/src/lib/image-cache.ts
+++ b/apps/web/src/lib/image-cache.ts
@@ -8,15 +8,23 @@
  * push, then LINE caches the bitmap on the device for ~the lifetime of the
  * conversation.
  *
- * We instead hold the bytes in this module-level Map keyed by an opaque
+ * We instead hold the bytes in a `globalThis`-pinned Map keyed by an opaque
  * token, serve them from `/api/line-broadcast/images/[token]`, and let
  * stale entries expire after 24 h. A process restart drops the cache —
  * by then the push has long since completed, and LINE has already fetched
  * what it needs.
  *
  * NOT for cross-process / multi-instance deployments. The current
- * single-VM (Lightsail) topology is fine; a future move to multiple
+ * single-VM (Oracle Cloud) topology is fine; a future move to multiple
  * apps/web instances would need a shared backend (Redis or signed S3).
+ *
+ * Why `globalThis`-pinned (Issue #128): Next.js can bundle this module into
+ * multiple webpack chunks (Server Action side vs Route Handler side). Each
+ * chunk would otherwise instantiate its own `Map`, so `setCachedImage` from
+ * the broadcast pipeline and `getCachedImage` from the public route would
+ * see different stores → every image fetch 404s. Pinning the state to
+ * `globalThis` gives a single instance per Node.js process regardless of how
+ * many chunks import this file.
  *
  * r-final-17 should_fix: 上限なし Map だと 1 添付 30 ページ × 10MB の
  * ような実データで OOM し得る。total bytes と entry count に上限を
@@ -40,14 +48,24 @@ interface CacheEntry {
   byteLength: number
 }
 
-const cache = new Map<string, CacheEntry>()
-let totalBytes = 0
+interface ImageCacheState {
+  cache: Map<string, CacheEntry>
+  totalBytes: number
+}
+
+const globalRef = globalThis as unknown as {
+  __kagetraImageCacheState?: ImageCacheState
+}
+const state: ImageCacheState = (globalRef.__kagetraImageCacheState ??= {
+  cache: new Map<string, CacheEntry>(),
+  totalBytes: 0,
+})
 
 function deleteEntry(key: string): void {
-  const entry = cache.get(key)
+  const entry = state.cache.get(key)
   if (!entry) return
-  totalBytes -= entry.byteLength
-  cache.delete(key)
+  state.totalBytes -= entry.byteLength
+  state.cache.delete(key)
 }
 
 /**
@@ -55,10 +73,10 @@ function deleteEntry(key: string): void {
  * 保持するので、`cache.keys()` を最古から舐めれば LRU 近似になる。
  */
 function evictUntilUnderLimit(): void {
-  const it = cache.keys()
+  const it = state.cache.keys()
   while (
-    (totalBytes > MAX_TOTAL_BYTES || cache.size > MAX_ENTRIES) &&
-    cache.size > 0
+    (state.totalBytes > MAX_TOTAL_BYTES || state.cache.size > MAX_ENTRIES) &&
+    state.cache.size > 0
   ) {
     const next = it.next()
     if (next.done) break
@@ -82,13 +100,13 @@ export function setCachedImage(
   // (totalBytes の二重計上を防ぐ)。
   deleteEntry(token)
 
-  cache.set(token, {
+  state.cache.set(token, {
     data,
     contentType,
     expiresAt: Date.now() + ttlMs,
     byteLength: data.byteLength,
   })
-  totalBytes += data.byteLength
+  state.totalBytes += data.byteLength
 
   // r-final-17 should_fix: 容量超過していたら最古から evict。
   evictUntilUnderLimit()
@@ -98,7 +116,7 @@ export function setCachedImage(
   // (LINE 側はその時点で既に画像取得済み)。`unref()` で Node.js プロセスの
   // 終了を妨げないように。
   const timer = setTimeout(() => {
-    const entry = cache.get(token)
+    const entry = state.cache.get(token)
     if (entry && entry.expiresAt <= Date.now()) {
       deleteEntry(token)
     }
@@ -112,7 +130,7 @@ export function getCachedImage(
   token: string,
   now: number = Date.now(),
 ): { data: Buffer; contentType: string } | null {
-  const entry = cache.get(token)
+  const entry = state.cache.get(token)
   if (!entry) return null
   if (entry.expiresAt <= now) {
     deleteEntry(token)
@@ -128,7 +146,7 @@ export function getCachedImage(
  */
 export function evictExpiredImages(now: number = Date.now()): number {
   let evicted = 0
-  for (const [key, entry] of cache.entries()) {
+  for (const [key, entry] of state.cache.entries()) {
     if (entry.expiresAt <= now) {
       deleteEntry(key)
       evicted++
@@ -138,8 +156,8 @@ export function evictExpiredImages(now: number = Date.now()): number {
 }
 
 export function _resetImageCacheForTests(): void {
-  cache.clear()
-  totalBytes = 0
+  state.cache.clear()
+  state.totalBytes = 0
 }
 
 /**
@@ -149,5 +167,5 @@ export function _getImageCacheStats(): {
   entries: number
   totalBytes: number
 } {
-  return { entries: cache.size, totalBytes }
+  return { entries: state.cache.size, totalBytes: state.totalBytes }
 }


### PR DESCRIPTION
## Summary

- `apps/web/src/lib/image-cache.ts` の Map / totalBytes を **`globalThis`-pinned** に変更
- Next.js が Server Action 側 chunk と Route Handler 側 chunk で同モジュールを別々に bundle しても、**1 プロセス内で常に同じ State** を共有する
- これにより `setCachedImage` で書いた本文画像 buffer が、Route Handler の `getCachedImage` から確実に取り出せる → LINE 本文画像が 404 で空表示になる退行を解消
- 挙動 (24h TTL / LRU evict / 200MB & 500entry 上限) は無変更

## Bug

Fixes #128

### 観測 (本番 SSH 経由)

- mail_id=93 (宮崎大会 link) の `event_broadcast_messages`: `status='sent'`, `sent_image_count=2`, `error_message=NULL` (broadcastMailToEvent は完走)
- nginx access.log (2026-06-07 15:43+):
  - `/api/line-broadcast/images/<token>` → **全て 404** (本文画像 4 token × 複数アクセス)
  - `/api/line-broadcast/attachments/<token>` → 200 OK (DB 取得経路)
- 過去 broadcast: id 1-7 (2026-05-31 〜 2026-06-02) は image URL 200 OK、**id 8 (今回, 06-07) のみ全 404**
- `image-cache.ts` / `line-broadcast.ts` / Route Handler のコード自体は 06-02 以降無変更
- 06-07 PR #127 で新 Route Handler 2 本 (`api/admin/mail-inbox/[id]/draft-status`, `api/admin/mail/unprocessed-count`) + 新 Server Action 群 (`triggerExtractDraft`, `linkMailToEvent`, `unlinkMailFromEvent`) を追加 → Next.js webpack chunk splitting が再評価された

これらは「`setCachedImage` を呼んだ Map と、`getCachedImage` が見る Map が別 instance」でしか説明がつかない。

### 修正

```ts
interface ImageCacheState { cache: Map<string, CacheEntry>; totalBytes: number }
const state: ImageCacheState = (
  (globalThis as unknown as { __kagetraImageCacheState?: ImageCacheState })
    .__kagetraImageCacheState ??= { cache: new Map(), totalBytes: 0 }
)
```

以後 `state.cache` / `state.totalBytes` を経由。挙動は完全に同じ。

## Test plan

- [x] `pnpm --filter @kagetra/web test src/lib/line-broadcast.test.ts src/lib/mail-body-image-render.test.ts` → 17 pass / 1 skip
- [x] `tsc --noEmit` → エラーなし
- [ ] 本番反映 (auto-deploy) 後、mail-inbox で「既存大会への結びつけ」or「会で流す」を実行し、本文画像が LINE で本文込みで表示されることを実機確認
- [ ] 同時に nginx ログで `/api/line-broadcast/images/` が 200 OK で返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)