### PR TITLE
fix(tournament-results): 出場者DB形式パーサで氏名=選手名・所属=所属会を採用（ふりがな/所属会2の誤検出を修正）

### DIFF
--- a/apps/mail-worker/src/result-import/parser.ts
+++ b/apps/mail-worker/src/result-import/parser.ts
@@ -45,7 +45,10 @@ interface ColMap {
  * Handles: 「選手名」「氏名」「名前」「参加者」.
  */
 function isPlayerNameHeader(v: string): boolean {
-  return /選手名|氏名|名前/.test(v)
+  // Exclude furigana/reading columns (e.g.「選手名ふりがな」「氏名カナ」) which also contain
+  // 選手名/氏名: the 出場者DB layout places 選手名 and 選手名ふりがな side by side, and
+  // last-match-wins otherwise picked the kana column → every name imported as hiragana.
+  return /選手名|氏名|名前/.test(v) && !/ふりがな|フリガナ|カナ|読み|かな/.test(v)
 }
 
 function isOpponentHeader(v: string): boolean {
@@ -78,7 +81,8 @@ function detectSignatureRow(
 
     for (let c = 0; c < cells.length; c++) {
       const s = cells[c]!
-      if (isPlayerNameHeader(s)) playerNameCol = c
+      // First-match-wins: keep the first 選手名/氏名 column (kanji), not a later duplicate.
+      if (playerNameCol < 0 && isPlayerNameHeader(s)) playerNameCol = c
       else if (isOpponentHeader(s)) opponentCols.push(c)
       else if (isResultHeader(s)) resultCols.push(c)
     }
@@ -154,18 +158,22 @@ function detectSignatureRow(
       rounds,
     }
 
+    // Auxiliary columns. Each detector takes the FIRST matching column (guarded by
+    // `=== null`). Some 出場者DB layouts carry duplicate columns such as 所属会 + 所属会2,
+    // where 所属会2 is usually blank — last-match-wins picked the blank one and dropped
+    // every affiliation. First-match-wins keeps the primary column.
     for (let c = 0; c < cells.length; c++) {
       const s = cells[c]!
       if (c === playerNameCol) continue
-      if (/^no\.?$/i.test(s) || s === '番号' || s === 'No') colMap.seqNoCol = c
-      else if (/ふりがな|フリガナ|読み|かな/.test(s)) colMap.kanaCol = c
-      else if (/所属/.test(s)) colMap.affiliationCol = c
-      else if (/都道府県/.test(s)) colMap.prefectureCol = c
-      else if (/段位|段(?!位)/.test(s)) colMap.danCol = c
-      else if (/会員番号/.test(s)) colMap.memberNoCol = c
-      else if (/順位/.test(s)) colMap.rankCol = c
-      else if (/^[A-E]?級$/.test(s) || s === '級') colMap.gradeCol = c
-      else if (/^クラス$|^class$/i.test(s)) colMap.classCol = c
+      if (colMap.seqNoCol === null && (/^no\.?$/i.test(s) || s === '番号' || s === 'No')) colMap.seqNoCol = c
+      else if (colMap.kanaCol === null && /ふりがな|フリガナ|読み|かな/.test(s)) colMap.kanaCol = c
+      else if (colMap.affiliationCol === null && /所属/.test(s)) colMap.affiliationCol = c
+      else if (colMap.prefectureCol === null && /都道府県/.test(s)) colMap.prefectureCol = c
+      else if (colMap.danCol === null && /段位|段(?!位)/.test(s)) colMap.danCol = c
+      else if (colMap.memberNoCol === null && /会員番号/.test(s)) colMap.memberNoCol = c
+      else if (colMap.rankCol === null && /順位/.test(s)) colMap.rankCol = c
+      else if (colMap.gradeCol === null && (/^[A-E]?級$/.test(s) || s === '級')) colMap.gradeCol = c
+      else if (colMap.classCol === null && /^クラス$|^class$/i.test(s)) colMap.classCol = c
     }
 
     return { headerRowIdx: rowIdx, colMap }

--- a/apps/mail-worker/test/result-import/parser.test.ts
+++ b/apps/mail-worker/test/result-import/parser.test.ts
@@ -272,3 +272,46 @@ describe('parseResultExcel — 4-column round block (相手/枚数/備考/勝敗
     expect(p.matches[0]?.opponentName).toBe('選手乙')
   })
 })
+
+/**
+ * 伊助 出場者DB — REAL layout carrying BOTH 選手名 + 選手名ふりがな AND 所属会 + 所属会2.
+ * Regression for the duplicate-column bug: last-match-wins picked 選手名ふりがな (→ every
+ * name imported as hiragana) and 所属会2 (usually blank → empty affiliation), which ALSO
+ * broke opponent resolution downstream (hiragana own-name vs kanji opponent-name never
+ * matched). 13 of 42 surveyed workbooks hit this. 所属会2 is intentionally blank to match
+ * real files. The pre-fix MULTI_CLASS_SHEET fixture lacked these duplicate columns, so it
+ * never caught the bug.
+ */
+const SHUSSHA_DB_DUP_COLS_SHEET: SheetData = makeSheet('出場者DB', [
+  ['出場者DB', null, null, null, null, null, null, null, null, null, null, null, null, null],
+  [null, null, null, null, null, null, null, null, '1回戦', null, null, '2回戦', null, null],
+  ['No.', '級', 'クラス', '段位', '選手名', '選手名ふりがな', '所属会', '所属会2', '相手', '枚数', '勝敗', '相手', '枚数', '勝敗'],
+  ['1', 'A級', 'A1', '5段', '漢字太郎', 'かんじたろう', '東京会', null, '漢字次郎', '7', '○', '漢字三郎', '3', '×'],
+  ['2', 'A級', 'A2', '4段', '漢字次郎', 'かんじじろう', '大阪会', null, '漢字太郎', '9', '×', null, null, null],
+])
+
+describe('parseResultExcel — 出場者DB with 選手名ふりがな + 所属会2 (regression)', () => {
+  const classes = parseResultExcel([SHUSSHA_DB_DUP_COLS_SHEET])
+  const p1 = classes[0]!.participants[0]!
+
+  it('uses the kanji 選手名 column, NOT 選手名ふりがな', () => {
+    expect(p1.name).toBe('漢字太郎')
+    expect(p1.name).not.toBe('かんじたろう')
+  })
+
+  it('captures 選手名ふりがな as nameKana (no longer dropped)', () => {
+    expect(p1.nameKana).toBe('かんじたろう')
+  })
+
+  it('uses 所属会 (primary), NOT the blank 所属会2', () => {
+    expect(p1.affiliation).toBe('東京会')
+  })
+
+  it('keeps opponent names as kanji that match participant names (resolvable downstream)', () => {
+    const p2 = classes[1]!.participants[0]!
+    expect(p2.name).toBe('漢字次郎')
+    // own name (kanji) and opponent name (kanji) are in the same script → materialize
+    // can normalize-match them; pre-fix the own name was hiragana and never matched.
+    expect(p1.matches[0]?.opponentName).toBe('漢字次郎')
+  })
+})


### PR DESCRIPTION
## 何を
大会結果取り込みパーサ（`apps/mail-worker/src/result-import/parser.ts`）のヘッダ検出を修正。伊助「出場者DB」形式の票で、選手名が全員ひらがな・所属がほぼ空・対戦相手の紐付けが全滅していた問題を解消する。

## なぜ
出場者DB形式の票は `選手名`(漢字) と `選手名ふりがな`、`所属会` と `所属会2`(通常空) を列として併存させる。従来のヘッダ検出は last-match-wins（最後にマッチした列で上書き）だったため:
- 氏名に `選手名ふりがな` を採用 → 全選手名がひらがな
- 所属に空の `所属会2` を採用 → 所属がほぼ空
- 自分の名前がひらがな・相手列が漢字になり `normalizePlayerName` 同士が一致せず、相手解決が0%（全試合の対戦相手が紐付かない）

`docs/調査用` の実票42件を実パーサに通したところ **13件**（11大会: 全日本選手権/大阪/静岡/広島/桑名/信州/富山/奈良/酒田 等）で発生。正常28件は氏名=列1・所属=列2の単一列形式で無影響。

## 修正
1. `isPlayerNameHeader` をふりがな列除外に（`/選手名|氏名|名前/` かつ `!/ふりがな|フリガナ|カナ|読み|かな/`）。選手名漢字列を採用し、選手名ふりがな列は `kanaCol` として正しく取得（ふりがなも保存されるように）。
2. `playerNameCol` を first-match-wins に。
3. 補助列検出（所属/かな/段位等）を first-match-wins に（`所属会` を採用・`所属会2` を無視）。

## テスト方法
- 実票の重複列レイアウト（選手名+選手名ふりがな、所属会+所属会2）を持つ回帰テスト4本を `parser.test.ts` に追加（既存フィクスチャは重複列が無くバグを取り逃していた）。
- ローカル検証（`docs/調査用` の実票42件を実パーサに通すハーネス）: 異常 **13→0件**、旧バグ群は氏名=漢字・所属充足100%・相手解決 **0→100%**・ふりがな取得、正常28件は完全不変（近江神宮 665/665 一致）。
- `pnpm exec vitest run test/result-import/`（mail-worker）: **53テスト全通過**（parser 26[新規4含む] + run 7 + normalize 20）。
- `pnpm exec tsc --noEmit`: 型チェック OK。

## 備考（スコープ外）
- 熊本大会票（シート: 大会報告/Ａ級詳報/Ｂ級詳報）は署名検出されず0件取り込みになる**別問題**を発見。本PRとは切り離して別途追跡（サイレントに成功に見える点で要対応）。
- 承認前の愛知ドラフトは本PR反映後に却下→再取り込みで正データ化できる（DB無傷）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
