### PR TITLE
fix: 承認画面の会内締切にAI抽出の大会申込締切の6日前をデフォルト表示

### DIFF
--- a/apps/web/src/app/(app)/admin/mail-inbox/components/ApprovalForm.test.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/components/ApprovalForm.test.tsx
@@ -313,4 +313,62 @@ describe('ApprovalForm — 複数単位フォーム', () => {
     ) as HTMLInputElement
     expect(kind.value).toBe('individual')
   })
+
+  it('会内締切を大会申込締切の 6 日前で prefill する', () => {
+    // buildUnit デフォルトの entry_deadline = 2030-11-30 → 6 日前 = 2030-11-24
+    const payload = buildPayload([buildUnit()])
+    const { container } = render(
+      <ApprovalForm
+        payload={payload}
+        shortNameStem="大阪"
+        registeredUnitKeys={[]}
+        groups={[]}
+        action={noop}
+      />,
+    )
+    const entryDeadline = container.querySelector(
+      'input[name="u1__entryDeadline"]',
+    ) as HTMLInputElement
+    expect(entryDeadline.value).toBe('2030-11-30')
+    const internalDeadline = container.querySelector(
+      'input[name="u1__internalDeadline"]',
+    ) as HTMLInputElement
+    expect(internalDeadline.value).toBe('2030-11-24')
+  })
+
+  it('会内締切の 6 日前計算は月・年跨ぎでも正しい', () => {
+    const payload = buildPayload([
+      buildUnit({ entry_deadline: '2031-01-03' }),
+    ])
+    const { container } = render(
+      <ApprovalForm
+        payload={payload}
+        shortNameStem="大阪"
+        registeredUnitKeys={[]}
+        groups={[]}
+        action={noop}
+      />,
+    )
+    const internalDeadline = container.querySelector(
+      'input[name="u1__internalDeadline"]',
+    ) as HTMLInputElement
+    expect(internalDeadline.value).toBe('2030-12-28')
+  })
+
+  it('entry_deadline が null の単位は会内締切を prefill しない', () => {
+    const payload = buildPayload([buildUnit({ entry_deadline: null })])
+    const { container } = render(
+      <ApprovalForm
+        payload={payload}
+        shortNameStem="大阪"
+        registeredUnitKeys={[]}
+        groups={[]}
+        action={noop}
+      />,
+    )
+    const internalDeadline = container.querySelector(
+      'input[name="u1__internalDeadline"]',
+    ) as HTMLInputElement
+    expect(internalDeadline.value).toBe('')
+  })
 })

--- a/apps/web/src/app/(app)/admin/mail-inbox/components/ApprovalForm.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/components/ApprovalForm.tsx
@@ -8,6 +8,14 @@ import type {
 import { composeTitle } from '@kagetra/mail-worker/classify/title'
 import { EventForm } from '@/components/events/event-form'
 import { Card } from '@/components/ui'
+import { addDays } from '@/lib/jst-date'
+
+/**
+ * 会内締切デフォルト = 大会申込締切の 6 日前。会内で参加者を取りまとめて
+ * 主催者へ申し込むためのリードタイム（運用ルール）。承認画面の prefill
+ * 専用で、登録後の編集画面では連動しない。
+ */
+const INTERNAL_DEADLINE_LEAD_DAYS = 6
 
 /**
  * tournament-title-grade-split: one event unit ready for the approval form.
@@ -244,6 +252,9 @@ export function ApprovalForm({
                       entryMethod: unit.entry_method ?? null,
                       organizer: unit.organizer_text ?? null,
                       entryDeadline: unit.entry_deadline ?? null,
+                      internalDeadline: unit.entry_deadline
+                        ? addDays(unit.entry_deadline, -INTERNAL_DEADLINE_LEAD_DAYS)
+                        : null,
                       eligibleGrades: unit.eligible_grades ?? null,
                       kind: unit.kind ?? 'individual',
                       // EventUnit has no announcement-wide capacity; per-grade only.


### PR DESCRIPTION
## Summary
- AI抽出の承認画面 (mail-inbox) で、会内締切が常に空欄だったのを修正
- `entry_deadline`（大会申込締切）を AI が抽出できた単位は、その **6日前** を会内締切の defaultValue として prefill（会内取りまとめ→主催者申込のリードタイム）
- 計算は既存の `addDays`（`@/lib/jst-date`、UTCミリ秒演算）を使用し、月跨ぎ・年跨ぎも正しく処理
- `entry_deadline` が null（AI が抽出できなかった）の単位は従来どおり空欄
- 承認画面の prefill のみの変更。server action / DB / 他画面への変更なし（`internalDeadline` のフォーム送信・パースは実装済みだった）

## Test plan
- [x] ApprovalForm.test.tsx に prefill テスト3件追加（6日前計算 / 年跨ぎ / entry_deadline=null で空欄）
- [x] web 全テスト 428 passed / typecheck / lint パス
- [ ] 動作確認（承認画面で会内締切が prefill されること）

🤖 Generated with [Claude Code](https://claude.com/claude-code)