### PR TITLE
fix(mail-inbox): 件名を全文表示し、送信者行を削除

### DIFF
--- a/apps/web/src/app/(app)/admin/mail-inbox/page.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/page.tsx
@@ -64,8 +64,6 @@ const LIST_COLUMNS = {
   id: true,
   receivedAt: true,
   subject: true,
-  fromName: true,
-  fromAddress: true,
   status: true,
   classification: true,
   triageStatus: true,
@@ -207,15 +205,10 @@ export default async function MailInboxPage() {
           </div>
           <Link
             href={`/admin/mail-inbox/mail/${row.id}`}
-            className="truncate font-medium text-ink hover:underline"
+            className="break-words font-medium text-ink hover:underline"
           >
             {row.subject || '(件名なし)'}
           </Link>
-          <div className="truncate text-xs text-ink-meta">
-            {row.fromName
-              ? `${row.fromName} <${row.fromAddress}>`
-              : row.fromAddress}
-          </div>
           <AttachmentList items={row.attachments} />
           {row.draft && (
             <Link href={`/admin/mail-inbox/${row.draft.id}`} className="block">


### PR DESCRIPTION
## Summary
- 受信箱一覧カードの件名 Link から `truncate` を外し、`break-words` で全文表示に変更
- 件名直下の「送信者名 \<送信元アドレス\>」行を削除（カードの情報密度を下げる）
- 一覧クエリの `LIST_COLUMNS` から `fromName` / `fromAddress` の projection を削除（参照箇所がなくなったため）

詳細画面 (`mail-inbox/mail/[id]` および `mail-inbox/[id]`) では送信者情報は従来通り表示する。

## Test plan
- [x] vitest: `apps/web/src/app/(app)/admin/mail-inbox/**` 127 件 pass
- [x] lint pass (`pnpm --filter @kagetra/web lint`)
- [x] check-types pass (`pnpm --filter @kagetra/web check-types`)
- [ ] 実機（モバイル）で件名の折り返し表示を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)