### PR TITLE
fix(deploy): auto-install kagetra-* systemd units on deploy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,10 @@
 # GitHub Actions deploy). CRLF would break them with `$'\r': command not found`,
 # so force LF regardless of the committer's platform / autocrlf setting.
 *.sh text eol=lf
+
+# systemd unit files and sudoers fragments are parsed by Linux daemons that
+# reject CRLF (sudoers では visudo -c が `>>> syntax error` で蹴る、systemd
+# は `Failed to parse` で start に失敗する)。LF を強制。
+infra/sudoers/* text eol=lf
+apps/*/systemd/*.service text eol=lf
+apps/*/systemd/*.timer text eol=lf

--- a/docs/deploy/mail-worker.md
+++ b/docs/deploy/mail-worker.md
@@ -90,6 +90,13 @@ Lightsail 上に systemd timer で 30 分ごとに動かすまでの一通り。
    ファイルを更新したら本番側もこの手順で再配置する (auto-deploy では更新
    しない — 失敗時のロールバックが難しいため)。
 
+   **新規 systemd unit を追加する場合**: 必ず同 PR で `infra/sudoers/kagetra-deploy`
+   にも対応エントリ (`install ...` / `systemctl restart ...` / `is-active ...`) を
+   追記する。sudoers は **固定 unit 名のみ** 列挙し、`kagetra-*` のワイルドカードは
+   使わない (kagetra アカウントから任意 unit を root 実行できる privilege escalation
+   を防ぐため)。sudoers 更新後の本番反映 (再 install) を忘れると、auto-deploy が
+   新 unit の `install` で sudo に蹴られて fail するので即座に気付ける。
+
 8. systemd unit 配置 + 有効化:
 
    ```bash

--- a/docs/deploy/mail-worker.md
+++ b/docs/deploy/mail-worker.md
@@ -78,22 +78,43 @@ Lightsail 上に systemd timer で 30 分ごとに動かすまでの一通り。
    sudo -u kagetra bash -c 'cd /opt/kagetra && corepack pnpm --filter @kagetra/shared db:migrate'
    ```
 
-7. systemd unit 配置 + 有効化:
+7. scoped sudoers 配置 (auto-deploy が systemd unit を更新できるようにする):
+
+   ```bash
+   sudo install -m 0440 -o root -g root \
+     /opt/kagetra/infra/sudoers/kagetra-deploy /etc/sudoers.d/kagetra-deploy
+   sudo visudo -c -f /etc/sudoers.d/kagetra-deploy   # syntax check
+   ```
+
+   この sudoers は repo `infra/sudoers/kagetra-deploy` で版管理されている。
+   ファイルを更新したら本番側もこの手順で再配置する (auto-deploy では更新
+   しない — 失敗時のロールバックが難しいため)。
+
+8. systemd unit 配置 + 有効化:
 
    ```bash
    # IMAP fetch 用 (30 分間隔)。mail-inbox-mailer 以降は --mode=fetch-only で AI を呼ばない。
-   sudo cp /opt/kagetra/apps/mail-worker/systemd/kagetra-mail-worker.service /etc/systemd/system/
-   sudo cp /opt/kagetra/apps/mail-worker/systemd/kagetra-mail-worker.timer /etc/systemd/system/
+   sudo install -m 644 -o root -g root \
+     /opt/kagetra/apps/mail-worker/systemd/kagetra-mail-worker.service /etc/systemd/system/kagetra-mail-worker.service
+   sudo install -m 644 -o root -g root \
+     /opt/kagetra/apps/mail-worker/systemd/kagetra-mail-worker.timer /etc/systemd/system/kagetra-mail-worker.timer
 
    # mail-inbox-mailer (タスク6): AI 抽出専用 (30 秒間隔、--mode=extract-only)。
    # 「会で流す（AI 抽出）」ボタンから生成される manual_extract ジョブを処理する。
-   sudo cp /opt/kagetra/apps/mail-worker/systemd/kagetra-mail-worker-extract.service /etc/systemd/system/
-   sudo cp /opt/kagetra/apps/mail-worker/systemd/kagetra-mail-worker-extract.timer /etc/systemd/system/
+   sudo install -m 644 -o root -g root \
+     /opt/kagetra/apps/mail-worker/systemd/kagetra-mail-worker-extract.service /etc/systemd/system/kagetra-mail-worker-extract.service
+   sudo install -m 644 -o root -g root \
+     /opt/kagetra/apps/mail-worker/systemd/kagetra-mail-worker-extract.timer /etc/systemd/system/kagetra-mail-worker-extract.timer
 
    sudo systemctl daemon-reload
    sudo systemctl enable --now kagetra-mail-worker.timer
    sudo systemctl enable --now kagetra-mail-worker-extract.timer
    ```
+
+   **2回目以降のデプロイ**: 上記 sudoers が配置済みなら
+   `scripts/deploy/auto-deploy.sh` が `apps/*/systemd/kagetra-*.{service,timer}`
+   の差分を検知して自動で `install` + `daemon-reload` + (timer なら `enable
+   --now` + `restart`) を実行する。手動オペは初回 / sudoers 自体の更新時のみ。
 
 ## 2. LINE Bot 初期登録
 

--- a/infra/sudoers/kagetra-deploy
+++ b/infra/sudoers/kagetra-deploy
@@ -1,0 +1,46 @@
+# kagetra デプロイアカウント用 scoped sudo 設定。
+#
+# 配置先:
+#   /etc/sudoers.d/kagetra-deploy (mode 0440, owner root:root)
+#
+# 適用手順:
+#   sudo install -m 0440 -o root -g root \
+#     /opt/kagetra/infra/sudoers/kagetra-deploy /etc/sudoers.d/kagetra-deploy
+#   sudo visudo -c -f /etc/sudoers.d/kagetra-deploy   # syntax check
+#
+# 設計方針:
+#   - kagetra ユーザー (= GitHub Actions deploy 鍵で SSH するアカウント) には
+#     /opt/kagetra 配下のファイル所有権 + 限定的な systemctl 操作のみ NOPASSWD
+#     で許可する。root シェル / 全 systemctl は不可。
+#   - sudoers ワイルドカード `*` は `/` にマッチしないので、source/dest とも
+#     `/opt/kagetra/apps/<APP>/systemd/` / `/etc/systemd/system/` 直下に限定される。
+#   - `install` を使う理由: 1 コマンドで cp + chown + chmod が原子的に済み、
+#     中途半端なファイルが置かれない。
+#
+# 何を許可するか:
+#   - kagetra-*.service / kagetra-*.timer の install
+#     (source: /opt/kagetra/apps/*/systemd/、dest: /etc/systemd/system/)
+#   - daemon-reload
+#   - kagetra-* の enable / restart / is-active
+#
+# 何を許可しないか:
+#   - 任意のファイルの install (dest pattern が kagetra-*.{service,timer} に限定)
+#   - kagetra-* 以外のユニット操作
+#   - stop / disable / mask (誤操作で本番が止まるリスク回避)
+
+# ---- systemd unit ファイル配置 (apps/*/systemd → /etc/systemd/system) ----
+kagetra ALL=(root) NOPASSWD: /usr/bin/install -m 644 -o root -g root /opt/kagetra/apps/api/systemd/kagetra-*.service /etc/systemd/system/kagetra-*.service
+kagetra ALL=(root) NOPASSWD: /usr/bin/install -m 644 -o root -g root /opt/kagetra/apps/api/systemd/kagetra-*.timer /etc/systemd/system/kagetra-*.timer
+kagetra ALL=(root) NOPASSWD: /usr/bin/install -m 644 -o root -g root /opt/kagetra/apps/web/systemd/kagetra-*.service /etc/systemd/system/kagetra-*.service
+kagetra ALL=(root) NOPASSWD: /usr/bin/install -m 644 -o root -g root /opt/kagetra/apps/web/systemd/kagetra-*.timer /etc/systemd/system/kagetra-*.timer
+kagetra ALL=(root) NOPASSWD: /usr/bin/install -m 644 -o root -g root /opt/kagetra/apps/mail-worker/systemd/kagetra-*.service /etc/systemd/system/kagetra-*.service
+kagetra ALL=(root) NOPASSWD: /usr/bin/install -m 644 -o root -g root /opt/kagetra/apps/mail-worker/systemd/kagetra-*.timer /etc/systemd/system/kagetra-*.timer
+
+# ---- systemctl 操作 (kagetra-* に限定) ----
+kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl daemon-reload
+kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl enable kagetra-*.timer
+kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl enable --now kagetra-*.timer
+kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl restart kagetra-*.service
+kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl restart kagetra-*.timer
+kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl is-active kagetra-*.service
+kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl is-active kagetra-*.timer

--- a/infra/sudoers/kagetra-deploy
+++ b/infra/sudoers/kagetra-deploy
@@ -24,6 +24,20 @@
 #     `install` の段階で sudo に蹴られて fail する (= 攻撃ベクトル無し)。
 #   - `install` を使う理由: 1 コマンドで cp + chown + chmod が原子的に済み、
 #     中途半端なファイルが置かれない。
+#
+# 信頼境界 (Codex r3 blocker への明示的な応答):
+#   - kagetra ユーザーは source ファイルを書き換えてから install できるため、
+#     固定 unit 名でも「許可済 unit 内容の改ざんによる privilege escalation」
+#     経路は理論上存在する (例: kagetra-web.service の User= を root に書き換え)。
+#   - 本プロジェクトでは以下の信頼モデルでこのリスクを許容する:
+#       1. main への push 権 = 本番への deploy 認可 (1 人開発)
+#       2. main 取得者は SSH/root 鍵も既に保有 (escalation の追加リスクが
+#          限定的)
+#       3. auto-deploy.sh 側で .service の `User=kagetra` / `Group=kagetra`
+#          を必須にする defensive check を行い、典型的な改ざん攻撃を弾く
+#          (NoNewPrivileges / Capabilities 系の高度な迂回までは防がない)
+#   - multi-developer 環境に拡張する場合は root 所有 staging dir + 検収手順
+#     (allowlist / sha256 照合) への置き換えを再検討する。
 
 # ============================================================================
 # systemd unit ファイル配置 (apps/*/systemd → /etc/systemd/system)

--- a/infra/sudoers/kagetra-deploy
+++ b/infra/sudoers/kagetra-deploy
@@ -12,35 +12,72 @@
 #   - kagetra ユーザー (= GitHub Actions deploy 鍵で SSH するアカウント) には
 #     /opt/kagetra 配下のファイル所有権 + 限定的な systemctl 操作のみ NOPASSWD
 #     で許可する。root シェル / 全 systemctl は不可。
-#   - sudoers ワイルドカード `*` は `/` にマッチしないので、source/dest とも
-#     `/opt/kagetra/apps/<APP>/systemd/` / `/etc/systemd/system/` 直下に限定される。
+#   - **unit 名は固定列挙** (ワイルドカード `kagetra-*` を使わない)。
+#     kagetra は /opt/kagetra/apps/*/systemd/ に任意ファイルを置けるため、
+#     ワイルドカードを許すと `kagetra-evil.service` を追加して
+#     `sudo systemctl restart kagetra-evil.service` で root コード実行できる
+#     (PR #132 Codex r1 blocker 指摘)。
+#   - **新規 unit を追加する場合**: (1) apps/<APP>/systemd/<NAME>.{service,timer}
+#     を追加 + (2) このファイルに install / systemctl エントリを追記 +
+#     (3) 本番に /etc/sudoers.d/kagetra-deploy を再配置 (上記手順)。
+#     auto-deploy.sh は sudoers を更新しないので、未登録 unit を deploy しても
+#     `install` の段階で sudo に蹴られて fail する (= 攻撃ベクトル無し)。
 #   - `install` を使う理由: 1 コマンドで cp + chown + chmod が原子的に済み、
 #     中途半端なファイルが置かれない。
-#
-# 何を許可するか:
-#   - kagetra-*.service / kagetra-*.timer の install
-#     (source: /opt/kagetra/apps/*/systemd/、dest: /etc/systemd/system/)
-#   - daemon-reload
-#   - kagetra-* の enable / restart / is-active
-#
-# 何を許可しないか:
-#   - 任意のファイルの install (dest pattern が kagetra-*.{service,timer} に限定)
-#   - kagetra-* 以外のユニット操作
-#   - stop / disable / mask (誤操作で本番が止まるリスク回避)
 
-# ---- systemd unit ファイル配置 (apps/*/systemd → /etc/systemd/system) ----
-kagetra ALL=(root) NOPASSWD: /usr/bin/install -m 644 -o root -g root /opt/kagetra/apps/api/systemd/kagetra-*.service /etc/systemd/system/kagetra-*.service
-kagetra ALL=(root) NOPASSWD: /usr/bin/install -m 644 -o root -g root /opt/kagetra/apps/api/systemd/kagetra-*.timer /etc/systemd/system/kagetra-*.timer
-kagetra ALL=(root) NOPASSWD: /usr/bin/install -m 644 -o root -g root /opt/kagetra/apps/web/systemd/kagetra-*.service /etc/systemd/system/kagetra-*.service
-kagetra ALL=(root) NOPASSWD: /usr/bin/install -m 644 -o root -g root /opt/kagetra/apps/web/systemd/kagetra-*.timer /etc/systemd/system/kagetra-*.timer
-kagetra ALL=(root) NOPASSWD: /usr/bin/install -m 644 -o root -g root /opt/kagetra/apps/mail-worker/systemd/kagetra-*.service /etc/systemd/system/kagetra-*.service
-kagetra ALL=(root) NOPASSWD: /usr/bin/install -m 644 -o root -g root /opt/kagetra/apps/mail-worker/systemd/kagetra-*.timer /etc/systemd/system/kagetra-*.timer
+# ============================================================================
+# systemd unit ファイル配置 (apps/*/systemd → /etc/systemd/system)
+# 各 unit ごとに固定の source + dest を明示する。
+# ============================================================================
 
-# ---- systemctl 操作 (kagetra-* に限定) ----
+# --- apps/api ---
+kagetra ALL=(root) NOPASSWD: /usr/bin/install -m 644 -o root -g root /opt/kagetra/apps/api/systemd/kagetra-api.service /etc/systemd/system/kagetra-api.service
+
+# --- apps/web ---
+kagetra ALL=(root) NOPASSWD: /usr/bin/install -m 644 -o root -g root /opt/kagetra/apps/web/systemd/kagetra-web.service /etc/systemd/system/kagetra-web.service
+kagetra ALL=(root) NOPASSWD: /usr/bin/install -m 644 -o root -g root /opt/kagetra/apps/web/systemd/kagetra-broadcast-cleanup.service /etc/systemd/system/kagetra-broadcast-cleanup.service
+kagetra ALL=(root) NOPASSWD: /usr/bin/install -m 644 -o root -g root /opt/kagetra/apps/web/systemd/kagetra-broadcast-cleanup.timer /etc/systemd/system/kagetra-broadcast-cleanup.timer
+kagetra ALL=(root) NOPASSWD: /usr/bin/install -m 644 -o root -g root /opt/kagetra/apps/web/systemd/kagetra-lifecycle-reminders.service /etc/systemd/system/kagetra-lifecycle-reminders.service
+kagetra ALL=(root) NOPASSWD: /usr/bin/install -m 644 -o root -g root /opt/kagetra/apps/web/systemd/kagetra-lifecycle-reminders.timer /etc/systemd/system/kagetra-lifecycle-reminders.timer
+
+# --- apps/mail-worker ---
+kagetra ALL=(root) NOPASSWD: /usr/bin/install -m 644 -o root -g root /opt/kagetra/apps/mail-worker/systemd/kagetra-mail-worker.service /etc/systemd/system/kagetra-mail-worker.service
+kagetra ALL=(root) NOPASSWD: /usr/bin/install -m 644 -o root -g root /opt/kagetra/apps/mail-worker/systemd/kagetra-mail-worker.timer /etc/systemd/system/kagetra-mail-worker.timer
+kagetra ALL=(root) NOPASSWD: /usr/bin/install -m 644 -o root -g root /opt/kagetra/apps/mail-worker/systemd/kagetra-mail-worker-extract.service /etc/systemd/system/kagetra-mail-worker-extract.service
+kagetra ALL=(root) NOPASSWD: /usr/bin/install -m 644 -o root -g root /opt/kagetra/apps/mail-worker/systemd/kagetra-mail-worker-extract.timer /etc/systemd/system/kagetra-mail-worker-extract.timer
+kagetra ALL=(root) NOPASSWD: /usr/bin/install -m 644 -o root -g root /opt/kagetra/apps/mail-worker/systemd/kagetra-backup.service /etc/systemd/system/kagetra-backup.service
+kagetra ALL=(root) NOPASSWD: /usr/bin/install -m 644 -o root -g root /opt/kagetra/apps/mail-worker/systemd/kagetra-backup.timer /etc/systemd/system/kagetra-backup.timer
+
+# ============================================================================
+# systemctl 操作 (各 unit 名を固定列挙)
+# ============================================================================
+
+# --- daemon-reload (unit ファイル更新後に必要、unit 名を取らないので 1 行) ---
 kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl daemon-reload
-kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl enable kagetra-*.timer
-kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl enable --now kagetra-*.timer
-kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl restart kagetra-*.service
-kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl restart kagetra-*.timer
-kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl is-active kagetra-*.service
-kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl is-active kagetra-*.timer
+
+# --- timer enable --now (新規 timer の有効化+即起動) ---
+kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl enable --now kagetra-mail-worker.timer
+kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl enable --now kagetra-mail-worker-extract.timer
+kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl enable --now kagetra-backup.timer
+kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl enable --now kagetra-broadcast-cleanup.timer
+kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl enable --now kagetra-lifecycle-reminders.timer
+
+# --- restart (service: deploy 時のコード反映用) ---
+kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl restart kagetra-web.service
+kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl restart kagetra-api.service
+
+# --- restart (timer: スケジュール変更の即時反映用) ---
+kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl restart kagetra-mail-worker.timer
+kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl restart kagetra-mail-worker-extract.timer
+kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl restart kagetra-backup.timer
+kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl restart kagetra-broadcast-cleanup.timer
+kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl restart kagetra-lifecycle-reminders.timer
+
+# --- is-active (deploy 後の healthcheck 用) ---
+kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl is-active kagetra-web.service
+kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl is-active kagetra-api.service
+kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl is-active kagetra-mail-worker.timer
+kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl is-active kagetra-mail-worker-extract.timer
+kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl is-active kagetra-backup.timer
+kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl is-active kagetra-broadcast-cleanup.timer
+kagetra ALL=(root) NOPASSWD: /usr/bin/systemctl is-active kagetra-lifecycle-reminders.timer

--- a/scripts/deploy/auto-deploy.sh
+++ b/scripts/deploy/auto-deploy.sh
@@ -143,33 +143,33 @@ if [ -n "$SYSTEMD_CHANGES" ]; then
       || fail "install $name failed (sudoers /etc/sudoers.d/kagetra-deploy 未配置?)"
     case "$name" in *.timer) CHANGED_TIMERS="$CHANGED_TIMERS $name" ;; esac
   done <<< "$SYSTEMD_CHANGES"
-  sudo -n systemctl daemon-reload || fail "systemctl daemon-reload failed"
+  sudo -n /usr/bin/systemctl daemon-reload || fail "systemctl daemon-reload failed"
   for t in $CHANGED_TIMERS; do
     # enable --now: 新規 timer なら有効化+起動。既に有効なら no-op (idempotent)。
-    sudo -n systemctl enable --now "$t" || fail "enable --now $t failed"
+    sudo -n /usr/bin/systemctl enable --now "$t" || fail "enable --now $t failed"
     # restart: 既存 timer のスケジュール変更を即時反映 (enable --now だけだと
     # 既に active な timer は再起動されないので OnUnitActiveSec= 等の変更が
     # 次回 active 化まで反映されない)。新規 timer に対しては no-op。
-    sudo -n systemctl restart "$t" || fail "restart $t failed"
-    [ "$(sudo -n systemctl is-active "$t")" = active ] || fail "$t not active after restart"
+    sudo -n /usr/bin/systemctl restart "$t" || fail "restart $t failed"
+    [ "$(sudo -n /usr/bin/systemctl is-active "$t")" = active ] || fail "$t not active after restart"
     log "timer active: $t"
   done
 fi
 
 # --- restart (build 成功後のみ到達)。mail-worker は oneshot+timer なので
 #     次回 timer 発火で新バンドルが走る → restart 不要 ---
-if [ "$WEB" = 1 ]; then sudo -n systemctl restart kagetra-web.service || fail "web restart failed"; fi
-if [ "$API" = 1 ]; then sudo -n systemctl restart kagetra-api.service || fail "api restart failed"; fi
+if [ "$WEB" = 1 ]; then sudo -n /usr/bin/systemctl restart kagetra-web.service || fail "web restart failed"; fi
+if [ "$API" = 1 ]; then sudo -n /usr/bin/systemctl restart kagetra-api.service || fail "api restart failed"; fi
 
 sleep 4
 if [ "$WEB" = 1 ]; then
-  [ "$(sudo -n systemctl is-active kagetra-web.service)" = active ] || fail "web service not active after restart"
+  [ "$(sudo -n /usr/bin/systemctl is-active kagetra-web.service)" = active ] || fail "web service not active after restart"
   CODE=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 http://127.0.0.1:3000 || echo "000")
   log "web healthcheck http://127.0.0.1:3000 -> $CODE"
   case "$CODE" in 2*|3*) ;; *) fail "web healthcheck got HTTP $CODE" ;; esac
 fi
 if [ "$API" = 1 ]; then
-  [ "$(sudo -n systemctl is-active kagetra-api.service)" = active ] || fail "api service not active after restart"
+  [ "$(sudo -n /usr/bin/systemctl is-active kagetra-api.service)" = active ] || fail "api service not active after restart"
 fi
 
 log "deployed HEAD: $(git rev-parse --short HEAD)"

--- a/scripts/deploy/auto-deploy.sh
+++ b/scripts/deploy/auto-deploy.sh
@@ -115,7 +115,15 @@ fi
 # --now / restart) するよう、deploy script 側で吸収する。
 #
 # 配置は `install -m 644 -o root -g root` で行う (cp+chown+chmod を 1 コマンドで原子化)。
-# scoped sudo は infra/sudoers/kagetra-deploy で `kagetra-*.{service,timer}` のみ許可。
+# scoped sudo は infra/sudoers/kagetra-deploy で **固定 unit 名のみ** 列挙する (Codex
+# r1 blocker: ワイルドカード `kagetra-*` だと kagetra アカウントが任意 unit を root
+# 実行できる privilege escalation を生む)。
+#
+# 新規 unit を追加する場合は infra/sudoers/kagetra-deploy にも対応エントリを追記し、
+# 本番に sudoers を再配置 (docs/deploy/mail-worker.md §1 step 7 参照) してから
+# その unit を含む PR をマージする。sudoers 未登録の unit を deploy しても、auto-deploy
+# の `install` が sudo に蹴られて即 fail するため安全側に倒れる。
+#
 # daemon-reload は新規 unit を systemd に認識させるのに必須。
 # timer は enable で `WantedBy=timers.target` symlink を張り --now で即起動、変更後は
 # restart で新スケジュールを再読込する (oneshot service 側は次回発火で新ファイルを読む)。

--- a/scripts/deploy/auto-deploy.sh
+++ b/scripts/deploy/auto-deploy.sh
@@ -108,6 +108,46 @@ if echo "$CHANGED" | grep -qE '^packages/shared/drizzle/[0-9].*\.sql$'; then
   log "migrations applied"
 fi
 
+# --- systemd unit ファイル配置 (kagetra-* の .service/.timer が変わったとき) ---
+# Issue #131: PR #127 で新規追加された kagetra-mail-worker-extract.{service,timer}
+# が本番に未配置のまま AI 抽出が永遠に待たされた。以降は repo の systemd ユニットが
+# 変わったら自動で /etc/systemd/system/ にコピー + daemon-reload + (timer なら enable
+# --now / restart) するよう、deploy script 側で吸収する。
+#
+# 配置は `install -m 644 -o root -g root` で行う (cp+chown+chmod を 1 コマンドで原子化)。
+# scoped sudo は infra/sudoers/kagetra-deploy で `kagetra-*.{service,timer}` のみ許可。
+# daemon-reload は新規 unit を systemd に認識させるのに必須。
+# timer は enable で `WantedBy=timers.target` symlink を張り --now で即起動、変更後は
+# restart で新スケジュールを再読込する (oneshot service 側は次回発火で新ファイルを読む)。
+SYSTEMD_CHANGES=$(echo "$CHANGED" | grep -E '^apps/[^/]+/systemd/kagetra-[^/]+\.(service|timer)$' || true)
+if [ -n "$SYSTEMD_CHANGES" ]; then
+  log "systemd unit changes detected:"
+  echo "$SYSTEMD_CHANGES" | sed 's/^/    /'
+  CHANGED_TIMERS=""
+  while IFS= read -r unit_path; do
+    [ -z "$unit_path" ] && continue
+    src="$REPO/$unit_path"
+    [ -f "$src" ] || fail "unit source missing after checkout: $src"
+    name=$(basename "$unit_path")
+    dest="/etc/systemd/system/$name"
+    log "installing unit: $name"
+    sudo -n /usr/bin/install -m 644 -o root -g root "$src" "$dest" \
+      || fail "install $name failed (sudoers /etc/sudoers.d/kagetra-deploy 未配置?)"
+    case "$name" in *.timer) CHANGED_TIMERS="$CHANGED_TIMERS $name" ;; esac
+  done <<< "$SYSTEMD_CHANGES"
+  sudo -n systemctl daemon-reload || fail "systemctl daemon-reload failed"
+  for t in $CHANGED_TIMERS; do
+    # enable --now: 新規 timer なら有効化+起動。既に有効なら no-op (idempotent)。
+    sudo -n systemctl enable --now "$t" || fail "enable --now $t failed"
+    # restart: 既存 timer のスケジュール変更を即時反映 (enable --now だけだと
+    # 既に active な timer は再起動されないので OnUnitActiveSec= 等の変更が
+    # 次回 active 化まで反映されない)。新規 timer に対しては no-op。
+    sudo -n systemctl restart "$t" || fail "restart $t failed"
+    [ "$(sudo -n systemctl is-active "$t")" = active ] || fail "$t not active after restart"
+    log "timer active: $t"
+  done
+fi
+
 # --- restart (build 成功後のみ到達)。mail-worker は oneshot+timer なので
 #     次回 timer 発火で新バンドルが走る → restart 不要 ---
 if [ "$WEB" = 1 ]; then sudo -n systemctl restart kagetra-web.service || fail "web restart failed"; fi

--- a/scripts/deploy/auto-deploy.sh
+++ b/scripts/deploy/auto-deploy.sh
@@ -124,6 +124,20 @@ fi
 # その unit を含む PR をマージする。sudoers 未登録の unit を deploy しても、auto-deploy
 # の `install` が sudo に蹴られて即 fail するため安全側に倒れる。
 #
+# --- Trust model (Codex r3 blocker への明示的な応答) ---
+# kagetra ユーザーは /opt/kagetra 配下の unit ファイルに書き込み可能。そのため
+# 理論上は「kagetra デプロイ鍵を奪取した攻撃者が unit 内容を改ざんしてから sudo
+# install + restart で root 権限の任意コード実行を成立させる」経路が存在する。
+# 本リポジトリの信頼境界では:
+#   1. main への push 権が = 本番への deploy 認可。1 人開発でその person が
+#      root SSH 鍵も保有しているため、escalation の追加リスクは限定的
+#   2. それでも下記の defensive check で「典型的な User= 改ざん攻撃」は塞ぐ:
+#      .service には `User=kagetra` と `Group=kagetra` が必須。欠落していたら
+#      install を拒否する (NoNewPrivileges, Capabilities 等の高度な迂回は防げ
+#      ないが、低コスト/低保守で実用的な閾値)
+#   3. multi-developer 環境に拡張する場合は root 所有 staging dir + 検収手順
+#      (allowlist / sha256 照合) への置き換えを再検討する
+#
 # daemon-reload は新規 unit を systemd に認識させるのに必須。
 # timer は enable で `WantedBy=timers.target` symlink を張り --now で即起動、変更後は
 # restart で新スケジュールを再読込する (oneshot service 側は次回発火で新ファイルを読む)。
@@ -138,6 +152,17 @@ if [ -n "$SYSTEMD_CHANGES" ]; then
     [ -f "$src" ] || fail "unit source missing after checkout: $src"
     name=$(basename "$unit_path")
     dest="/etc/systemd/system/$name"
+    # Defensive check (trust model 2): .service は User=kagetra + Group=kagetra
+    # を必須にする。.timer は実行ユーザを持たないので check 不要。改ざんで User=
+    # を root に書き換えるタイプの escalation を低コストで弾く。
+    case "$name" in
+      *.service)
+        grep -qE '^User=kagetra$' "$src" \
+          || fail "$name does not declare 'User=kagetra' — refusing to install (privilege escalation guard)"
+        grep -qE '^Group=kagetra$' "$src" \
+          || fail "$name does not declare 'Group=kagetra' — refusing to install"
+        ;;
+    esac
     log "installing unit: $name"
     sudo -n /usr/bin/install -m 644 -o root -g root "$src" "$dest" \
       || fail "install $name failed (sudoers /etc/sudoers.d/kagetra-deploy 未配置?)"


### PR DESCRIPTION
## Summary
- `scripts/deploy/auto-deploy.sh` に `apps/*/systemd/kagetra-*.{service,timer}` 差分検出 + 自動インストール (`install` → `daemon-reload` → timer `enable --now` + `restart` + `is-active`) を追加
- `infra/sudoers/kagetra-deploy` (新規) で kagetra アカウントに kagetra-* unit のスコープド sudo を許可
- `docs/deploy/mail-worker.md` の手順 7 を `install` + sudoers 配置に更新、2 回目以降は auto-deploy 吸収と注記
- `.gitattributes` に sudoers / systemd unit の eol=lf を追加（CRLF 混入で visudo / systemctl が parse error）

## Bug
Fixes #131

PR #127 (mail-inbox-mailer) で新規追加された `kagetra-mail-worker-extract.{service,timer}` が本番に未配置のまま、AI 抽出ボタンを押した `manual_extract` ジョブが永遠に pending のまま残った（多摩大会案内メール、~26h 滞留）。

根本原因は auto-deploy.sh が systemd unit 配置を全くやらない設計で、手動配置手順 (`docs/deploy/mail-worker.md`) を踏まないと unit が反映されないこと。同種の取りこぼしを将来も招くため、deploy 側で吸収する。

## Operational state (本 PR 前に実施済)
- 本番 sudoers を新版へ置換（`visudo -c` OK + kagetra ユーザーでスモーク済: install/daemon-reload/is-active 全て OK）
- 滞留していた多摩大会 manual_extract ジョブ (id=1) は extract timer 配置直後の発火で 18 秒で AI 抽出完了 → `tournament_drafts.id=29` が `pending_review` へ遷移

## Test plan
- [ ] CI green
- [ ] 多摩大会の draft を UI で確認（pending_review カードが見える）
- [ ] PR merge → auto-deploy 走行 → DEPLOY_RESULT=SKIPPED_NOCODE か SUCCESS（systemd 変更は無いので install ロジックは no-op）
- [ ] 次に mail-worker の systemd unit を変えた PR で実際に install ロジックが動くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)