### PR TITLE
fix(result-import): 段位(dan)を positional/見出し無し列レイアウトで取りこぼさない

### DIFF
--- a/apps/mail-worker/src/result-import/parser.ts
+++ b/apps/mail-worker/src/result-import/parser.ts
@@ -177,6 +177,27 @@ function detectSignatureRow(
       else if (colMap.classCol === null && /^クラス$|^class$/i.test(s)) colMap.classCol = c
     }
 
+    // Content fallback for an unlabeled 段位 column (dan ranks with no 段位 header).
+    // Only fills danCol when the header scan missed it, from an otherwise-unassigned
+    // column whose data is predominantly dan ranks — cannot alter any other column.
+    if (colMap.danCol === null) {
+      const danLimit = colMap.rounds[0]?.opponentCol ?? cells.length
+      const assigned = new Set<number>(
+        [
+          colMap.playerNameCol,
+          colMap.seqNoCol,
+          colMap.kanaCol,
+          colMap.affiliationCol,
+          colMap.prefectureCol,
+          colMap.memberNoCol,
+          colMap.rankCol,
+          colMap.gradeCol,
+          colMap.classCol,
+        ].filter((x): x is number => x != null),
+      )
+      colMap.danCol = findDanColByContent(grid, rowIdx + 1, danLimit, assigned)
+    }
+
     return { headerRowIdx: rowIdx, colMap }
   }
   return null
@@ -190,6 +211,37 @@ function cellStr(row: readonly CellValue[], col: number | null): string | null {
   if (v == null) return null
   const s = normalizeText(v)
   return s || null
+}
+
+// ── 段位 (dan) recovery: content-based unlabeled-column detector ───────────────
+// Some sheets carry dan ranks (初段〜十段) in a column with NO 段位 header — e.g.
+// 名人位/クイーン位 qualifier sheets place 六段/五段 in a header-less column between
+// 選手名 and the first round. This finds such a column by CONTENT (the first
+// otherwise-unassigned column, left of the rounds, whose data cells are
+// predominantly dan ranks) and is only consulted when the header scan found no 段位
+// column. It only ever yields a danCol — no other field's column is affected.
+const DAN_VALUE_RE = /^(初|壱|弐|二|参|三|四|五|六|七|八|九|十)段$/
+function findDanColByContent(
+  grid: readonly (readonly CellValue[])[],
+  dataStartRow: number,
+  limitCol: number,
+  assigned: ReadonlySet<number>,
+): number | null {
+  for (let c = 0; c < limitCol; c++) {
+    if (assigned.has(c)) continue
+    let danLike = 0
+    let nonEmpty = 0
+    for (let r = dataStartRow; r < Math.min(grid.length, dataStartRow + 60); r++) {
+      const v = (grid[r] ?? [])[c]
+      if (v == null) continue
+      const s = normalizeText(v)
+      if (!s) continue
+      nonEmpty++
+      if (DAN_VALUE_RE.test(s)) danLike++
+    }
+    if (nonEmpty >= 3 && danLike / nonEmpty >= 0.5) return c
+  }
+  return null
 }
 
 function parseDataRow(
@@ -376,6 +428,7 @@ interface RoundLayout {
   gradeCol: number | null
   classCol: number | null
   rankCol: number | null
+  danCol: number | null
   blocks: RoundBlock[]
 }
 
@@ -474,6 +527,7 @@ function detectRoundLayoutSignature(
     let gradeCol: number | null = null
     let classCol: number | null = null
     let rankCol: number | null = null
+    let danCol: number | null = null
     for (let c = 0; c < Math.min(nameKeys.length, firstK); c++) {
       if (c === nameCol) continue
       const s = nameKeys[c]!
@@ -483,6 +537,16 @@ function detectRoundLayoutSignature(
       else if (rankCol === null && /順位/.test(s)) rankCol = c
       else if (classCol === null && /^クラス$|^class$/i.test(s)) classCol = c
       else if (gradeCol === null && (/^[A-E]?級$/.test(s) || s === '級')) gradeCol = c
+      else if (danCol === null && /段位|段(?!位)/.test(s)) danCol = c
+    }
+    // Unlabeled 段位 column (dan ranks with no header) — content fallback, danCol only.
+    if (danCol === null) {
+      const assigned = new Set<number>(
+        [nameCol, seqNoCol, kanaCol, affiliationCol, gradeCol, classCol, rankCol].filter(
+          (x): x is number => x != null,
+        ),
+      )
+      danCol = findDanColByContent(grid, dataStartIdx, firstK, assigned)
     }
 
     return {
@@ -495,6 +559,7 @@ function detectRoundLayoutSignature(
       gradeCol,
       classCol,
       rankCol,
+      danCol,
       blocks,
     }
   }
@@ -554,7 +619,7 @@ function parseRoundLayoutRow(
     nameKana: cellStr(row, layout.kanaCol),
     affiliation: cellStr(row, layout.affiliationCol),
     prefecture: null,
-    dan: null,
+    dan: cellStr(row, layout.danCol),
     memberNo: null,
     finalRank: cellStr(row, layout.rankCol),
     matches,

--- a/apps/mail-worker/test/result-import/parser-round-layout.test.ts
+++ b/apps/mail-worker/test/result-import/parser-round-layout.test.ts
@@ -241,3 +241,61 @@ describe('parseResultExcel — fallback guards (no false positives)', () => {
     expect(classes[0]!.participants.find((p) => p.name === '主選手')!.matches[0]).toMatchObject({ result: 'win', scoreDiff: 8, opponentName: '相手選手' })
   })
 })
+
+// ── 段位 (dan) capture: labeled (fallback), content-based (fallback & primary), none ──
+describe('parseResultExcel — 段位 (dan) capture', () => {
+  // Labeled 段位 column in a fallback sheet (primary fails: 勝/敗 split, not 勝敗).
+  it('reads a labeled 段位 column via the positional fallback', () => {
+    const sheet = makeSheet('Ａ級', [
+      [null, null, null, null, '1回戦', null, null, '2回戦', null, null],
+      ['No', '氏名', '所属', '段位', '相手', '勝', '敗', '相手', '勝', '敗'],
+      ['1', '段持選手', '甲会', '六段', '乙野選手', '○', '5', '丙野選手', '○', '7'],
+      ['2', '乙野選手', '乙会', '四段', '段持選手', '×', '5', null, null, null],
+    ])
+    const cls = parseResultExcel([sheet])
+    expect(cls[0]!.participants.find((p) => p.name === '段持選手')!.dan).toBe('六段')
+    expect(cls[0]!.participants.find((p) => p.name === '乙野選手')!.dan).toBe('四段')
+  })
+
+  // Header-less dan column recovered by content (predominantly dan ranks) — fallback path.
+  it('recovers an unlabeled dan column by content in the fallback path', () => {
+    const sheet = makeSheet('Ｂ級', [
+      [null, null, null, '1回戦', null, null, '2回戦', null, null],
+      ['No', '氏名', null, '相手', '勝', '敗', '相手', '勝', '敗'],
+      ['1', '甲野選手', '五段', '乙野選手', '○', '5', '丙野選手', '○', '7'],
+      ['2', '乙野選手', '六段', '甲野選手', '×', '5', null, null, null],
+      ['3', '丙野選手', '初段', '甲野選手', '×', '7', null, null, null],
+    ])
+    const cls = parseResultExcel([sheet])
+    expect(cls[0]!.participants.find((p) => p.name === '甲野選手')!.dan).toBe('五段')
+  })
+
+  // Header-less dan column in a PRIMARY-detected sheet (名人位/クイーン位 style: dan
+  // sits in a label-less column between 選手名 and the first 相手).
+  it('recovers an unlabeled dan column by content in the primary path', () => {
+    const sheet = makeSheet('対戦結果表_名人位級', [
+      [null, null, null, '1回戦', null, null, '2回戦', null, null],
+      ['No', '選手名', null, '相手', '枚数', '勝敗', '相手', '枚数', '勝敗'],
+      ['1', '高段選手', '六段', '乙野選手', '5', '○', '丙野選手', '7', '○'],
+      ['2', '乙野選手', '五段', '高段選手', '5', '×', null, null, null],
+      ['3', '丙野選手', '四段', '高段選手', '7', '×', null, null, null],
+    ])
+    const cls = parseResultExcel([sheet])
+    expect(cls[0]!.participants.find((p) => p.name === '高段選手')!.dan).toBe('六段')
+    // the same row's match data must be unaffected by the dan recovery
+    expect(cls[0]!.participants.find((p) => p.name === '高段選手')!.matches[0]).toMatchObject({
+      result: 'win', scoreDiff: 5, opponentName: '乙野選手',
+    })
+  })
+
+  // No 段位 anywhere → the content scan must not invent dan (no false positives).
+  it('leaves dan null when there is no 段位 column', () => {
+    const sheet = makeSheet('C級', [
+      [null, '氏名', '所属', '1回戦', null, null],
+      [null, '甲野選手', '甲会', '乙野選手', '○', '8'],
+      [null, '乙野選手', '乙会', '甲野選手', '×', '8'],
+    ])
+    const cls = parseResultExcel([sheet])
+    expect(cls[0]!.participants.every((p) => p.dan === null)).toBe(true)
+  })
+})


### PR DESCRIPTION
## 何を
過去結果取込パーサ `parseResultExcel` が一部レイアウトで選手の **段位(dan)** を取りこぼしていた問題を修正。**段位列のみ**を補完し、他フィールド(氏名/所属/対戦/回戦/級…)の解析は一切変更しない。

## なぜ
- positional 「N回戦」フォールバック経路 (`detectRoundLayoutSignature` / `parseRoundLayoutRow`) が `dan` を常に `null` にしていた（「勝/敗」分割見出しや全角空白入り `氏　名` 見出しで primary 署名を外れる大会が該当。例: 第11回奥の細道むすび 760件、東京東会 等）。
- 名人位/クイーン位・選抜など最上位級は **段位列にヘッダが無く** primary 経路でも `danCol=null` になっていた。
→ 段位検索で最も価値のあるトップ層の段位が落ちていた。

## 変更
- フォールバックの補助列走査に 段位 列検出を追加し `parseRoundLayoutRow` で読む。
- `findDanColByContent` を追加：見出し無し段位列を**内容**（初段〜十段が過半）で回収。`danCol` が null の時のみ primary/フォールバック双方で起動し、**段位列以外の列割当は不変**（誤検出時も dan 以外に影響しない設計）。

## テスト方法
- 新規ユニットテスト4本（フォールバック=ラベル有り / 内容ベース、primary=内容ベース、段位無し=null維持）。
- mail-worker: `vitest` **107 passed** / `lint` clean / `check-types` clean。
- 実コーパス回帰（過去大会 Excel 933ファイル, git外）: **段位以外の出力がバイト単位で前後完全一致**（本変更は段位列のみに影響することを実証）、段位抽出 **17,692 → 20,762 (+3,070)**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)