### PR TITLE
fix: iPhone PWAでメール添付(PDF以外)のリンクが開けない

### DIFF
--- a/apps/web/src/app/api/admin/mail/attachments/[id]/route.test.ts
+++ b/apps/web/src/app/api/admin/mail/attachments/[id]/route.test.ts
@@ -144,7 +144,10 @@ describe('GET /api/admin/mail/attachments/:id', () => {
     expect(res.headers.get('content-disposition')).toMatch(/^attachment;/)
   })
 
-  it('forces DOCX attachments to octet-stream + attachment', async () => {
+  it('serves DOCX inline with its declared MIME (iOS PWA QuickLook preview)', async () => {
+    // Issue #138: attachment+octet-stream dies on a blank page in the iOS
+    // home-screen PWA in-app browser. Non-active-content types are served
+    // inline so WebKit can hand them to the QuickLook previewer.
     await setAuthSession({ id: 'u1', role: 'admin' })
     const data = Buffer.from([0x50, 0x4b, 0x03, 0x04])
     mockFindFirst.mockResolvedValue({
@@ -156,14 +159,32 @@ describe('GET /api/admin/mail/attachments/:id', () => {
     })
     const res = await GET(makeRequest(), mkParams('1'))
     expect(res.status).toBe(200)
-    expect(res.headers.get('content-type')).toBe('application/octet-stream')
-    expect(res.headers.get('content-disposition')).toMatch(/^attachment;/)
+    expect(res.headers.get('content-type')).toBe(
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    )
+    expect(res.headers.get('content-disposition')).toMatch(/^inline;/)
+    expect(res.headers.get('x-content-type-options')).toBe('nosniff')
+  })
+
+  it('serves legacy .doc (application/msword) inline', async () => {
+    await setAuthSession({ id: 'u1', role: 'admin' })
+    const data = Buffer.from([0xd0, 0xcf, 0x11, 0xe0])
+    mockFindFirst.mockResolvedValue({
+      data,
+      filename: '32rd(A-E)多摩大会案内.doc',
+      contentType: 'application/msword',
+      sizeBytes: data.length,
+    })
+    const res = await GET(makeRequest(), mkParams('1'))
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('application/msword')
+    expect(res.headers.get('content-disposition')).toMatch(/^inline;/)
   })
 
   it('rejects header-injection attempts in stored Content-Type', async () => {
-    // A hostile sender could try to smuggle "application/pdf" via the
-    // allowlist by appending parameters; the route strips parameters before
-    // checking and never echoes the raw value back.
+    // A hostile sender could try to smuggle parameters into the response
+    // header; the route strips them before the blocklist check and never
+    // echoes the raw value back.
     await setAuthSession({ id: 'u1', role: 'admin' })
     const data = Buffer.from('<svg/>')
     mockFindFirst.mockResolvedValue({
@@ -174,12 +195,38 @@ describe('GET /api/admin/mail/attachments/:id', () => {
     })
     const res = await GET(makeRequest(), mkParams('1'))
     expect(res.status).toBe(200)
-    // Parameter stripped → matches the allowlist → inline + application/pdf.
+    // Parameter stripped → not in the blocklist → inline + application/pdf.
     expect(res.headers.get('content-type')).toBe('application/pdf')
     expect(res.headers.get('content-disposition')).toMatch(/^inline;/)
     // Whatever the stored value, the response carries no `; bogus=1`.
     expect(res.headers.get('content-type')).not.toContain('bogus')
   })
+
+  it.each([
+    'not a mime',
+    'application/we"ird',
+    'application/pdf,text/html',
+    '',
+  ])(
+    'falls back to octet-stream + attachment for malformed stored Content-Type %p',
+    async (badType) => {
+      // Values outside the RFC 6838 token grammar would throw inside
+      // `new NextResponse(..., { headers })` and surface as a 500; they must
+      // degrade to a plain download instead.
+      await setAuthSession({ id: 'u1', role: 'admin' })
+      const data = Buffer.from('payload')
+      mockFindFirst.mockResolvedValue({
+        data,
+        filename: 'weird.bin',
+        contentType: badType,
+        sizeBytes: data.length,
+      })
+      const res = await GET(makeRequest(), mkParams('1'))
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toBe('application/octet-stream')
+      expect(res.headers.get('content-disposition')).toMatch(/^attachment;/)
+    },
+  )
 
   it('uses data.length for body + Content-Length even when sizeBytes column disagrees', async () => {
     // Writer (imap-client) falls back to `data.length` when mailparser

--- a/apps/web/src/app/api/admin/mail/attachments/[id]/route.test.ts
+++ b/apps/web/src/app/api/admin/mail/attachments/[id]/route.test.ts
@@ -148,8 +148,8 @@ describe('GET /api/admin/mail/attachments/:id', () => {
     'forces %s (RFC 6839 +xml suffix) to octet-stream + attachment',
     async (xmlType) => {
       // Sender-controlled +xml types reach the browser's XML/XSLT pipeline
-      // and can carry active content; the exact-match blocklist alone would
-      // let them render inline (pr139 r1 blocker).
+      // and can carry active content; they must stay outside the inline
+      // allowlist (pr139 r1 blocker).
       await setAuthSession({ id: 'u1', role: 'admin' })
       const data = Buffer.from('<rss version="2.0"/>')
       mockFindFirst.mockResolvedValue({
@@ -202,6 +202,42 @@ describe('GET /api/admin/mail/attachments/:id', () => {
     expect(res.headers.get('content-disposition')).toMatch(/^inline;/)
   })
 
+  it('serves raster images (image/png) inline', async () => {
+    await setAuthSession({ id: 'u1', role: 'admin' })
+    const data = Buffer.from([0x89, 0x50, 0x4e, 0x47])
+    mockFindFirst.mockResolvedValue({
+      data,
+      filename: '会場地図.png',
+      contentType: 'image/png',
+      sizeBytes: data.length,
+    })
+    const res = await GET(makeRequest(), mkParams('1'))
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('image/png')
+    expect(res.headers.get('content-disposition')).toMatch(/^inline;/)
+  })
+
+  it.each(['application/zip', 'application/ecmascript', 'text/vtt'])(
+    'fails closed to octet-stream + attachment for %s (outside the allowlist)',
+    async (outsideType) => {
+      // The allowlist is the security boundary: well-formed but unlisted
+      // types — including active-content variants we never enumerated —
+      // must degrade to a plain download (pr139 r2 blocker).
+      await setAuthSession({ id: 'u1', role: 'admin' })
+      const data = Buffer.from('payload')
+      mockFindFirst.mockResolvedValue({
+        data,
+        filename: 'other.bin',
+        contentType: outsideType,
+        sizeBytes: data.length,
+      })
+      const res = await GET(makeRequest(), mkParams('1'))
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toBe('application/octet-stream')
+      expect(res.headers.get('content-disposition')).toMatch(/^attachment;/)
+    },
+  )
+
   it('rejects header-injection attempts in stored Content-Type', async () => {
     // A hostile sender could try to smuggle parameters into the response
     // header; the route strips them before the blocklist check and never
@@ -216,7 +252,7 @@ describe('GET /api/admin/mail/attachments/:id', () => {
     })
     const res = await GET(makeRequest(), mkParams('1'))
     expect(res.status).toBe(200)
-    // Parameter stripped → not in the blocklist → inline + application/pdf.
+    // Parameter stripped → matches the allowlist → inline + application/pdf.
     expect(res.headers.get('content-type')).toBe('application/pdf')
     expect(res.headers.get('content-disposition')).toMatch(/^inline;/)
     // Whatever the stored value, the response carries no `; bogus=1`.
@@ -231,9 +267,9 @@ describe('GET /api/admin/mail/attachments/:id', () => {
   ])(
     'falls back to octet-stream + attachment for malformed stored Content-Type %p',
     async (badType) => {
-      // Values outside the RFC 6838 token grammar would throw inside
-      // `new NextResponse(..., { headers })` and surface as a 500; they must
-      // degrade to a plain download instead.
+      // Malformed values must never reach the response headers (they would
+      // throw inside `new NextResponse(..., { headers })` and surface as a
+      // 500); with the allowlist they degrade to a plain download.
       await setAuthSession({ id: 'u1', role: 'admin' })
       const data = Buffer.from('payload')
       mockFindFirst.mockResolvedValue({

--- a/apps/web/src/app/api/admin/mail/attachments/[id]/route.test.ts
+++ b/apps/web/src/app/api/admin/mail/attachments/[id]/route.test.ts
@@ -144,6 +144,27 @@ describe('GET /api/admin/mail/attachments/:id', () => {
     expect(res.headers.get('content-disposition')).toMatch(/^attachment;/)
   })
 
+  it.each(['application/rss+xml', 'application/atom+xml'])(
+    'forces %s (RFC 6839 +xml suffix) to octet-stream + attachment',
+    async (xmlType) => {
+      // Sender-controlled +xml types reach the browser's XML/XSLT pipeline
+      // and can carry active content; the exact-match blocklist alone would
+      // let them render inline (pr139 r1 blocker).
+      await setAuthSession({ id: 'u1', role: 'admin' })
+      const data = Buffer.from('<rss version="2.0"/>')
+      mockFindFirst.mockResolvedValue({
+        data,
+        filename: 'feed.xml',
+        contentType: xmlType,
+        sizeBytes: data.length,
+      })
+      const res = await GET(makeRequest(), mkParams('1'))
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toBe('application/octet-stream')
+      expect(res.headers.get('content-disposition')).toMatch(/^attachment;/)
+    },
+  )
+
   it('serves DOCX inline with its declared MIME (iOS PWA QuickLook preview)', async () => {
     // Issue #138: attachment+octet-stream dies on a blank page in the iOS
     // home-screen PWA in-app browser. Non-active-content types are served

--- a/apps/web/src/app/api/admin/mail/attachments/[id]/route.ts
+++ b/apps/web/src/app/api/admin/mail/attachments/[id]/route.ts
@@ -111,7 +111,13 @@ export async function GET(
     .toLowerCase()
     .split(';')[0]
     ?.trim() ?? ''
-  const isDangerous = DANGEROUS_CONTENT_TYPES.has(declaredContentType)
+  // RFC 6839 structured-syntax suffix: `*/*+xml` (rss+xml / atom+xml /
+  // xslt+xml …) は exact match の Set に居なくてもブラウザの XML/XSLT
+  // パイプラインに到達し active content を運べる。Content-Type は送信者
+  // 制御なので、suffix 一致でまとめて強制ダウンロードに落とす (pr139 r1)。
+  const isDangerous =
+    DANGEROUS_CONTENT_TYPES.has(declaredContentType) ||
+    declaredContentType.endsWith('+xml')
   const isValidMime = SAFE_MIME_RE.test(declaredContentType)
   const forceDownload = isDangerous || !isValidMime
   const responseContentType = forceDownload

--- a/apps/web/src/app/api/admin/mail/attachments/[id]/route.ts
+++ b/apps/web/src/app/api/admin/mail/attachments/[id]/route.ts
@@ -13,25 +13,31 @@ export const dynamic = 'force-dynamic'
  *
  * Mail attachments are UNTRUSTED user input from the IMAP fetcher: a hostile
  * sender can attach `text/html` or `image/svg+xml` and turn an inline preview
- * into stored XSS on the same origin as the admin UI. Policy (blocklist):
- *   - Known active-content MIMEs (html/xhtml/svg/xml/js) are rewritten to
- *     `application/octet-stream` and forced to `Content-Disposition: attachment`
- *     so the browser downloads instead of executing.
- *   - Everything else (pdf / doc / docx / xlsx / images …) is served INLINE
- *     with its declared MIME. None of these are active content, and inline is
- *     what lets the iOS home-screen PWA preview them via QuickLook: the
- *     standalone in-app browser cannot hand `Content-Disposition: attachment`
- *     to a download manager and dies on a blank page instead (Issue #138).
- *     Desktop browsers download types they cannot render inline, so nothing
- *     regresses there.
+ * into stored XSS on the same origin as the admin UI. Policy (fail-closed
+ * allowlist):
+ *   - Only the inert preview types below (PDF / Office documents / raster
+ *     images / plain text) are served inline with their declared MIME.
+ *     Inline is what lets the iOS home-screen PWA preview them via QuickLook:
+ *     the standalone in-app browser cannot hand
+ *     `Content-Disposition: attachment` to a download manager and dies on a
+ *     blank page instead (Issue #138). Desktop browsers download types they
+ *     cannot render inline, so nothing regresses there.
+ *   - Everything else — active content (html / svg / xml / js …), unknown or
+ *     malformed types — is rewritten to `application/octet-stream` and forced
+ *     to `Content-Disposition: attachment`. Sender-controlled input cannot be
+ *     made safe by enumerating known-bad types, so anything outside the
+ *     allowlist fails closed to a download (codex pr139 r2).
+ *   - The response Content-Type is therefore always either an allowlist
+ *     constant or `application/octet-stream`; the stored value is never
+ *     echoed back, so a malformed string can neither break response headers
+ *     nor smuggle parameters.
  *   - `X-Content-Type-Options: nosniff` is always set so the browser cannot
  *     override the declared type by sniffing the body.
  *
- * This mirrors the blocklist of the public
- * `/api/line-broadcast/attachments/[token]` route (PR #70) with one deliberate
- * difference: that route pins `attachment` for ALL types because it is
- * unauthenticated and must never render anything same-origin, while this route
- * is admin/vice_admin-gated and prioritizes in-PWA preview.
+ * The public `/api/line-broadcast/attachments/[token]` route (PR #70) is
+ * stricter still: it pins `attachment` for ALL types because it is
+ * unauthenticated and must never render anything same-origin, while this
+ * route is admin/vice_admin-gated and prioritizes in-PWA preview.
  *
  * Filenames are RFC 5987-encoded (`filename*=UTF-8''…`) alongside a legacy
  * `filename="…"` so non-ASCII names like "大会要項.pdf" survive proxies that
@@ -42,26 +48,29 @@ export const dynamic = 'force-dynamic'
  *   - https://datatracker.ietf.org/doc/html/rfc5987
  *   - https://datatracker.ietf.org/doc/html/rfc6266
  */
-const DANGEROUS_CONTENT_TYPES = new Set<string>([
-  'text/html',
-  'application/xhtml+xml',
-  'image/svg+xml',
-  'application/svg+xml',
-  'text/xml',
-  'application/xml',
-  // application/javascript / text/javascript も念のため
-  'application/javascript',
-  'text/javascript',
+const INLINE_ALLOWED_CONTENT_TYPES = new Set<string>([
+  // PDF — ブラウザ内蔵ビューア / QuickLook
+  'application/pdf',
+  'application/x-pdf',
+  // Office 文書 — 大会要項・申込書・名簿で実際に届く型。active content では
+  // なく、iOS QuickLook がプレビューできる (Issue #138 の本命は .doc/.docx)
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.ms-powerpoint',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  // ラスタ画像のみ (image/svg+xml は active content なので絶対に入れない)
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'image/heic',
+  'image/heif',
+  // プレーンテキスト — nosniff 前提でテキストとして描画される
+  'text/plain',
+  'text/csv',
 ])
-
-/**
- * RFC 6838 token grammar に沿った `type/subtype` 形式の MIME 判定。
- * 制御文字 / 空白 / カンマが混入した stored Content-Type をそのまま
- * ヘッダに乗せると `new NextResponse(..., { headers })` が例外になり
- * 500 を返してしまうため、通らない値は octet-stream + attachment に
- * 落とす (public token route と同じパターン、pr70 r1 should_fix)。
- */
-const SAFE_MIME_RE = /^[a-z0-9!#$&^_.+-]+\/[a-z0-9!#$&^_.+-]+$/i
 
 export async function GET(
   _req: Request,
@@ -104,26 +113,19 @@ export async function GET(
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
   }
 
-  // Strip parameters (e.g. `; charset=utf-8`) before blocklist comparison so a
-  // hostile `text/html; charset=utf-8\r\n…` header can't dodge the rewrite and
-  // also can't header-inject — we never echo the raw value back.
+  // Strip parameters (e.g. `; charset=utf-8`) before the allowlist check so
+  // `application/pdf; charset=utf-8` still previews. The stored value is
+  // never echoed into a response header (the response type is an allowlist
+  // constant or octet-stream), so header injection is structurally impossible.
   const declaredContentType = (row.contentType ?? '')
     .toLowerCase()
     .split(';')[0]
     ?.trim() ?? ''
-  // RFC 6839 structured-syntax suffix: `*/*+xml` (rss+xml / atom+xml /
-  // xslt+xml …) は exact match の Set に居なくてもブラウザの XML/XSLT
-  // パイプラインに到達し active content を運べる。Content-Type は送信者
-  // 制御なので、suffix 一致でまとめて強制ダウンロードに落とす (pr139 r1)。
-  const isDangerous =
-    DANGEROUS_CONTENT_TYPES.has(declaredContentType) ||
-    declaredContentType.endsWith('+xml')
-  const isValidMime = SAFE_MIME_RE.test(declaredContentType)
-  const forceDownload = isDangerous || !isValidMime
-  const responseContentType = forceDownload
-    ? 'application/octet-stream'
-    : declaredContentType
-  const dispositionType = forceDownload ? 'attachment' : 'inline'
+  const allowInline = INLINE_ALLOWED_CONTENT_TYPES.has(declaredContentType)
+  const responseContentType = allowInline
+    ? declaredContentType
+    : 'application/octet-stream'
+  const dispositionType = allowInline ? 'inline' : 'attachment'
 
   const safeAscii = row.filename.replace(/[^\x20-\x7E]/g, '_').replace(/"/g, '')
   const utf8Encoded = encodeURIComponent(row.filename)

--- a/apps/web/src/app/api/admin/mail/attachments/[id]/route.ts
+++ b/apps/web/src/app/api/admin/mail/attachments/[id]/route.ts
@@ -13,13 +13,25 @@ export const dynamic = 'force-dynamic'
  *
  * Mail attachments are UNTRUSTED user input from the IMAP fetcher: a hostile
  * sender can attach `text/html` or `image/svg+xml` and turn an inline preview
- * into stored XSS on the same origin as the admin UI. To prevent that:
- *   - Only `application/pdf` (sandboxed by the browser viewer) is allowed to
- *     render inline; everything else is forced to
- *     `Content-Disposition: attachment` with `Content-Type: application/octet-stream`
+ * into stored XSS on the same origin as the admin UI. Policy (blocklist):
+ *   - Known active-content MIMEs (html/xhtml/svg/xml/js) are rewritten to
+ *     `application/octet-stream` and forced to `Content-Disposition: attachment`
  *     so the browser downloads instead of executing.
+ *   - Everything else (pdf / doc / docx / xlsx / images …) is served INLINE
+ *     with its declared MIME. None of these are active content, and inline is
+ *     what lets the iOS home-screen PWA preview them via QuickLook: the
+ *     standalone in-app browser cannot hand `Content-Disposition: attachment`
+ *     to a download manager and dies on a blank page instead (Issue #138).
+ *     Desktop browsers download types they cannot render inline, so nothing
+ *     regresses there.
  *   - `X-Content-Type-Options: nosniff` is always set so the browser cannot
  *     override the declared type by sniffing the body.
+ *
+ * This mirrors the blocklist of the public
+ * `/api/line-broadcast/attachments/[token]` route (PR #70) with one deliberate
+ * difference: that route pins `attachment` for ALL types because it is
+ * unauthenticated and must never render anything same-origin, while this route
+ * is admin/vice_admin-gated and prioritizes in-PWA preview.
  *
  * Filenames are RFC 5987-encoded (`filename*=UTF-8''…`) alongside a legacy
  * `filename="…"` so non-ASCII names like "大会要項.pdf" survive proxies that
@@ -30,10 +42,26 @@ export const dynamic = 'force-dynamic'
  *   - https://datatracker.ietf.org/doc/html/rfc5987
  *   - https://datatracker.ietf.org/doc/html/rfc6266
  */
-const INLINE_ALLOWED_CONTENT_TYPES = new Set<string>([
-  'application/pdf',
-  'application/x-pdf',
+const DANGEROUS_CONTENT_TYPES = new Set<string>([
+  'text/html',
+  'application/xhtml+xml',
+  'image/svg+xml',
+  'application/svg+xml',
+  'text/xml',
+  'application/xml',
+  // application/javascript / text/javascript も念のため
+  'application/javascript',
+  'text/javascript',
 ])
+
+/**
+ * RFC 6838 token grammar に沿った `type/subtype` 形式の MIME 判定。
+ * 制御文字 / 空白 / カンマが混入した stored Content-Type をそのまま
+ * ヘッダに乗せると `new NextResponse(..., { headers })` が例外になり
+ * 500 を返してしまうため、通らない値は octet-stream + attachment に
+ * 落とす (public token route と同じパターン、pr70 r1 should_fix)。
+ */
+const SAFE_MIME_RE = /^[a-z0-9!#$&^_.+-]+\/[a-z0-9!#$&^_.+-]+$/i
 
 export async function GET(
   _req: Request,
@@ -76,16 +104,20 @@ export async function GET(
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
   }
 
-  // Strip parameters (e.g. `; charset=utf-8`) before allowlist comparison so a
-  // hostile `application/pdf; charset=utf-8\r\n…` header can't slip through and
+  // Strip parameters (e.g. `; charset=utf-8`) before blocklist comparison so a
+  // hostile `text/html; charset=utf-8\r\n…` header can't dodge the rewrite and
   // also can't header-inject — we never echo the raw value back.
   const declaredContentType = (row.contentType ?? '')
     .toLowerCase()
     .split(';')[0]
     ?.trim() ?? ''
-  const allowInline = INLINE_ALLOWED_CONTENT_TYPES.has(declaredContentType)
-  const responseContentType = allowInline ? declaredContentType : 'application/octet-stream'
-  const dispositionType = allowInline ? 'inline' : 'attachment'
+  const isDangerous = DANGEROUS_CONTENT_TYPES.has(declaredContentType)
+  const isValidMime = SAFE_MIME_RE.test(declaredContentType)
+  const forceDownload = isDangerous || !isValidMime
+  const responseContentType = forceDownload
+    ? 'application/octet-stream'
+    : declaredContentType
+  const dispositionType = forceDownload ? 'attachment' : 'inline'
 
   const safeAscii = row.filename.replace(/[^\x20-\x7E]/g, '_').replace(/"/g, '')
   const utf8Encoded = encodeURIComponent(row.filename)


### PR DESCRIPTION
## Summary
- `GET /api/admin/mail/attachments/[id]` の inline 許可 allowlist を PDF のみ → **PDF / Office 文書 (doc/docx/xls/xlsx/ppt/pptx) / ラスタ画像 (jpeg/png/gif/webp/heic/heif) / プレーンテキスト (txt/csv)** に拡張
- 上記の inert なプレビュー型は実 MIME + `Content-Disposition: inline` で配信し、iOS ホーム画面 PWA のアプリ内ブラウザで QuickLook プレビューが効くようにする（attachment 強制だと白い画面のまま死ぬ WebKit 既知挙動の回避）
- allowlist 外（html/svg/xml/js 等の active content、未知・不正な MIME すべて）は従来どおり `application/octet-stream` + `attachment` に **fail-closed**（stored XSS 防御維持。レビュー R1/R2 の指摘を反映し blocklist 案から転換）
- 応答 Content-Type は allowlist 定数か octet-stream のみで stored 値をエコーしないため、ヘッダ注入は構造的に不可能
- 公開側 `/api/line-broadcast/attachments/[token]` (PR #70) は非認証のため attachment 固定を維持（意図的な差分として route コメントに明記）
- route.test.ts を 31 ケースに拡充（doc/docx/png の inline 配信、+xml suffix・zip/ecmascript/vtt・不正 MIME 4 パターンの fail-closed degrade、html/svg の XSS 防御継続）

## Bug
Fixes #138

## Test plan
- [x] vitest: route.test.ts 31/31 pass
- [x] tsc --noEmit pass / next lint pass
- [ ] 本番反映後、iPhone ホーム画面 PWA で多摩大会 .doc 添付チップ → QuickLook プレビュー表示を実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)