### PR TITLE
fix(deploy): mail-worker/lockfile 変更時も web を再ビルド対象にする

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -8,6 +8,12 @@ const nextConfig: NextConfig = {
   // package is in `transpilePackages`. Mirrors the existing @kagetra/shared
   // entry; without it, /admin/mail-inbox/[id] fails to compile because
   // actions.ts → classifier.ts → ../persist/draft.js cannot be resolved.
+  //
+  // Deploy coupling (Issue #135): everything listed here is compiled INTO the
+  // web bundle at build time, so a source change in these packages requires a
+  // web rebuild + restart even when apps/web/ itself is untouched.
+  // scripts/deploy/auto-deploy.sh's WEB target detection must cover each
+  // bundled package's directory — keep the two in sync when adding entries.
   transpilePackages: ['@kagetra/shared', '@kagetra/mail-worker'],
   output: 'standalone',
   // monorepo の root を明示。Next.js 15 は auto-detect するが、CI/prod 差異リスク回避のため明示 (Phase B Phase 0 Discovery 結果)。

--- a/scripts/deploy/auto-deploy.sh
+++ b/scripts/deploy/auto-deploy.sh
@@ -40,9 +40,15 @@ CHANGED=$(git diff --name-only "$OLD" "$NEW")
 git checkout -B main origin/main -q || fail "git checkout failed"
 log "after: $(git rev-parse --short HEAD)"
 
-# 変更パスから対象アプリを判定 (packages/ 変更は全アプリに波及)
-if echo "$CHANGED" | grep -qE '^packages/'; then SHARED=1; else SHARED=0; fi
-if [ "$SHARED" = 1 ] || echo "$CHANGED" | grep -qE '^apps/web/';         then WEB=1;    else WEB=0;    fi
+# 変更パスから対象アプリを判定 (packages/ と pnpm-lock.yaml の変更は全アプリに波及)。
+# pnpm-lock.yaml: 依存の追加/更新はアプリのファイルを変えずに各バンドルの内容を
+# 変える (例: PR #134 の word-extractor 追加) ため、安全側で全アプリ再ビルドに倒す。
+if echo "$CHANGED" | grep -qE '^(packages/|pnpm-lock\.yaml$)'; then SHARED=1; else SHARED=0; fi
+# web は @kagetra/mail-worker の TS ソースを transpilePackages で Next.js バンドルに
+# 焼き込む (apps/web/next.config.ts)。mail-worker のみの変更でも web の再ビルド+
+# 再起動が必須 — Issue #135: PR #134 (mail-worker only) のデプロイが web=0 と判定
+# され、本番の再抽出 Server Action が旧 classifier (prompt 2.0.0) のまま残留した。
+if [ "$SHARED" = 1 ] || echo "$CHANGED" | grep -qE '^apps/(web|mail-worker)/'; then WEB=1; else WEB=0; fi
 if [ "$SHARED" = 1 ] || echo "$CHANGED" | grep -qE '^apps/api/';         then API=1;    else API=0;    fi
 if [ "$SHARED" = 1 ] || echo "$CHANGED" | grep -qE '^apps/mail-worker/'; then WORKER=1; else WORKER=0; fi
 


### PR DESCRIPTION
## Summary
- `scripts/deploy/auto-deploy.sh` の WEB 判定を `^apps/(web|mail-worker)/` に拡張。apps/web は `@kagetra/mail-worker` の TS ソースを `transpilePackages` で Next.js バンドルに焼き込むため、mail-worker のみの変更でも web の再ビルド+再起動が必要
- SHARED 判定に `pnpm-lock.yaml` を追加。依存の追加/更新はアプリのファイルを変えずに各バンドルの内容を変える（例: PR #134 の word-extractor 追加）ため全アプリ再ビルドに倒す
- `apps/web/next.config.ts` に transpilePackages ⇔ デプロイ判定の連動制約をコメントで明文化。**この変更自体が `^apps/web/` にマッチして今回のデプロイで WEB=1 を誘発し、マージだけで本番 web が PR #134 の新 classifier 込みで再ビルド・再起動される（手動本番操作なしの即時修復）**

## Bug
Fixes #135

PR #134（apps/mail-worker + pnpm-lock.yaml のみの変更）のデプロイが `targets: web=0 api=0 worker=1` と判定され、本番の Web バンドルに旧 classifier（prompt 2.0.0 / .doc lazy fallback なし）が残留。ドラフト詳細画面の「再抽出」(`reextractDraft` Server Action) は Web プロセス内でバンドル済み classifier を同期実行するため、押下しても旧ロジックで再抽出され結果が変わらず「処理が走らない」ように見えていた。

## Test plan
- [x] `bash -n` で構文チェック
- [x] 新判定ロジックを代表 5 ケース（mail-worker のみ / +lockfile / 本PR / docs のみ / api のみ）でシミュレートし期待通りを確認
- [x] worktree で `pnpm --filter @kagetra/web build` を実行し、`word-extractor` 参照が `admin/mail-inbox/[id]/page.js` に、prompt 2.1.0 文言が server chunk に入ることを確認（standalone symlink EPERM は Windows ローカル固有、本番 Ubuntu では発生しない）
- [ ] マージ後: デプロイログで `targets: web=1` と healthcheck 通過を確認
- [ ] 本番で多摩 draft #29 を再抽出 → 締切 prefill（申込期間終了日）を確認（PR #134 の残 DoD）

🤖 Generated with [Claude Code](https://claude.com/claude-code)