### PR TITLE
feat(broadcast): 既存大会LINE配信に冒頭メッセージ（見出し）を任意追加

### DIFF
--- a/apps/web/src/app/(app)/admin/mail-inbox/actions.test.ts
+++ b/apps/web/src/app/(app)/admin/mail-inbox/actions.test.ts
@@ -1682,14 +1682,80 @@ describe('admin/mail-inbox actions', () => {
       const callArgs = (
         broadcastMailToEventMock.mock.calls[0] as unknown as [
           unknown,
-          { eventId: number; mailMessageId: number; isCorrection: boolean },
+          {
+            eventId: number
+            mailMessageId: number
+            isCorrection: boolean
+            leadText: string | null
+          },
         ]
       )
       expect(callArgs[1]).toEqual({
         eventId: event.id,
         mailMessageId: mail.id,
         isCorrection: false,
+        leadText: null,
       })
+    })
+
+    it('leadText を渡すと trim して broadcastMailToEvent に渡す', async () => {
+      const admin = await createAdmin()
+      await setAuthSession({ id: admin.id, role: 'admin' })
+      const mail = await createMailMessage({ triageStatus: 'unprocessed' })
+      const event = await createEvent({ title: '冒頭メッセージ大会' })
+
+      afterMock.mockImplementationOnce((cb) => cb())
+      broadcastMailToEventMock.mockClear()
+
+      const result = await linkMailToEvent(mail.id, event.id, '  抽選結果が出ました！  ')
+      expect(result.ok).toBe(true)
+
+      expect(broadcastMailToEventMock).toHaveBeenCalledTimes(1)
+      const callArgs = broadcastMailToEventMock.mock.calls[0] as unknown as [
+        unknown,
+        { leadText: string | null },
+      ]
+      // 前後空白は trim される。
+      expect(callArgs[1].leadText).toBe('抽選結果が出ました！')
+    })
+
+    it('201 文字以上の leadText はエラーを返し、紐付け・配信を行わない', async () => {
+      const admin = await createAdmin()
+      await setAuthSession({ id: admin.id, role: 'admin' })
+      const mail = await createMailMessage({ triageStatus: 'unprocessed' })
+      const event = await createEvent({ title: 'E' })
+
+      broadcastMailToEventMock.mockClear()
+
+      const result = await linkMailToEvent(mail.id, event.id, 'あ'.repeat(201))
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.error).toMatch(/200文字以内/)
+
+      // 紐付け・triage 更新・配信のいずれも起きない。
+      const after = await getMail(mail.id)
+      expect(after?.linkedEventId).toBeNull()
+      expect(after?.triageStatus).toBe('unprocessed')
+      expect(broadcastMailToEventMock).not.toHaveBeenCalled()
+    })
+
+    it('空白のみの leadText は null 扱いで配信される (冒頭なし)', async () => {
+      const admin = await createAdmin()
+      await setAuthSession({ id: admin.id, role: 'admin' })
+      const mail = await createMailMessage({ triageStatus: 'unprocessed' })
+      const event = await createEvent({ title: 'E' })
+
+      afterMock.mockImplementationOnce((cb) => cb())
+      broadcastMailToEventMock.mockClear()
+
+      const result = await linkMailToEvent(mail.id, event.id, '   ')
+      expect(result.ok).toBe(true)
+
+      const callArgs = broadcastMailToEventMock.mock.calls[0] as unknown as [
+        unknown,
+        { leadText: string | null },
+      ]
+      expect(callArgs[1].leadText).toBeNull()
     })
 
     // Codex r5 should-fix: UI 候補条件 (cancelled 除外 / 過去 30 日以内) を

--- a/apps/web/src/app/(app)/admin/mail-inbox/actions.ts
+++ b/apps/web/src/app/(app)/admin/mail-inbox/actions.ts
@@ -19,6 +19,7 @@ import {
   extractEventUnitsFormData,
 } from '@/lib/form-schemas'
 import { broadcastMailToEvent, loadActiveBinding } from '@/lib/line-broadcast'
+import { LEAD_TEXT_MAX_LENGTH } from '@/lib/broadcast-lead-presets'
 import {
   linkableEventCutoffStr,
   validateLinkableEvent,
@@ -1029,8 +1030,16 @@ export async function triggerExtractDraft(
 export async function linkMailToEvent(
   mailId: number,
   eventId: number,
+  leadText?: string | null,
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   const session = await requireAdminSession()
+
+  // 冒頭メッセージ (任意)。trim 後空なら null、200 字超は紐付け前に弾く
+  // (紐付け・配信とも実行しない)。
+  const normalizedLeadText = leadText?.trim() || null
+  if (normalizedLeadText && normalizedLeadText.length > LEAD_TEXT_MAX_LENGTH) {
+    return { ok: false, error: '冒頭メッセージは200文字以内で入力してください' }
+  }
 
   let linkedMailMessageId: number | null = null
 
@@ -1128,6 +1137,7 @@ export async function linkMailToEvent(
           eventId,
           mailMessageId: messageId,
           isCorrection: false,
+          leadText: normalizedLeadText,
         })
       } catch (err) {
         console.error('[linkMailToEvent] broadcastMailToEvent failed', err)

--- a/apps/web/src/app/(app)/admin/mail-inbox/components/ExistingEventLinkSheet.test.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/components/ExistingEventLinkSheet.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { ExistingEventLinkSheet, type LinkableEventOption } from './ExistingEventLinkSheet'
+import { linkMailToEvent } from '../actions'
+
+// Server Action と router は副作用なので mock。leadText が action に正しく
+// 渡るかを呼び出し引数で検証する。
+vi.mock('../actions', () => ({ linkMailToEvent: vi.fn() }))
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }))
+
+const linkMailToEventMock = vi.mocked(linkMailToEvent)
+
+const events: LinkableEventOption[] = [
+  { id: 1, title: '春季大会', eventDate: '2030-05-01', status: 'published' },
+]
+
+function openSheet() {
+  render(<ExistingEventLinkSheet mailId={10} events={events} />)
+  // 開く前はトリガーボタンのみ「既存イベントに紐付ける」テキストを持つ。
+  fireEvent.click(screen.getByText('既存イベントに紐付ける'))
+}
+
+describe('ExistingEventLinkSheet — 冒頭メッセージ', () => {
+  beforeEach(() => {
+    linkMailToEventMock.mockReset()
+    linkMailToEventMock.mockResolvedValue({ ok: true })
+  })
+
+  it('プリセットチップをクリックすると textarea に文言が流し込まれる', () => {
+    openSheet()
+    fireEvent.click(screen.getByText('抽選結果が出ました！'))
+    const textarea = screen.getByPlaceholderText(
+      '例: 抽選結果が出ました！',
+    ) as HTMLTextAreaElement
+    expect(textarea.value).toBe('抽選結果が出ました！')
+  })
+
+  it('入力した leadText は trim されて linkMailToEvent に渡る', async () => {
+    openSheet()
+    fireEvent.click(screen.getByLabelText(/春季大会/))
+    const textarea = screen.getByPlaceholderText('例: 抽選結果が出ました！')
+    fireEvent.change(textarea, { target: { value: '  組合せが出ました！  ' } })
+    fireEvent.click(screen.getByText('結びつける'))
+
+    await waitFor(() => {
+      expect(linkMailToEventMock).toHaveBeenCalledWith(10, 1, '組合せが出ました！')
+    })
+  })
+
+  it('冒頭メッセージ空欄でも送信でき、leadText=null で渡る', async () => {
+    openSheet()
+    fireEvent.click(screen.getByLabelText(/春季大会/))
+    fireEvent.click(screen.getByText('結びつける'))
+
+    await waitFor(() => {
+      expect(linkMailToEventMock).toHaveBeenCalledWith(10, 1, null)
+    })
+  })
+
+  it('再オープン時に前回入力した leadText はリセットされる', () => {
+    render(<ExistingEventLinkSheet mailId={10} events={events} />)
+    fireEvent.click(screen.getByText('既存イベントに紐付ける'))
+    fireEvent.click(screen.getByText('会場・アクセスのご案内'))
+    expect(
+      (screen.getByPlaceholderText('例: 抽選結果が出ました！') as HTMLTextAreaElement)
+        .value,
+    ).toBe('会場・アクセスのご案内')
+    // キャンセルで閉じて再オープン → 空に戻る。
+    fireEvent.click(screen.getByText('キャンセル'))
+    fireEvent.click(screen.getByText('既存イベントに紐付ける'))
+    expect(
+      (screen.getByPlaceholderText('例: 抽選結果が出ました！') as HTMLTextAreaElement)
+        .value,
+    ).toBe('')
+  })
+})

--- a/apps/web/src/app/(app)/admin/mail-inbox/components/ExistingEventLinkSheet.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/components/ExistingEventLinkSheet.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
 import { Btn, Card } from '@/components/ui'
 import { linkMailToEvent } from '../actions'
+import { BROADCAST_LEAD_PRESETS, LEAD_TEXT_MAX_LENGTH } from '@/lib/broadcast-lead-presets'
 
 /**
  * mail-inbox-mailer タスク4: 既存イベント結びつけ用のボトムシート。
@@ -38,6 +39,7 @@ export function ExistingEventLinkSheet({
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState('')
   const [selectedId, setSelectedId] = useState<number | null>(null)
+  const [leadText, setLeadText] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [pending, startTransition] = useTransition()
   const router = useRouter()
@@ -48,6 +50,7 @@ export function ExistingEventLinkSheet({
       setQuery('')
       setSelectedId(null)
       setError(null)
+      setLeadText('')
     }
   }, [open])
 
@@ -62,7 +65,7 @@ export function ExistingEventLinkSheet({
     const eventId = selectedId
     setError(null)
     startTransition(async () => {
-      const result = await linkMailToEvent(mailId, eventId)
+      const result = await linkMailToEvent(mailId, eventId, leadText.trim() || null)
       if (!result.ok) {
         setError(result.error)
         return
@@ -145,6 +148,36 @@ export function ExistingEventLinkSheet({
                   )
                 })
               )}
+            </div>
+
+            {/* 冒頭メッセージ（任意）: LINE 配信の先頭に付ける見出し。
+                プリセットチップはタップで textarea に流し込む（上書き）。 */}
+            <div className="mt-3 flex flex-col gap-1.5">
+              <span className="text-xs font-medium text-ink">
+                冒頭メッセージ（任意）
+              </span>
+              <div className="flex flex-wrap gap-1">
+                {BROADCAST_LEAD_PRESETS.map((preset) => (
+                  <button
+                    key={preset}
+                    type="button"
+                    onClick={() => setLeadText(preset)}
+                    disabled={pending}
+                    className="rounded-full border border-border-soft bg-surface px-2 py-0.5 text-xs text-ink-meta hover:bg-brand-bg hover:text-ink disabled:opacity-50"
+                  >
+                    {preset}
+                  </button>
+                ))}
+              </div>
+              <textarea
+                value={leadText}
+                onChange={(e) => setLeadText(e.target.value)}
+                maxLength={LEAD_TEXT_MAX_LENGTH}
+                rows={2}
+                placeholder="例: 抽選結果が出ました！"
+                disabled={pending}
+                className="rounded border border-border-soft bg-surface px-2 py-1.5 text-sm text-ink placeholder:text-ink-meta"
+              />
             </div>
 
             {error && (

--- a/apps/web/src/app/(app)/events/[id]/actions.test.ts
+++ b/apps/web/src/app/(app)/events/[id]/actions.test.ts
@@ -1,17 +1,39 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { and, eq } from 'drizzle-orm'
-import { eventAttendances } from '@kagetra/shared/schema'
+import {
+  eventAttendances,
+  eventBroadcastMessages,
+  eventLineBroadcasts,
+  lineChannels,
+  mailMessages,
+} from '@kagetra/shared/schema'
 import { closeTestDb, testDb, truncateAll } from '@/test-utils/db'
 import { createAdmin, createEvent, createUser } from '@/test-utils/seed'
 import { mockAuthModule, setAuthSession } from '@/test-utils/auth-mock'
+
+const { broadcastMailToEventMock } = vi.hoisted(() => ({
+  broadcastMailToEventMock: vi.fn(async () => ({
+    status: 'sent' as const,
+    sentLeadCount: 0,
+    sentTextCount: 0,
+    sentImageCount: 0,
+    fallbackLinkCount: 0,
+  })),
+}))
 
 vi.mock('@/auth', () => mockAuthModule())
 vi.mock('next/cache', () => ({
   revalidatePath: vi.fn(),
 }))
+// manualBroadcast の再配信検証用。実配信 (LINE push) はテスト対象外なので
+// broadcastMailToEvent をモックし、継承された引数 (leadText / isCorrection /
+// force) を検証する。
+vi.mock('@/lib/line-broadcast', () => ({
+  broadcastMailToEvent: broadcastMailToEventMock,
+}))
 
 // Import under test AFTER mocks so @/auth resolution uses the mock.
-const { submitAttendance } = await import('./actions')
+const { submitAttendance, manualBroadcast } = await import('./actions')
 
 function formWith(attend: boolean, comment?: string): FormData {
   const fd = new FormData()
@@ -29,12 +51,64 @@ async function getAttendance(eventId: number, userId: string) {
   })
 }
 
+// 全 describe 共有の test DB プールはファイル単位で 1 回だけ閉じる
+// (describe ごとに閉じると pg Pool.end() の二重呼び出しでエラーになる)。
+afterAll(async () => {
+  await closeTestDb()
+})
+
+// broadcast 監査行 (lead_text 入り) を seed して manualBroadcast の継承を検証する。
+async function seedBroadcastAuditRow(opts: {
+  leadText: string | null
+}): Promise<{ eventId: number; mailMessageId: number }> {
+  const channelRows = await testDb
+    .insert(lineChannels)
+    .values({
+      channelId: `ch-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      channelSecret: 'secret',
+      channelAccessToken: 'token',
+      botId: '@bot-test',
+      purpose: 'event_broadcast',
+      status: 'active',
+    })
+    .returning({ id: lineChannels.id })
+  const event = await createEvent({ title: '再配信大会' })
+  const broadcastRows = await testDb
+    .insert(eventLineBroadcasts)
+    .values({
+      eventId: event.id,
+      lineChannelId: channelRows[0]!.id,
+      status: 'linked',
+      lineGroupId: 'C123456789',
+      linkedAt: new Date(),
+    })
+    .returning({ id: eventLineBroadcasts.id })
+  const mailRows = await testDb
+    .insert(mailMessages)
+    .values({
+      messageId: `m-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      fromAddress: 'organiser@example.com',
+      toAddresses: ['admin@kagetra'],
+      subject: '補足連絡',
+      receivedAt: new Date(),
+      bodyText: '補足本文',
+      status: 'ai_done',
+    })
+    .returning({ id: mailMessages.id })
+  await testDb.insert(eventBroadcastMessages).values({
+    eventLineBroadcastId: broadcastRows[0]!.id,
+    mailMessageId: mailRows[0]!.id,
+    status: 'sent',
+    isCorrection: false,
+    leadText: opts.leadText,
+    sentLeadCount: opts.leadText ? 1 : 0,
+  })
+  return { eventId: event.id, mailMessageId: mailRows[0]!.id }
+}
+
 describe('submitAttendance — permission control', () => {
   beforeEach(async () => {
     await truncateAll()
-  })
-  afterAll(async () => {
-    await closeTestDb()
   })
 
   it('一般会員: isInvited=false では回答不可', async () => {
@@ -110,5 +184,58 @@ describe('submitAttendance — permission control', () => {
       attend: false,
       comment: 'keep me',
     })
+  })
+})
+
+describe('manualBroadcast — lead text inheritance', () => {
+  beforeEach(async () => {
+    await truncateAll()
+    broadcastMailToEventMock.mockClear()
+  })
+
+  it('保存済み lead_text を継承して再送する', async () => {
+    const admin = await createAdmin()
+    await setAuthSession({ id: admin.id, role: 'admin' })
+    const { eventId, mailMessageId } = await seedBroadcastAuditRow({
+      leadText: '抽選結果が出ました！',
+    })
+
+    await manualBroadcast(eventId, mailMessageId)
+
+    expect(broadcastMailToEventMock).toHaveBeenCalledTimes(1)
+    const callArgs = broadcastMailToEventMock.mock.calls[0] as unknown as [
+      unknown,
+      {
+        eventId: number
+        mailMessageId: number
+        isCorrection: boolean
+        leadText: string | null
+        force?: boolean
+      },
+    ]
+    expect(callArgs[1]).toMatchObject({
+      eventId,
+      mailMessageId,
+      isCorrection: false,
+      leadText: '抽選結果が出ました！',
+      force: true,
+    })
+  })
+
+  it('lead_text=null の行は冒頭なしで再送する (従来挙動)', async () => {
+    const admin = await createAdmin()
+    await setAuthSession({ id: admin.id, role: 'admin' })
+    const { eventId, mailMessageId } = await seedBroadcastAuditRow({
+      leadText: null,
+    })
+
+    await manualBroadcast(eventId, mailMessageId)
+
+    expect(broadcastMailToEventMock).toHaveBeenCalledTimes(1)
+    const callArgs = broadcastMailToEventMock.mock.calls[0] as unknown as [
+      unknown,
+      { leadText: string | null },
+    ]
+    expect(callArgs[1].leadText).toBeNull()
   })
 })

--- a/apps/web/src/app/(app)/events/[id]/actions.ts
+++ b/apps/web/src/app/(app)/events/[id]/actions.ts
@@ -357,12 +357,14 @@ export async function manualBroadcast(
 ): Promise<void> {
   await requireAdminSession()
 
-  // Look up the existing audit row (if any) to inherit the correction flag.
-  // Manual rebroadcast should preserve whether the underlying mail was a
-  // correction so the 【訂正】 prefix stays consistent across retries.
+  // Look up the existing audit row (if any) to inherit the correction flag
+  // and the saved lead heading. Manual rebroadcast should preserve whether
+  // the underlying mail was a correction (so the 【訂正】 prefix stays
+  // consistent) and re-send the original 冒頭メッセージ verbatim.
   const existing = await db
     .select({
       isCorrection: eventBroadcastMessages.isCorrection,
+      leadText: eventBroadcastMessages.leadText,
     })
     .from(eventBroadcastMessages)
     .innerJoin(
@@ -381,6 +383,8 @@ export async function manualBroadcast(
     eventId,
     mailMessageId,
     isCorrection: existing[0]?.isCorrection ?? false,
+    // 保存済み冒頭メッセージを継承して再送する (isCorrection 継承と同じパターン)。
+    leadText: existing[0]?.leadText ?? null,
     // r-final-3 should_fix: manualBroadcast は UI からの「再配信」操作な
     // ので、status='sent' でも skip せず強制送信する。自動配信ループ
     // (approveDraft / linkDraftToEvent) では force を立てないため、

--- a/apps/web/src/lib/broadcast-lead-presets.test.ts
+++ b/apps/web/src/lib/broadcast-lead-presets.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { BROADCAST_LEAD_PRESETS, LEAD_TEXT_MAX_LENGTH } from './broadcast-lead-presets'
+
+describe('broadcast-lead-presets', () => {
+  it('LEAD_TEXT_MAX_LENGTH は 200', () => {
+    expect(LEAD_TEXT_MAX_LENGTH).toBe(200)
+  })
+
+  it('プリセットは要件の 6 件で、重複が無い', () => {
+    expect(BROADCAST_LEAD_PRESETS).toHaveLength(6)
+    expect(new Set(BROADCAST_LEAD_PRESETS).size).toBe(BROADCAST_LEAD_PRESETS.length)
+  })
+
+  it('全プリセットが trim 後 1〜LEAD_TEXT_MAX_LENGTH 文字に収まる', () => {
+    for (const preset of BROADCAST_LEAD_PRESETS) {
+      const len = preset.trim().length
+      expect(len).toBeGreaterThanOrEqual(1)
+      expect(len).toBeLessThanOrEqual(LEAD_TEXT_MAX_LENGTH)
+      // 前後空白を持たない（チップ流し込み時に意図せぬ空白を避ける）
+      expect(preset).toBe(preset.trim())
+    }
+  })
+})

--- a/apps/web/src/lib/broadcast-lead-presets.ts
+++ b/apps/web/src/lib/broadcast-lead-presets.ts
@@ -1,0 +1,24 @@
+/**
+ * 既存大会への LINE 配信（manual existing-event link）に任意で付ける冒頭
+ * 見出しテキストのプリセット。連絡内容（抽選結果・組合せ・OC 案内…）は毎回
+ * 変わるため固定文言では不十分だが、身内アプリゆえ DB 管理＋CRUD 画面は過剰。
+ * コード定数として持ち、文言の増減・修正は小 PR で対応する。
+ *
+ * client（ExistingEventLinkSheet のチップ）と server（linkMailToEvent の
+ * 長さ検証）双方から import するため、server-only な依存を持ち込まないこと。
+ */
+export const BROADCAST_LEAD_PRESETS = [
+  '抽選結果が出ました！',
+  '組合せ（対戦表）が出ました！',
+  '大会専用オープンチャットのお知らせ',
+  'タイムテーブル・進行のご案内',
+  '会場・アクセスのご案内',
+  'その他のご連絡',
+] as const
+
+/**
+ * 冒頭メッセージの最大長（trim 後）。LINE テキストメッセージ上限 5000 文字に
+ * 対し十分小さく、分割不要。client の textarea maxLength と server の長さ検証で
+ * 共有する。
+ */
+export const LEAD_TEXT_MAX_LENGTH = 200

--- a/apps/web/src/lib/line-broadcast.test.ts
+++ b/apps/web/src/lib/line-broadcast.test.ts
@@ -389,4 +389,112 @@ describe('broadcastMailToEvent', () => {
     })
     expect(row?.isCorrection).toBe(true)
   })
+
+  // --- 冒頭メッセージ (lead text, broadcast-lead-message) ---
+
+  it('saves leadText and counts it as sent_lead_count=1', async () => {
+    const fx = await buildLinkedFixture()
+    const result = await broadcastMailToEvent(db, {
+      eventId: fx.eventId,
+      mailMessageId: fx.mailMessageId,
+      isCorrection: false,
+      leadText: '組合せ（対戦表）が出ました！',
+    })
+    expect(result.status).toBe('sent')
+    expect(result.sentLeadCount).toBe(1)
+    // 本文画像 1 ページはそのまま配信される。
+    expect(result.sentImageCount).toBe(1)
+
+    const row = await db.query.eventBroadcastMessages.findFirst({
+      where: eq(eventBroadcastMessages.mailMessageId, fx.mailMessageId),
+    })
+    expect(row?.leadText).toBe('組合せ（対戦表）が出ました！')
+    expect(row?.sentLeadCount).toBe(1)
+  })
+
+  it('adds no lead message when leadText is empty or whitespace-only', async () => {
+    const fx = await buildLinkedFixture()
+    const result = await broadcastMailToEvent(db, {
+      eventId: fx.eventId,
+      mailMessageId: fx.mailMessageId,
+      isCorrection: false,
+      leadText: '   ',
+    })
+    expect(result.status).toBe('sent')
+    expect(result.sentLeadCount).toBe(0)
+    expect(result.sentImageCount).toBe(1)
+
+    const row = await db.query.eventBroadcastMessages.findFirst({
+      where: eq(eventBroadcastMessages.mailMessageId, fx.mailMessageId),
+    })
+    // trim 後空なので保存もしない (従来挙動を完全維持)。
+    expect(row?.leadText).toBeNull()
+    expect(row?.sentLeadCount).toBe(0)
+  })
+
+  it('prepends leadText and sends in lead → body image → attachment link order', async () => {
+    const fx = await buildLinkedFixture()
+    await addAttachment(fx.mailMessageId, 'shiori.pdf', 'application/pdf')
+
+    // 送信順を検証するため DRY_RUN を一時解除し、fetch ペイロードを捕捉する。
+    const prevDryRun = process.env.LINE_NOTIFY_DRY_RUN
+    delete process.env.LINE_NOTIFY_DRY_RUN
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 200 }))
+    try {
+      const result = await broadcastMailToEvent(db, {
+        eventId: fx.eventId,
+        mailMessageId: fx.mailMessageId,
+        isCorrection: false,
+        leadText: '抽選結果が出ました！',
+      })
+      expect(result.status).toBe('sent')
+      expect(result.sentLeadCount).toBe(1)
+      expect(result.sentImageCount).toBe(1)
+      expect(result.fallbackLinkCount).toBe(1)
+      expect(result.sentTextCount).toBe(0)
+
+      const sentMessages = fetchSpy.mock.calls.flatMap(([, init]) => {
+        const body = JSON.parse(String(init?.body)) as {
+          messages: Array<{ type: string; text?: string }>
+        }
+        return body.messages
+      })
+      expect(sentMessages).toHaveLength(3)
+      // 先頭は冒頭テキスト、続いて本文画像、最後に添付リンク。
+      expect(sentMessages[0]).toEqual({ type: 'text', text: '抽選結果が出ました！' })
+      expect(sentMessages[1]?.type).toBe('image')
+      expect(sentMessages[2]?.type).toBe('text')
+      expect(sentMessages[2]?.text).toContain('📎 shiori.pdf')
+    } finally {
+      fetchSpy.mockRestore()
+      if (prevDryRun != null) process.env.LINE_NOTIFY_DRY_RUN = prevDryRun
+    }
+  })
+
+  it('sends only the lead message when body and attachments are empty (no placeholder)', async () => {
+    const fx = await buildLinkedFixture()
+    // 件名・本文を空にし、本文画像も 0 ページ → text fallback も空配列 →
+    // body メッセージ 0 件。添付も無い。
+    await db
+      .update(mailMessages)
+      .set({ subject: '', bodyText: '' })
+      .where(eq(mailMessages.id, fx.mailMessageId))
+    renderBodyImageMock.mockResolvedValueOnce({ pages: [], truncated: false })
+
+    const result = await broadcastMailToEvent(db, {
+      eventId: fx.eventId,
+      mailMessageId: fx.mailMessageId,
+      isCorrection: false,
+      leadText: 'タイムテーブル・進行のご案内',
+    })
+    expect(result.status).toBe('sent')
+    expect(result.sentLeadCount).toBe(1)
+    // lead が messages を非空にするので '(本文・添付ともになし)' プレース
+    // ホルダ (body_text) は出ない。本文・画像・添付はいずれも 0。
+    expect(result.sentTextCount).toBe(0)
+    expect(result.sentImageCount).toBe(0)
+    expect(result.fallbackLinkCount).toBe(0)
+  })
 })

--- a/apps/web/src/lib/line-broadcast.ts
+++ b/apps/web/src/lib/line-broadcast.ts
@@ -76,6 +76,7 @@ const NOOP_LOGGER = { info: () => undefined, warn: () => undefined }
 export interface BroadcastResult {
   status: 'sent' | 'partial' | 'failed' | 'skipped'
   reason?: string
+  sentLeadCount: number
   sentTextCount: number
   sentImageCount: number
   fallbackLinkCount: number
@@ -449,6 +450,14 @@ export async function broadcastMailToEvent(
     mailMessageId: number
     isCorrection: boolean
     /**
+     * 任意の冒頭見出しテキスト (broadcast-lead-message)。手動の
+     * linkMailToEvent / manualBroadcast 経由でのみ渡る。trim 後非空なら
+     * LINE メッセージ列の先頭に text 1 通として差し込み、監査行 (lead_text)
+     * に保存する。AI 下書き自動配信・訂正下書き紐付けでは undefined/null で
+     * 挙動不変。空・空白のみは null 扱い (付けない)。
+     */
+    leadText?: string | null
+    /**
      * 強制再送フラグ。manualBroadcast (UI からの再配信操作) で true を
      * 渡すと、status='sent' な mail でも skip せず再送する。
      * approveDraft / linkDraftToEvent / 自動配信トリガーでは false の
@@ -470,11 +479,16 @@ export async function broadcastMailToEvent(
   }
   const logger = options.logger ?? NOOP_LOGGER
 
+  // 冒頭見出しテキスト (任意)。trim 後空なら null = 保存も配信もしない。
+  // 差し込むのは手動の linkMailToEvent / manualBroadcast 経由のみ。
+  const leadText = args.leadText?.trim() || null
+
   const binding = await loadActiveBinding(db, args.eventId)
   if (!binding) {
     return {
       status: 'skipped',
       reason: 'no_active_binding',
+      sentLeadCount: 0,
       sentTextCount: 0,
       sentImageCount: 0,
       fallbackLinkCount: 0,
@@ -489,6 +503,7 @@ export async function broadcastMailToEvent(
     return {
       status: 'failed',
       reason: 'mail_not_found',
+      sentLeadCount: 0,
       sentTextCount: 0,
       sentImageCount: 0,
       fallbackLinkCount: 0,
@@ -527,6 +542,7 @@ export async function broadcastMailToEvent(
   //   - fallbackLinkCount: 添付の URL リンク (role='attachment_link')
   const existingAudit = await db
     .select({
+      sentLeadCount: eventBroadcastMessages.sentLeadCount,
       sentTextCount: eventBroadcastMessages.sentTextCount,
       sentImageCount: eventBroadcastMessages.sentImageCount,
       fallbackLinkCount: eventBroadcastMessages.fallbackLinkCount,
@@ -554,6 +570,7 @@ export async function broadcastMailToEvent(
     return {
       status: 'skipped',
       reason: 'already_sent',
+      sentLeadCount: existingAudit[0].sentLeadCount,
       sentTextCount: existingAudit[0].sentTextCount,
       sentImageCount: existingAudit[0].sentImageCount,
       fallbackLinkCount: existingAudit[0].fallbackLinkCount,
@@ -581,6 +598,7 @@ export async function broadcastMailToEvent(
       return {
         status: 'skipped',
         reason: 'already_in_progress',
+        sentLeadCount: existingAudit[0].sentLeadCount,
         sentTextCount: existingAudit[0].sentTextCount,
         sentImageCount: existingAudit[0].sentImageCount,
         fallbackLinkCount: existingAudit[0].fallbackLinkCount,
@@ -603,7 +621,8 @@ export async function broadcastMailToEvent(
   // でも sent*Count があれば skip prefix として使う。さもないと次の自動
   // 配信が先頭から再送して LINE に重複配信になる。
   const deliveredCount = existingAudit[0]
-    ? existingAudit[0].sentTextCount +
+    ? existingAudit[0].sentLeadCount +
+      existingAudit[0].sentTextCount +
       existingAudit[0].sentImageCount +
       existingAudit[0].fallbackLinkCount
     : 0
@@ -622,6 +641,7 @@ export async function broadcastMailToEvent(
       mailMessageId: args.mailMessageId,
       status: 'sending',
       isCorrection: args.isCorrection,
+      leadText,
     })
     .onConflictDoUpdate({
       target: [
@@ -631,6 +651,7 @@ export async function broadcastMailToEvent(
       set: {
         status: 'sending',
         isCorrection: args.isCorrection,
+        leadText,
         errorMessage: null,
         updatedAt: sql`now()`,
       },
@@ -660,6 +681,7 @@ export async function broadcastMailToEvent(
     return {
       status: 'skipped',
       reason: 'already_in_progress',
+      sentLeadCount: existingAudit[0]?.sentLeadCount ?? 0,
       sentTextCount: existingAudit[0]?.sentTextCount ?? 0,
       sentImageCount: existingAudit[0]?.sentImageCount ?? 0,
       fallbackLinkCount: existingAudit[0]?.fallbackLinkCount ?? 0,
@@ -681,9 +703,16 @@ export async function broadcastMailToEvent(
     //
     // roles は実際の送信順 metadata。partial 再送時に deliveredCount 分だけ
     // role 別カウントを正しく残すために message と並走させる (rr1 review)。
-    type MessageRole = 'body_image' | 'body_text' | 'attachment_link'
+    type MessageRole = 'lead_text' | 'body_image' | 'body_text' | 'attachment_link'
     const messages: LineMessage[] = []
     const roles: MessageRole[] = []
+
+    // 冒頭見出し (任意) を最優先で先頭に積む。ビルド順を lead → body →
+    // attachment に固定するため body/attachment 構築より前で push する。
+    if (leadText) {
+      messages.push({ type: 'text', text: leadText })
+      roles.push('lead_text')
+    }
 
     let bodyImageMessages: LineMessage[] = []
     try {
@@ -766,6 +795,7 @@ export async function broadcastMailToEvent(
     // 別物なので partial スキップを諦めて全件再送に切り替える。
     let effectivePreviouslyDelivered = previouslyDelivered
     if (previouslyDelivered > 0 && existingAudit[0]) {
+      const currentLeadCount = roles.filter((r) => r === 'lead_text').length
       const currentTextCount = roles.filter((r) => r === 'body_text').length
       const currentImageCount = roles.filter(
         (r) => r === 'body_image',
@@ -774,6 +804,7 @@ export async function broadcastMailToEvent(
         (r) => r === 'attachment_link',
       ).length
       const layoutShrunk =
+        existingAudit[0].sentLeadCount > currentLeadCount ||
         existingAudit[0].sentTextCount > currentTextCount ||
         existingAudit[0].sentImageCount > currentImageCount ||
         existingAudit[0].fallbackLinkCount > currentLinkCount
@@ -781,6 +812,8 @@ export async function broadcastMailToEvent(
         logger.warn('partial layout shrunk between sends; falling back to full re-send', {
           eventId: args.eventId,
           mailMessageId: args.mailMessageId,
+          previousLead: existingAudit[0].sentLeadCount,
+          currentLead: currentLeadCount,
           previousText: existingAudit[0].sentTextCount,
           currentText: currentTextCount,
           previousImage: existingAudit[0].sentImageCount,
@@ -827,6 +860,7 @@ export async function broadcastMailToEvent(
       return {
         status: 'skipped',
         reason: 'binding_changed',
+        sentLeadCount: 0,
         sentTextCount: 0,
         sentImageCount: 0,
         fallbackLinkCount: 0,
@@ -864,11 +898,15 @@ export async function broadcastMailToEvent(
 
     // 実際の送信順 (`roles`) に沿って累計 deliveredCount 件を数える。
     // image / fallback link が交互に並んでも正しいカウント (rr1 review)。
+    let deliveredLead = 0
     let deliveredText = 0
     let deliveredImage = 0
     let deliveredFallback = 0
     for (let i = 0; i < totalDelivered && i < roles.length; i++) {
       switch (roles[i]) {
+        case 'lead_text':
+          deliveredLead++
+          break
         case 'body_text':
           deliveredText++
           break
@@ -885,6 +923,7 @@ export async function broadcastMailToEvent(
       .update(eventBroadcastMessages)
       .set({
         status: finalStatus,
+        sentLeadCount: deliveredLead,
         sentTextCount: deliveredText,
         sentImageCount: deliveredImage,
         fallbackLinkCount: deliveredFallback,
@@ -1033,6 +1072,7 @@ export async function broadcastMailToEvent(
     return {
       status: finalStatus,
       reason: pushResult.error?.message,
+      sentLeadCount: deliveredLead,
       sentTextCount: deliveredText,
       sentImageCount: deliveredImage,
       fallbackLinkCount: deliveredFallback,
@@ -1062,6 +1102,7 @@ export async function broadcastMailToEvent(
     return {
       status: 'failed',
       reason: errorMessage,
+      sentLeadCount: existingAudit[0]?.sentLeadCount ?? 0,
       sentTextCount: existingAudit[0]?.sentTextCount ?? 0,
       sentImageCount: existingAudit[0]?.sentImageCount ?? 0,
       fallbackLinkCount: existingAudit[0]?.fallbackLinkCount ?? 0,

--- a/docs/features/broadcast-lead-message/implementation-plan.md
+++ b/docs/features/broadcast-lead-message/implementation-plan.md
@@ -33,7 +33,7 @@ status: completed
 - **対応Issue:** #150
 
 ### タスク3: broadcastMailToEvent に冒頭テキスト対応（バックエンド中核）
-- [ ] 完了
+- [x] 完了
 - **概要:** 配信オーケストレーションに `leadText` を導入。先頭に text メッセージを 1 通追加し、保存・role別カウント・partial 再送 skip を lead 対応にする。
 - **変更対象ファイル:**
   - `apps/web/src/lib/line-broadcast.ts`

--- a/docs/features/broadcast-lead-message/implementation-plan.md
+++ b/docs/features/broadcast-lead-message/implementation-plan.md
@@ -56,7 +56,7 @@ status: completed
 - **対応Issue:** #151
 
 ### タスク4: linkMailToEvent に leadText を通す＋バリデート
-- [ ] 完了
+- [x] 完了
 - **概要:** 手動紐付け配信の入口に `leadText` 引数を追加し、trim/長さ検証して broadcast に渡す。
 - **変更対象ファイル:**
   - `apps/web/src/app/(app)/admin/mail-inbox/actions.ts` — `linkMailToEvent(mailId, eventId, leadText?: string | null)`。

--- a/docs/features/broadcast-lead-message/implementation-plan.md
+++ b/docs/features/broadcast-lead-message/implementation-plan.md
@@ -71,7 +71,7 @@ status: completed
 - **対応Issue:** #152
 
 ### タスク5: manualBroadcast で leadText を継承
-- [ ] 完了
+- [x] 完了
 - **概要:** イベント画面からの再配信で、保存済み `lead_text` を監査行から継承して再送する（isCorrection 継承と同じ）。
 - **変更対象ファイル:**
   - `apps/web/src/app/(app)/events/[id]/actions.ts` — `manualBroadcast` の既存監査行 SELECT に `leadText` を追加し、

--- a/docs/features/broadcast-lead-message/implementation-plan.md
+++ b/docs/features/broadcast-lead-message/implementation-plan.md
@@ -84,7 +84,7 @@ status: completed
 - **対応Issue:** #153
 
 ### タスク6: ExistingEventLinkSheet に冒頭メッセージ欄
-- [ ] 完了
+- [x] 完了
 - **概要:** 紐付けシートに「冒頭メッセージ（任意）」UI（プリセットチップ＋編集可能欄）を追加し、leadText を action に渡す。
 - **変更対象ファイル:**
   - `apps/web/src/app/(app)/admin/mail-inbox/components/ExistingEventLinkSheet.tsx` —

--- a/docs/features/broadcast-lead-message/implementation-plan.md
+++ b/docs/features/broadcast-lead-message/implementation-plan.md
@@ -23,7 +23,7 @@ status: completed
 - **対応Issue:** #149
 
 ### タスク2: プリセット定数ファイル
-- [ ] 完了
+- [x] 完了
 - **概要:** 冒頭テキストのプリセットと最大長を定数化（コード固定）。client/server 双方から import 可能にする。
 - **変更対象ファイル:**
   - `apps/web/src/lib/broadcast-lead-presets.ts`（新規）— `export const BROADCAST_LEAD_PRESETS = [...] as const`

--- a/docs/features/broadcast-lead-message/implementation-plan.md
+++ b/docs/features/broadcast-lead-message/implementation-plan.md
@@ -1,0 +1,117 @@
+---
+status: completed
+---
+# broadcast-lead-message 実装手順書
+
+既存大会への LINE 配信に「冒頭テキスト（見出し）」を任意で付ける機能。テストファースト
+（CLAUDE.md ルール 2）で、各タスクは「テスト追加 → 実装 → green 確認」の順に進める。
+ローカルの vitest は `--no-file-parallelism` で実行（test DB のクロックドリフト回避）。
+
+## 実装タスク
+
+### タスク1: DB スキーマ＋マイグレーション
+- [x] 完了
+- **概要:** `event_broadcast_messages` に冒頭テキスト保存用の 2 カラムを追加し、マイグレーションを生成する。
+- **変更対象ファイル:**
+  - `packages/shared/src/schema/event-broadcast-messages.ts` — `leadText: text('lead_text')`（nullable）と
+    `sentLeadCount: integer('sent_lead_count').notNull().default(0)` を追加。doc コメントの counters 説明にも lead を追記。
+  - `packages/shared/drizzle/0025_*.sql` — `pnpm --filter @kagetra/shared db:generate` で自動生成（`ADD COLUMN` 2 本）。
+  - `packages/shared/drizzle/meta/_journal.json` ほか meta — generate で自動更新。
+- **依存タスク:** なし
+- **完了条件:** `db:generate` で 0025 が出力され、`db:migrate`（または test DB push）が通る。型チェック green。
+  既存行が `lead_text=NULL`/`sent_lead_count=0` になることを確認（後方互換）。
+- **対応Issue:** #149
+
+### タスク2: プリセット定数ファイル
+- [ ] 完了
+- **概要:** 冒頭テキストのプリセットと最大長を定数化（コード固定）。client/server 双方から import 可能にする。
+- **変更対象ファイル:**
+  - `apps/web/src/lib/broadcast-lead-presets.ts`（新規）— `export const BROADCAST_LEAD_PRESETS = [...] as const`
+    （要件 §3.1 の 6 件）と `export const LEAD_TEXT_MAX_LENGTH = 200`。server-only import を含めないこと。
+- **依存タスク:** なし
+- **完了条件:** 定数が export され、各文言が 1〜200 文字に収まることを軽い unit test で確認（任意）。
+- **対応Issue:** #150
+
+### タスク3: broadcastMailToEvent に冒頭テキスト対応（バックエンド中核）
+- [ ] 完了
+- **概要:** 配信オーケストレーションに `leadText` を導入。先頭に text メッセージを 1 通追加し、保存・role別カウント・partial 再送 skip を lead 対応にする。
+- **変更対象ファイル:**
+  - `apps/web/src/lib/line-broadcast.ts`
+    - 引数型に `leadText?: string | null` を追加。
+    - `MessageRole` に `'lead_text'` を追加。
+    - `existingAudit` の SELECT に `sentLeadCount` を追加し、`deliveredCount` の合算に含める。
+    - 監査行 insert / `onConflictDoUpdate` の `set` に `leadText: args.leadText?.trim() || null` を保存。
+    - メッセージ組み立てを「lead → body → attachment」順に固定。`leadText` が trim 後非空のとき
+      先頭に `{ type:'text', text }` を push、`roles` 先頭に `'lead_text'`。
+    - `layoutShrunk` 判定に `existingAudit.sentLeadCount > currentLeadCount` を追加。
+    - 完走カウントに `deliveredLead` を追加し、更新 set に `sentLeadCount: deliveredLead`。
+  - `apps/web/src/lib/line-broadcast.test.ts` — 以下のケースを追加（テストファースト）:
+    - leadText 指定 → 先頭が text==leadText / role lead_text / `lead_text` 保存 / `sent_lead_count=1`。
+    - leadText 空・空白のみ → 冒頭メッセージなし（従来挙動）。
+    - leadText + 本文画像 + 添付 → 送信順が lead, image, link。
+    - 本文・添付空 + leadText → 冒頭 1 通のみ（空配信プレースホルダは出ない）。
+    - （任意）partial 後の再送で lead の skip が効く。
+- **依存タスク:** タスク1
+- **完了条件:** 上記テスト green、既存 line-broadcast テストも green、型チェック green。
+- **対応Issue:** #151
+
+### タスク4: linkMailToEvent に leadText を通す＋バリデート
+- [ ] 完了
+- **概要:** 手動紐付け配信の入口に `leadText` 引数を追加し、trim/長さ検証して broadcast に渡す。
+- **変更対象ファイル:**
+  - `apps/web/src/app/(app)/admin/mail-inbox/actions.ts` — `linkMailToEvent(mailId, eventId, leadText?: string | null)`。
+    先頭で trim → 空なら null、201 文字以上なら `{ ok:false, error:'冒頭メッセージは200文字以内で入力してください' }`
+    を返す（紐付け・配信を実行しない）。`after()` の `broadcastMailToEvent` 呼び出しに `leadText` を渡す。
+  - `apps/web/src/app/(app)/admin/mail-inbox/actions.test.ts` — テスト追加（テストファースト）:
+    - leadText 指定 → 紐付け成功 + 監査行に lead_text 保存（配信は DRY_RUN）。
+    - 201 文字 → エラー返却・紐付けされない。
+    - 空文字/空白 → null として正常（冒頭なし）。
+- **依存タスク:** タスク3
+- **完了条件:** 追加テスト green、既存 linkMailToEvent テスト green、型チェック green。
+- **対応Issue:** #152
+
+### タスク5: manualBroadcast で leadText を継承
+- [ ] 完了
+- **概要:** イベント画面からの再配信で、保存済み `lead_text` を監査行から継承して再送する（isCorrection 継承と同じ）。
+- **変更対象ファイル:**
+  - `apps/web/src/app/(app)/events/[id]/actions.ts` — `manualBroadcast` の既存監査行 SELECT に `leadText` を追加し、
+    `broadcastMailToEvent` へ `leadText: existing[0]?.leadText ?? null` を渡す。
+  - `apps/web/src/app/(app)/events/[id]/actions.test.ts` — テスト追加（テストファースト）:
+    - lead_text 保存済みの行を manualBroadcast → 冒頭テキストが再送される。
+    - lead_text=null の行 → 冒頭なしで再送（従来挙動）。
+- **依存タスク:** タスク1, タスク3
+- **完了条件:** 追加テスト green、既存 manualBroadcast テスト green、型チェック green。
+- **対応Issue:** #153
+
+### タスク6: ExistingEventLinkSheet に冒頭メッセージ欄
+- [ ] 完了
+- **概要:** 紐付けシートに「冒頭メッセージ（任意）」UI（プリセットチップ＋編集可能欄）を追加し、leadText を action に渡す。
+- **変更対象ファイル:**
+  - `apps/web/src/app/(app)/admin/mail-inbox/components/ExistingEventLinkSheet.tsx` —
+    `leadText` state（open 時リセット）、`BROADCAST_LEAD_PRESETS` チップ（タップで `setLeadText`）、
+    `maxLength={LEAD_TEXT_MAX_LENGTH}` の textarea（2 行）。`onConfirm` で
+    `linkMailToEvent(mailId, eventId, leadText.trim() || null)`。エラー表示は既存 `error` を流用。
+  - `apps/web/src/app/(app)/admin/mail-inbox/components/ExistingEventLinkSheet.test.tsx`（新規, テストファースト）:
+    - プリセットチップ click → textarea にその文言が入る。
+    - textarea 入力 → 「結びつける」で linkMailToEvent に leadText が渡る（action を mock）。
+    - 空欄でも送信可（leadText=null）。
+- **依存タスク:** タスク2, タスク4
+- **完了条件:** コンポーネントテスト green、型チェック green、lint green。
+- **対応Issue:** #154
+
+## 実装順序
+1. タスク1: DB スキーマ＋マイグレーション（依存なし）
+2. タスク2: プリセット定数（依存なし）
+3. タスク3: broadcastMailToEvent 冒頭テキスト対応（タスク1）
+4. タスク4: linkMailToEvent に leadText（タスク3）
+5. タスク5: manualBroadcast で leadText 継承（タスク1, 3）
+6. タスク6: ExistingEventLinkSheet 冒頭メッセージ欄（タスク2, 4）
+
+## DoD / 残作業（実装後）
+- API（line-broadcast / actions）テスト + フロント（ExistingEventLinkSheet）テスト + 型 + lint が全 green。
+- CI green、claude-mem 記録、PR 作成 + Codex レビュー対応。
+- E2E は既存 `mail-inbox-link-event.spec.ts` の範囲に影響なし（冒頭欄は任意なので既存フロー不変）。
+  必要なら冒頭テキスト入りの link→配信を 1 ケース追記検討（任意）。
+- **本番反映時**: migration 0025 適用（`db:migrate`）。auto-deploy が SHARED 変更を拾って自動適用する想定。
+- **実機確認（残 DoD）**: iPhone 実機で、紐付け時に冒頭テキストを入れて LINE グループに
+  「冒頭テキスト → 本文画像 → 添付リンク」の順で届くことを目視。再配信でも冒頭が再送されること。

--- a/docs/features/broadcast-lead-message/requirements.md
+++ b/docs/features/broadcast-lead-message/requirements.md
@@ -1,0 +1,192 @@
+---
+status: completed
+---
+# broadcast-lead-message 要件定義書
+
+## 1. 概要
+
+### 目的
+既存の大会（イベント）にメールを紐付けて LINE グループへ配信するとき、LINE BOT から
+**冒頭の見出しテキスト（例:「抽選結果が出ました！」）**を任意で 1 通先頭に付けられるようにする。
+
+### 背景・動機
+現状、既存イベントへメールを紐付けて配信すると、LINE グループには
+**メール本文の画像（A4 JPEG）と添付ファイルのリンクしか届かない**。
+受け取った会員は「これが何の連絡なのか」を示す導入テキストが無いまま、画像とファイル
+リンクだけを見ることになり、文脈が伝わりにくい。抽選結果・組合せ・オープンチャット案内
+など、既存大会への補足連絡は内容が毎回変わるため、1 行の見出しがあるだけで受け取り体験が
+大きく改善する。
+
+## 2. ユーザーストーリー
+
+- **対象ユーザー**: 管理者／副管理者（mail-inbox から既存大会へメールを紐付けて配信する人）と、
+  配信を受け取る LINE グループの会員。
+- **管理者の目的**: 補足連絡を既存大会の LINE グループへ流すとき「何の連絡か」を一目で伝える見出しを付けたい。
+- **会員の目的**: LINE 通知を開いた瞬間に「抽選結果が出たんだな」と分かり、画像や添付を見る前に文脈を把握できる。
+- **利用シナリオ**:
+  1. 大会主催者から「抽選結果」メールが届く（kagetra のメール受信トレイに入る）。
+  2. 管理者が mail-inbox 詳細で「既存イベントに紐付ける」シートを開き、対象大会を選ぶ。
+  3. 冒頭メッセージ欄でプリセット「抽選結果が出ました！」チップをタップ（必要なら手直し）。
+  4. 「結びつける」を押すと、LINE グループへ **冒頭テキスト → 本文画像 → 添付リンク** の順で配信される。
+
+## 3. 機能要件
+
+### 3.1 画面仕様（既存イベント紐付けシート）
+
+対象は `ExistingEventLinkSheet`（mail-inbox 詳細の「既存イベントに紐付ける」ボトムシート）。
+イベント選択リストの下に **「冒頭メッセージ（任意）」** セクションを追加する。
+
+- **プリセットチップ**: 定型文をチップ（ボタン）で横並び表示。タップすると下のテキスト欄に
+  その文言を**流し込む**（上書き）。チップは選択状態を保持しない（単なる流し込みトリガー）。
+- **テキスト欄**: 編集可能な複数行テキスト欄（2 行程度）。プリセット流し込み後に手直し可、
+  プリセットを使わず直接入力も可。`maxLength = 200`。プレースホルダ例:「例: 抽選結果が出ました！」
+- **任意**: 空欄のまま「結びつける」を押せる。空なら従来通り本文＋添付のみ配信。
+- 「結びつける」押下時、テキスト欄の値（trim 後）を `linkMailToEvent` に渡す。
+
+プリセット文言（コード固定・初期セット。増減・修正は小 PR で対応可）:
+1. 抽選結果が出ました！
+2. 組合せ（対戦表）が出ました！
+3. 大会専用オープンチャットのお知らせ
+4. タイムテーブル・進行のご案内
+5. 会場・アクセスのご案内
+6. その他のご連絡
+
+### 3.2 配信仕様
+
+- 冒頭テキストが非空のとき、LINE 送信メッセージ配列の **先頭** に
+  `{ type: 'text', text: <冒頭テキスト> }` を 1 通追加する（本文画像／本文テキストより前）。
+- 冒頭テキストが空（trim 後に空文字）なら何も追加しない（既存挙動）。
+- 適用範囲は **手動の `linkMailToEvent` 経由の配信のみ**。
+  AI 下書き承認の自動配信（`approveDraft` / `approveDraftUnits`）、訂正下書き紐付け
+  （`linkDraftToEvent`）には冒頭テキストを付けない（引数 `leadText` は渡さない＝null）。
+- 冒頭テキストは配信ログ（`event_broadcast_messages.lead_text`）に保存する。
+  イベント画面からの **再配信（`manualBroadcast`, force=true）では保存済みの冒頭テキストを
+  そのまま再送**する（`isCorrection` の継承と同じパターン）。
+
+### 3.3 ビジネスルール・制約
+
+- 冒頭テキストは 1〜200 文字（trim 後）。空は許容（=付けない）。201 文字以上は
+  Server Action 側で弾く（エラー文言「冒頭メッセージは200文字以内で入力してください」）。
+- LINE のテキストメッセージ上限（5000 文字）に対し 200 文字なので分割不要。
+- プリセットはあくまで入力補助。Server 側はプリセット一覧と照合しない（自由入力を許容）。
+- 配信先 LINE グループが無い（`loadActiveBinding` が null）場合は、従来通り配信自体が
+  スキップされる（冒頭テキストの有無に関わらず）。
+
+### 3.4 エラーケース・境界条件
+
+| ケース | 挙動 |
+|--------|------|
+| 冒頭テキスト空欄 | 冒頭テキストを付けず本文＋添付のみ配信（従来通り） |
+| 空白のみ入力 | trim で空とみなし付けない |
+| 201 文字以上 | `linkMailToEvent` がエラー返却、紐付け・配信とも実行しない |
+| 本文・添付が空 + 冒頭テキストあり | 冒頭テキストのみ 1 通配信（空配信プレースホルダは出ない） |
+| 部分送信（partial）後の再送 | `sent_lead_count` で冒頭の送信済み有無を追跡し、未送信分のみ再送 |
+| 再配信（manualBroadcast） | 保存済み `lead_text` を再送。null なら冒頭なし |
+
+## 4. 技術設計
+
+### 4.1 API（Server Actions）設計
+
+REST エンドポイントではなく既存の Server Action を拡張する。
+
+- **`linkMailToEvent(mailId, eventId, leadText?)`**
+  （`apps/web/src/app/(app)/admin/mail-inbox/actions.ts`）
+  - 第 3 引数 `leadText?: string | null` を追加。
+  - trim → 空なら null。201 文字以上なら `{ ok: false, error }` を返す（紐付け前にバリデート）。
+  - `after()` 内の `broadcastMailToEvent(db, { eventId, mailMessageId, isCorrection: false, leadText })` に渡す。
+- **`manualBroadcast(eventId, mailMessageId)`**
+  （`apps/web/src/app/(app)/events/[id]/actions.ts`）
+  - 既存監査行の SELECT に `leadText` を追加し、`broadcastMailToEvent` へ
+    `leadText: existing[0]?.leadText ?? null` を渡す（isCorrection 継承と同じ）。
+
+### 4.2 DB 設計
+
+`event_broadcast_messages` に 2 カラム追加（`packages/shared/src/schema/event-broadcast-messages.ts`）:
+
+| カラム | 型 | 制約 | 用途 |
+|--------|----|----|------|
+| `lead_text` | `text` | nullable | 配信した冒頭テキスト本文。再配信時の再送元・監査 |
+| `sent_lead_count` | `integer` | NOT NULL default 0 | 冒頭テキストの送信済み件数（0 or 1）。partial 再送の skip 計算・監査 |
+
+- マイグレーション: `pnpm --filter @kagetra/shared db:generate` で `0025_*.sql` を生成
+  （`ADD COLUMN lead_text text; ADD COLUMN sent_lead_count integer NOT NULL DEFAULT 0;`）。
+  既存行はデフォルトで `lead_text=NULL`, `sent_lead_count=0`。後方互換。
+- 本番反映は `db:migrate`（journal ベース・非 interactive）。
+
+### 4.3 フロントエンド設計
+
+- **`apps/web/src/lib/broadcast-lead-presets.ts`（新規）**: `BROADCAST_LEAD_PRESETS`
+  （string 配列）と `LEAD_TEXT_MAX_LENGTH = 200` を export。client/server 双方から import。
+- **`ExistingEventLinkSheet.tsx`**:
+  - `useState<string>` で `leadText` を保持。シート open 時にリセット。
+  - プリセットチップ群（`BROADCAST_LEAD_PRESETS.map`）。タップで `setLeadText(preset)`。
+  - 編集可能 textarea（`maxLength={LEAD_TEXT_MAX_LENGTH}`、2 行）。
+  - `onConfirm` で `linkMailToEvent(mailId, eventId, leadText.trim() || null)` を呼ぶ。
+
+### 4.4 バックエンド設計（`broadcastMailToEvent`, `apps/web/src/lib/line-broadcast.ts`）
+
+- 引数型に `leadText?: string | null` を追加。
+- `MessageRole` 型に `'lead_text'` を追加。
+- `existingAudit` の SELECT に `sentLeadCount` を追加し、`deliveredCount` の合算に含める。
+- 監査行 insert / onConflictDoUpdate の `set` に `leadText: args.leadText ?? null` を追加
+  （manualBroadcast が継承値を渡すため update でも上書き保存して問題ない）。
+- メッセージ組み立ての**先頭**で、`leadText` が trim 後非空なら
+  `messages.unshift`/先頭 push 相当で `{ type:'text', text: leadText.trim() }` を追加、
+  `roles` 先頭に `'lead_text'`。実装はビルド順を「lead → body → attachment」に固定する。
+- `layoutShrunk` 判定に lead 件数比較を追加（`existingAudit.sentLeadCount > currentLeadCount`）。
+- 完走カウントに `deliveredLead` を追加し、`sentLeadCount: deliveredLead` で更新。
+
+### 4.5 処理フロー
+
+```
+[mail-inbox 詳細] ExistingEventLinkSheet
+  └ イベント選択 + 冒頭メッセージ入力（プリセット流し込み/手入力, 任意）
+      └ linkMailToEvent(mailId, eventId, leadText)
+          ├ leadText を trim + 200字 validate（NGなら配信せずエラー）
+          ├ mail を event に紐付け（既存ロジック）
+          └ after() → broadcastMailToEvent({ eventId, mailMessageId, isCorrection:false, leadText })
+                ├ loadActiveBinding（無ければskip, 既存）
+                ├ 監査行 upsert（lead_text 保存）
+                ├ messages = [lead_text?, body_image*/body_text*, attachment_link*]
+                ├ pushMessages（既存）
+                └ 監査確定（sent_lead_count 含む role 別カウント）
+
+[イベント画面] 再配信ボタン
+  └ manualBroadcast(eventId, mailMessageId)
+      └ 既存監査行から leadText + isCorrection を継承
+          └ broadcastMailToEvent({ ..., force:true, leadText })  → 保存済み冒頭を再送
+```
+
+## 5. 影響範囲
+
+### 変更が必要な既存ファイル
+- `packages/shared/src/schema/event-broadcast-messages.ts` — 2 カラム追加
+- `packages/shared/drizzle/0025_*.sql` — 自動生成（新規）
+- `apps/web/src/lib/broadcast-lead-presets.ts` — 新規（プリセット定数）
+- `apps/web/src/lib/line-broadcast.ts` — leadText 引数・先頭メッセージ・lead カウント
+- `apps/web/src/app/(app)/admin/mail-inbox/actions.ts` — `linkMailToEvent` に leadText 引数＋バリデート
+- `apps/web/src/app/(app)/events/[id]/actions.ts` — `manualBroadcast` で leadText 継承
+- `apps/web/src/app/(app)/admin/mail-inbox/components/ExistingEventLinkSheet.tsx` — 冒頭メッセージ欄
+- 対応テスト各種
+
+### 既存機能への影響
+- **AI 下書き承認の自動配信**（`approveDraft` 等）: `leadText` を渡さない＝null なので**挙動不変**。
+- **イベント画面の再配信**: 保存済み `lead_text` を再送するようになる（新規行は null＝従来通り）。
+- **partial 再送ロジック**: lead 件数を skip 計算に含めるよう拡張（既存テキスト/画像/リンクの扱いは不変）。
+- **DB 後方互換**: 追加カラムは nullable / default 付きで既存行・既存クエリに影響なし。
+
+## 6. 設計判断の根拠
+
+- **プリセット＋自由入力／コード固定**: 連絡内容（抽選結果・組合せ・OC 案内…）は毎回変わるため
+  固定文言では不十分。一方で身内アプリにつき DB 管理＋CRUD 画面は過剰。コード定数なら最小実装で
+  即出しでき、文言変更も小 PR で足りる（スコープ管理・1PR=1機能）。
+- **チップで欄に流し込む 1 フィールド構成**: プルダウン＋別欄は「プリセットを選んでから一部修正」が
+  しづらい。チップ→編集可能欄なら「速い」と「柔軟」を両立。
+- **既存イベント紐付けのみに限定**: 新規大会案内（AI 下書き）は本文自体が案内なので冒頭テキストは
+  冗長。ユーザー要望も「既存の大会に紐づけて通知するとき」に限定されている。
+- **lead_text を監査行に保存して再送**: `manualBroadcast` は force 再送で `isCorrection` を監査行から
+  継承する既存パターンがある。冒頭テキストも同じ場所に保存して継承すれば、再配信が忠実になり
+  実装も一貫する。`sent_lead_count` を分離するのは partial 再送の skip 計算・監査の明瞭さのため
+  （既存も role 別カウントを分離している方針に合わせる）。
+- **先頭固定・任意**: 見出しは本文より前にあってこそ機能する。常時必須にすると単純な添付転送が
+  煩雑になるため任意とし、空ならスキップして既存挙動を完全維持する。

--- a/packages/shared/drizzle/0025_broadcast_lead_message.sql
+++ b/packages/shared/drizzle/0025_broadcast_lead_message.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "event_broadcast_messages" ADD COLUMN "lead_text" text;--> statement-breakpoint
+ALTER TABLE "event_broadcast_messages" ADD COLUMN "sent_lead_count" integer DEFAULT 0 NOT NULL;

--- a/packages/shared/drizzle/meta/0025_snapshot.json
+++ b/packages/shared/drizzle/meta/0025_snapshot.json
@@ -1,0 +1,2877 @@
+{
+  "id": "855af693-ced2-43e1-9550-927ebb30084d",
+  "prevId": "6d43cf87-431f-4727-bb3a-3012c7b31d7f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_user_id": {
+          "name": "line_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "grade": {
+          "name": "grade",
+          "type": "grade",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_invited": {
+          "name": "is_invited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affiliation": {
+          "name": "affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dan": {
+          "name": "dan",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zen_nichikyo": {
+          "name": "zen_nichikyo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_linked_at": {
+          "name": "line_linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_link_method": {
+          "name": "line_link_method",
+          "type": "line_link_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notification_line_user_id": {
+          "name": "notification_line_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_name_unique": {
+          "name": "users_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_line_user_id_unique": {
+          "name": "users_line_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "line_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_dan_range": {
+          "name": "users_dan_range",
+          "value": "\"users\".\"dan\" BETWEEN 0 AND 9 OR \"users\".\"dan\" IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_groups": {
+      "name": "event_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_groups_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_groups_name_unique": {
+          "name": "event_groups_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "events_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formal_name": {
+          "name": "formal_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official": {
+          "name": "official",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'individual'"
+        },
+        "entry_deadline": {
+          "name": "entry_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_deadline": {
+          "name": "internal_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_group_id": {
+          "name": "event_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligible_grades": {
+          "name": "eligible_grades",
+          "type": "grade[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_jpy": {
+          "name": "fee_jpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_deadline": {
+          "name": "payment_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lottery_date": {
+          "name": "lottery_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_info": {
+          "name": "payment_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_method": {
+          "name": "entry_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizer": {
+          "name": "organizer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_a": {
+          "name": "capacity_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_b": {
+          "name": "capacity_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_c": {
+          "name": "capacity_c",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_d": {
+          "name": "capacity_d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_e": {
+          "name": "capacity_e",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_status": {
+          "name": "entry_status",
+          "type": "event_entry_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_applied'"
+        },
+        "entry_applied_at": {
+          "name": "entry_applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_type": {
+          "name": "payment_type",
+          "type": "event_payment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "event_payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unpaid'"
+        },
+        "payment_paid_at": {
+          "name": "payment_paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournament_draft_id": {
+          "name": "tournament_draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournament_draft_unit_key": {
+          "name": "tournament_draft_unit_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_tournament_draft_unit_key_uniq": {
+          "name": "events_tournament_draft_unit_key_uniq",
+          "columns": [
+            {
+              "expression": "tournament_draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tournament_draft_unit_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"events\".\"tournament_draft_id\" IS NOT NULL AND \"events\".\"tournament_draft_unit_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_created_by_users_id_fk": {
+          "name": "events_created_by_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_event_group_id_event_groups_id_fk": {
+          "name": "events_event_group_id_event_groups_id_fk",
+          "tableFrom": "events",
+          "tableTo": "event_groups",
+          "columnsFrom": [
+            "event_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_attendances": {
+      "name": "event_attendances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_attendances_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attend": {
+          "name": "attend",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_attendances_event_id_events_id_fk": {
+          "name": "event_attendances_event_id_events_id_fk",
+          "tableFrom": "event_attendances",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_attendances_user_id_users_id_fk": {
+          "name": "event_attendances_user_id_users_id_fk",
+          "tableFrom": "event_attendances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_attendances_event_id_user_id_unique": {
+          "name": "event_attendances_event_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_items": {
+      "name": "schedule_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "schedule_items_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "schedule_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_items_owner_id_users_id_fk": {
+          "name": "schedule_items_owner_id_users_id_fk",
+          "tableFrom": "schedule_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_messages": {
+      "name": "mail_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_messages_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_addresses": {
+          "name": "to_addresses",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_message_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "mail_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imap_uid": {
+          "name": "imap_uid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imap_box": {
+          "name": "imap_box",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "triage_status": {
+          "name": "triage_status",
+          "type": "mail_triage_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unprocessed'"
+        },
+        "triaged_at": {
+          "name": "triaged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triaged_by_user_id": {
+          "name": "triaged_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_event_id": {
+          "name": "linked_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_messages_received_at_desc_idx": {
+          "name": "mail_messages_received_at_desc_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_messages_triage_status_idx": {
+          "name": "mail_messages_triage_status_idx",
+          "columns": [
+            {
+              "expression": "triage_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_messages_linked_event_id_idx": {
+          "name": "mail_messages_linked_event_id_idx",
+          "columns": [
+            {
+              "expression": "linked_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"mail_messages\".\"linked_event_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_messages_triaged_by_user_id_users_id_fk": {
+          "name": "mail_messages_triaged_by_user_id_users_id_fk",
+          "tableFrom": "mail_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triaged_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mail_messages_linked_event_id_events_id_fk": {
+          "name": "mail_messages_linked_event_id_events_id_fk",
+          "tableFrom": "mail_messages",
+          "tableTo": "events",
+          "columnsFrom": [
+            "linked_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mail_messages_message_id_unique": {
+          "name": "mail_messages_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_attachments": {
+      "name": "mail_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_attachments_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "mail_message_id": {
+          "name": "mail_message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extracted_text": {
+          "name": "extracted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_status": {
+          "name": "extraction_status",
+          "type": "attachment_extraction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mail_attachments_mail_message_id_idx": {
+          "name": "mail_attachments_mail_message_id_idx",
+          "columns": [
+            {
+              "expression": "mail_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_attachments_mail_message_id_mail_messages_id_fk": {
+          "name": "mail_attachments_mail_message_id_mail_messages_id_fk",
+          "tableFrom": "mail_attachments",
+          "tableTo": "mail_messages",
+          "columnsFrom": [
+            "mail_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tournament_drafts": {
+      "name": "tournament_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tournament_drafts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tournament_draft_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_correction": {
+          "name": "is_correction",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "references_subject": {
+          "name": "references_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_by_draft_id": {
+          "name": "superseded_by_draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracted_payload": {
+          "name": "extracted_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ai_raw_response": {
+          "name": "ai_raw_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_tokens_input": {
+          "name": "ai_tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_tokens_output": {
+          "name": "ai_tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_cost_usd": {
+          "name": "ai_cost_usd",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by_user_id": {
+          "name": "rejected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_drafts_status_created": {
+          "name": "idx_drafts_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_drafts_event_id": {
+          "name": "idx_drafts_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"tournament_drafts\".\"event_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tournament_drafts_message_id_mail_messages_id_fk": {
+          "name": "tournament_drafts_message_id_mail_messages_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "mail_messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tournament_drafts_event_id_events_id_fk": {
+          "name": "tournament_drafts_event_id_events_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tournament_drafts_approved_by_user_id_users_id_fk": {
+          "name": "tournament_drafts_approved_by_user_id_users_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tournament_drafts_rejected_by_user_id_users_id_fk": {
+          "name": "tournament_drafts_rejected_by_user_id_users_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "rejected_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tournament_drafts_message_id_unique": {
+          "name": "tournament_drafts_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tournament_drafts_confidence_range": {
+          "name": "tournament_drafts_confidence_range",
+          "value": "\"tournament_drafts\".\"confidence\" BETWEEN 0 AND 1 OR \"tournament_drafts\".\"confidence\" IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.line_channels": {
+      "name": "line_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "line_channels_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_secret": {
+          "name": "channel_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_access_token": {
+          "name": "channel_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "line_channel_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "line_channel_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system_notify'"
+        },
+        "assigned_user_id": {
+          "name": "assigned_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_event_id": {
+          "name": "assigned_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_destination_id": {
+          "name": "webhook_destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_line_user_id": {
+          "name": "notification_line_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "line_channels_assigned_user_id_users_id_fk": {
+          "name": "line_channels_assigned_user_id_users_id_fk",
+          "tableFrom": "line_channels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "line_channels_assigned_event_id_events_id_fk": {
+          "name": "line_channels_assigned_event_id_events_id_fk",
+          "tableFrom": "line_channels",
+          "tableTo": "events",
+          "columnsFrom": [
+            "assigned_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "line_channels_channel_id_unique": {
+          "name": "line_channels_channel_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "channel_id"
+          ]
+        },
+        "line_channels_assigned_user_id_unique": {
+          "name": "line_channels_assigned_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "assigned_user_id"
+          ]
+        },
+        "line_channels_assigned_event_id_unique": {
+          "name": "line_channels_assigned_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "assigned_event_id"
+          ]
+        },
+        "line_channels_webhook_destination_id_unique": {
+          "name": "line_channels_webhook_destination_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "webhook_destination_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_worker_jobs": {
+      "name": "mail_worker_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_worker_jobs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "since": {
+          "name": "since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_worker_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "mail_worker_job_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fetch'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_mail_worker_jobs_status_requested_at": {
+          "name": "idx_mail_worker_jobs_status_requested_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mail_worker_jobs_status_kind_requested_at": {
+          "name": "idx_mail_worker_jobs_status_kind_requested_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_worker_jobs_requested_by_user_id_users_id_fk": {
+          "name": "mail_worker_jobs_requested_by_user_id_users_id_fk",
+          "tableFrom": "mail_worker_jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mail_worker_jobs_run_id_mail_worker_runs_id_fk": {
+          "name": "mail_worker_jobs_run_id_mail_worker_runs_id_fk",
+          "tableFrom": "mail_worker_jobs",
+          "tableTo": "mail_worker_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_worker_runs": {
+      "name": "mail_worker_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_worker_runs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "mail_worker_run_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_worker_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_user_id": {
+          "name": "triggered_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "since": {
+          "name": "since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_worker_runs_triggered_by_user_id_users_id_fk": {
+          "name": "mail_worker_runs_triggered_by_user_id_users_id_fk",
+          "tableFrom": "mail_worker_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggered_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_line_broadcasts": {
+      "name": "event_line_broadcasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_line_broadcasts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_channel_id": {
+          "name": "line_channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code_expires_at": {
+          "name": "invite_code_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_group_id": {
+          "name": "line_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_line_broadcast_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invite_pending'"
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extended_until": {
+          "name": "extended_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoke_reason": {
+          "name": "revoke_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_line_broadcasts_invite_code_active_uq": {
+          "name": "event_line_broadcasts_invite_code_active_uq",
+          "columns": [
+            {
+              "expression": "invite_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"event_line_broadcasts\".\"invite_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_line_broadcasts_event_id_events_id_fk": {
+          "name": "event_line_broadcasts_event_id_events_id_fk",
+          "tableFrom": "event_line_broadcasts",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "event_line_broadcasts_line_channel_id_line_channels_id_fk": {
+          "name": "event_line_broadcasts_line_channel_id_line_channels_id_fk",
+          "tableFrom": "event_line_broadcasts",
+          "tableTo": "line_channels",
+          "columnsFrom": [
+            "line_channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_line_broadcasts_event_id_unique": {
+          "name": "event_line_broadcasts_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_broadcast_messages": {
+      "name": "event_broadcast_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_broadcast_messages_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_line_broadcast_id": {
+          "name": "event_line_broadcast_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mail_message_id": {
+          "name": "mail_message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "event_broadcast_message_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "is_correction": {
+          "name": "is_correction",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lead_text": {
+          "name": "lead_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_lead_count": {
+          "name": "sent_lead_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_text_count": {
+          "name": "sent_text_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_image_count": {
+          "name": "sent_image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "fallback_link_count": {
+          "name": "fallback_link_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_broadcast_messages_event_line_broadcast_id_event_line_broadcasts_id_fk": {
+          "name": "event_broadcast_messages_event_line_broadcast_id_event_line_broadcasts_id_fk",
+          "tableFrom": "event_broadcast_messages",
+          "tableTo": "event_line_broadcasts",
+          "columnsFrom": [
+            "event_line_broadcast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_broadcast_messages_mail_message_id_mail_messages_id_fk": {
+          "name": "event_broadcast_messages_mail_message_id_mail_messages_id_fk",
+          "tableFrom": "event_broadcast_messages",
+          "tableTo": "mail_messages",
+          "columnsFrom": [
+            "mail_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_broadcast_messages_broadcast_mail_uq": {
+          "name": "event_broadcast_messages_broadcast_mail_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_line_broadcast_id",
+            "mail_message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachment_share_tokens": {
+      "name": "attachment_share_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "attachment_share_tokens_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "mail_attachment_id": {
+          "name": "mail_attachment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attachment_share_tokens_attachment_idx": {
+          "name": "attachment_share_tokens_attachment_idx",
+          "columns": [
+            {
+              "expression": "mail_attachment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachment_share_tokens_expires_at_idx": {
+          "name": "attachment_share_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attachment_share_tokens_mail_attachment_id_mail_attachments_id_fk": {
+          "name": "attachment_share_tokens_mail_attachment_id_mail_attachments_id_fk",
+          "tableFrom": "attachment_share_tokens",
+          "tableTo": "mail_attachments",
+          "columnsFrom": [
+            "mail_attachment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "attachment_share_tokens_mail_attachment_id_unique": {
+          "name": "attachment_share_tokens_mail_attachment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mail_attachment_id"
+          ]
+        },
+        "attachment_share_tokens_token_unique": {
+          "name": "attachment_share_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_lifecycle_notifications": {
+      "name": "event_lifecycle_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_lifecycle_notifications_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "event_lifecycle_notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "event_lifecycle_notification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sent'"
+        },
+        "line_group_id": {
+          "name": "line_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_lifecycle_notifications_event_type_uq": {
+          "name": "event_lifecycle_notifications_event_type_uq",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_lifecycle_notifications_event_id_events_id_fk": {
+          "name": "event_lifecycle_notifications_event_id_events_id_fk",
+          "tableFrom": "event_lifecycle_notifications",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "push_subscriptions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_id_idx": {
+          "name": "push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_id_fk": {
+          "name": "push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_subscriptions_endpoint_unique": {
+          "name": "push_subscriptions_endpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "endpoint"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attachment_extraction_status": {
+      "name": "attachment_extraction_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "extracted",
+        "failed",
+        "unsupported"
+      ]
+    },
+    "public.event_broadcast_message_status": {
+      "name": "event_broadcast_message_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sending",
+        "sent",
+        "partial",
+        "failed"
+      ]
+    },
+    "public.event_entry_status": {
+      "name": "event_entry_status",
+      "schema": "public",
+      "values": [
+        "not_applied",
+        "applied"
+      ]
+    },
+    "public.event_kind": {
+      "name": "event_kind",
+      "schema": "public",
+      "values": [
+        "individual",
+        "team"
+      ]
+    },
+    "public.event_lifecycle_notification_status": {
+      "name": "event_lifecycle_notification_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.event_lifecycle_notification_type": {
+      "name": "event_lifecycle_notification_type",
+      "schema": "public",
+      "values": [
+        "entry_applied",
+        "entry_deadline_advance",
+        "entry_deadline_day",
+        "payment_paid",
+        "payment_deadline_advance",
+        "payment_deadline_day",
+        "onsite_payment_advance",
+        "onsite_payment_day",
+        "entry_applied_treasurer"
+      ]
+    },
+    "public.event_line_broadcast_status": {
+      "name": "event_line_broadcast_status",
+      "schema": "public",
+      "values": [
+        "invite_pending",
+        "joined_waiting_code",
+        "linked",
+        "revoked",
+        "released"
+      ]
+    },
+    "public.event_payment_status": {
+      "name": "event_payment_status",
+      "schema": "public",
+      "values": [
+        "unpaid",
+        "paid"
+      ]
+    },
+    "public.event_payment_type": {
+      "name": "event_payment_type",
+      "schema": "public",
+      "values": [
+        "advance",
+        "onsite"
+      ]
+    },
+    "public.event_status": {
+      "name": "event_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "cancelled",
+        "done"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female"
+      ]
+    },
+    "public.grade": {
+      "name": "grade",
+      "schema": "public",
+      "values": [
+        "A",
+        "B",
+        "C",
+        "D",
+        "E"
+      ]
+    },
+    "public.line_channel_purpose": {
+      "name": "line_channel_purpose",
+      "schema": "public",
+      "values": [
+        "system_notify",
+        "event_broadcast"
+      ]
+    },
+    "public.line_channel_status": {
+      "name": "line_channel_status",
+      "schema": "public",
+      "values": [
+        "available",
+        "assigned",
+        "active",
+        "system",
+        "disabled"
+      ]
+    },
+    "public.line_link_method": {
+      "name": "line_link_method",
+      "schema": "public",
+      "values": [
+        "self_identify",
+        "admin_link",
+        "account_switch"
+      ]
+    },
+    "public.mail_classification": {
+      "name": "mail_classification",
+      "schema": "public",
+      "values": [
+        "tournament",
+        "noise",
+        "unknown"
+      ]
+    },
+    "public.mail_message_status": {
+      "name": "mail_message_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "fetched",
+        "parse_failed",
+        "fetch_failed",
+        "ai_processing",
+        "ai_done",
+        "ai_failed",
+        "oversize_skipped",
+        "archived"
+      ]
+    },
+    "public.mail_triage_status": {
+      "name": "mail_triage_status",
+      "schema": "public",
+      "values": [
+        "unprocessed",
+        "processed"
+      ]
+    },
+    "public.mail_worker_job_kind": {
+      "name": "mail_worker_job_kind",
+      "schema": "public",
+      "values": [
+        "fetch",
+        "manual_extract"
+      ]
+    },
+    "public.mail_worker_job_status": {
+      "name": "mail_worker_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "claimed",
+        "done",
+        "failed"
+      ]
+    },
+    "public.mail_worker_run_kind": {
+      "name": "mail_worker_run_kind",
+      "schema": "public",
+      "values": [
+        "cron",
+        "manual"
+      ]
+    },
+    "public.mail_worker_run_status": {
+      "name": "mail_worker_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "imap_failed",
+        "ai_failed",
+        "partial"
+      ]
+    },
+    "public.schedule_kind": {
+      "name": "schedule_kind",
+      "schema": "public",
+      "values": [
+        "practice",
+        "meeting",
+        "social",
+        "other"
+      ]
+    },
+    "public.tournament_draft_status": {
+      "name": "tournament_draft_status",
+      "schema": "public",
+      "values": [
+        "pending_review",
+        "approved",
+        "rejected",
+        "ai_failed",
+        "superseded",
+        "ai_processing"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "vice_admin",
+        "member"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/shared/drizzle/meta/_journal.json
+++ b/packages/shared/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1780773748148,
       "tag": "0024_tournament_drafts_event_id_index",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1781702201439,
+      "tag": "0025_broadcast_lead_message",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/schema/event-broadcast-messages.ts
+++ b/packages/shared/src/schema/event-broadcast-messages.ts
@@ -15,9 +15,11 @@ import { mailMessages } from './mail-messages'
  * binding is fine — if the event itself is gone, the per-mail audit goes
  * with it.
  *
- * The counters (`sent_text_count`, `sent_image_count`, `fallback_link_count`)
- * record what actually went out so a `partial` row can be triaged without
- * replaying the original mail.
+ * The counters (`sent_lead_count`, `sent_text_count`, `sent_image_count`,
+ * `fallback_link_count`) record what actually went out so a `partial` row can
+ * be triaged without replaying the original mail. `lead_text` stores the
+ * optional heading prepended to a manual existing-event link so a re-broadcast
+ * can resend it verbatim.
  */
 export const eventBroadcastMessages = pgTable(
   'event_broadcast_messages',
@@ -31,6 +33,10 @@ export const eventBroadcastMessages = pgTable(
       .references(() => mailMessages.id, { onDelete: 'restrict' }),
     status: eventBroadcastMessageStatusEnum('status').notNull().default('pending'),
     isCorrection: boolean('is_correction').notNull().default(false),
+    // Optional heading prepended to a manual existing-event link broadcast
+    // (lead → body → attachment). Saved so manualBroadcast can resend it.
+    leadText: text('lead_text'),
+    sentLeadCount: integer('sent_lead_count').notNull().default(0),
     sentTextCount: integer('sent_text_count').notNull().default(0),
     sentImageCount: integer('sent_image_count').notNull().default(0),
     // Attachments that fell back to a signed-URL link (libreoffice/pdfjs


### PR DESCRIPTION
## Summary
既存大会へメールを紐付けて LINE 配信する際、冒頭の見出しテキスト（例「抽選結果が出ました！」）を任意で先頭に1通付けられるようにする。現状は本文画像→添付リンクのみで「何の連絡か」が伝わらない問題への対応（親 #148）。

- **DB (migration 0025)**: `event_broadcast_messages` に `lead_text`(text/null)・`sent_lead_count`(int default 0) を追加。既存行は NULL/0 で後方互換。
- **プリセット定数**: `broadcast-lead-presets.ts` に文言6件 + `LEAD_TEXT_MAX_LENGTH=200`（コード固定・client/server 共有）。
- **配信中核 (broadcastMailToEvent)**: `leadText` を受け、trim 後非空なら LINE メッセージ列の**先頭固定**（lead → body → attachment）で1通追加。`lead_text` 保存・`sent_lead_count` カウント・partial 再送 skip・layoutShrunk 判定に lead を反映。空はスキップで既存挙動を完全維持。
- **入口 (linkMailToEvent)**: 第3引数 `leadText` を追加。trim→空は null、200字超は紐付け前に `{ ok:false }` で弾く。AI 下書き承認・訂正紐付けは対象外で挙動不変。
- **再配信 (manualBroadcast)**: 保存済み `lead_text` を監査行から継承して再送（isCorrection 継承と同じパターン）。
- **UI (ExistingEventLinkSheet)**: 「冒頭メッセージ（任意）」欄。プリセットチップ（タップで textarea へ流し込み）＋ maxLength=200 の textarea。open 時リセット。

子 Issue: #149-154（commit の Fixes でマージ時クローズ）

## Test plan
- [x] shared / web 型チェック green、web lint green
- [x] web vitest **541 passed**（lead 関連: presets 3 / line-broadcast 13 / mail-inbox actions 99 / events actions 7 / ExistingEventLinkSheet 4）
- [x] shared vitest 4 passed
- [x] test DB へ migration 0025 適用確認（後方互換）
- [ ] iPhone 実機で「冒頭→本文画像→添付リンク」の順に届くこと、再配信で冒頭が継承されることを目視
- [ ] 本番 migration 0025 適用（auto-deploy が SHARED 変更を取り込む想定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)