### PR TITLE
fix(mail-body-image): 本文画像の行間を 1.7→1.3 に詰める

### DIFF
--- a/apps/web/src/lib/mail-body-image-render.test.ts
+++ b/apps/web/src/lib/mail-body-image-render.test.ts
@@ -19,7 +19,7 @@ describe('buildBodyImageHtml', () => {
         <meta charset="UTF-8">
         <style>
           @page { size: A4 portrait; margin: 25mm 20mm; }
-          body { font-family: 'Noto Sans CJK JP', sans-serif; font-size: 11pt; line-height: 1.7; color: #000; }
+          body { font-family: 'Noto Sans CJK JP', sans-serif; font-size: 11pt; line-height: 1.3; color: #000; }
           h1 { font-size: 14pt; font-weight: bold; margin: 0 0 1em 0; border-bottom: 1px solid #888; padding-bottom: 0.5em; }
           pre { font-family: 'Noto Sans CJK JP', sans-serif; white-space: pre-wrap; word-break: break-word; margin: 0; }
         </style>

--- a/apps/web/src/lib/mail-body-image-render.ts
+++ b/apps/web/src/lib/mail-body-image-render.ts
@@ -84,7 +84,7 @@ export function buildBodyImageHtml(input: BuildBodyImageInput): string {
   <meta charset="UTF-8">
   <style>
     @page { size: A4 portrait; margin: 25mm 20mm; }
-    body { font-family: 'Noto Sans CJK JP', sans-serif; font-size: 11pt; line-height: 1.7; color: #000; }
+    body { font-family: 'Noto Sans CJK JP', sans-serif; font-size: 11pt; line-height: 1.3; color: #000; }
     h1 { font-size: 14pt; font-weight: bold; margin: 0 0 1em 0; border-bottom: 1px solid #888; padding-bottom: 0.5em; }
     pre { font-family: 'Noto Sans CJK JP', sans-serif; white-space: pre-wrap; word-break: break-word; margin: 0; }
   </style>


### PR DESCRIPTION
## Summary
- メール本文を A4 縦 JPEG 画像化して LINE 配信する際の行間 (line-height) が 1.7 で広く読みづらいため、1.3 に詰める
- `buildBodyImageHtml` の `<style>`（実レンダリング）と、HTML 全文を比較するインラインスナップショットを同値に更新

## Test plan
- [x] `mail-body-image-render.test.ts` のスナップショットテスト green（ローカル確認済み: 8 passed / 1 skipped）
- [ ] 本番反映後、実機 LINE で本文画像の行間が詰まって読みやすくなったことを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)