### PR TITLE
feat(players): display_name を最頻の生表記に再計算（正規化は維持）

### DIFF
--- a/apps/web/scripts/backfill-player-display-name.ts
+++ b/apps/web/scripts/backfill-player-display-name.ts
@@ -1,0 +1,103 @@
+#!/usr/bin/env tsx
+/**
+ * players.display_name を「その選手の全 participations 横断の最頻表記（mode）」へ
+ * 一括是正する backfill スクリプト。
+ *
+ * 既にロード済みの環境（メール承認由来の player が居る本番や、過去結果を投入済みの
+ * リハ DB など）で、first-wins で固定された display_name（例: 生は「山﨑」なのに
+ * 表示が「山崎」に化けた行）を真の最頻表記へ寄せ直す。
+ *
+ * 新規ロードでは materialize（materializeResultDraft 末尾）が touched player を
+ * 自己補正するため本スクリプトは不要。あくまで既ロード環境向けの是正＋冪等な保険。
+ * recomputePlayerDisplayNames は変化分（display_name IS DISTINCT FROM 採用表記）の
+ * みを UPDATE するため、何度流しても安全（冪等）。
+ *
+ * Usage:
+ *   DATABASE_URL=postgres://... pnpm --filter @kagetra/web exec tsx \
+ *     scripts/backfill-player-display-name.ts [--dry-run]
+ *
+ * --dry-run: 更新予定件数のみ表示し DB は一切変更しない
+ *            （tx 内で recompute → 必ず ROLLBACK）。
+ */
+
+import { config as loadEnv } from 'dotenv'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const here = dirname(fileURLToPath(import.meta.url))
+loadEnv({ path: resolve(here, '..', '.env.local') })
+
+import { Pool } from 'pg'
+import { drizzle } from 'drizzle-orm/node-postgres'
+import * as schema from '@kagetra/shared/schema'
+import { recomputePlayerDisplayNames } from '@/lib/players/recompute-display-name'
+
+/**
+ * dry-run の sentinel。tx 内で recompute → これを throw して必ず ROLLBACK させる。
+ * drizzle 内部の rollback 例外名に依存せず、この専用クラスだけを catch で握りつぶす。
+ */
+class DryRunComplete extends Error {
+  constructor(readonly count: number) {
+    super('dry-run complete')
+    this.name = 'DryRunComplete'
+  }
+}
+
+export async function main(
+  argv: readonly string[] = process.argv.slice(2),
+): Promise<void> {
+  const dryRun = argv.includes('--dry-run')
+  const databaseUrl = process.env.DATABASE_URL
+  if (!databaseUrl) throw new Error('DATABASE_URL not set')
+
+  const pool = new Pool({ connectionString: databaseUrl })
+  try {
+    const db = drizzle(pool, { schema })
+
+    if (dryRun) {
+      // tx 内で recompute して件数を確保 → 必ず throw して ROLLBACK（DB 不変）。
+      let count = 0
+      try {
+        await db.transaction(async (tx) => {
+          count = await recomputePlayerDisplayNames(tx)
+          throw new DryRunComplete(count)
+        })
+      } catch (err) {
+        // 期待した rollback sentinel だけ握りつぶす。他は rethrow。
+        if (!(err instanceof DryRunComplete)) throw err
+      }
+      process.stdout.write(
+        `[backfill-player-display-name] [dry-run] would update ${count} players (no changes written)\n`,
+      )
+      return
+    }
+
+    const n = await recomputePlayerDisplayNames(db)
+    process.stdout.write(
+      `[backfill-player-display-name] updated ${n} players\n`,
+    )
+  } finally {
+    await pool.end()
+  }
+}
+
+const isDirectRun = (() => {
+  if (!process.argv[1]) return false
+  try {
+    return fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  } catch {
+    return false
+  }
+})()
+
+if (isDirectRun) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      process.stderr.write(
+        `[backfill-player-display-name] ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`,
+      )
+      process.exit(1)
+    },
+  )
+}

--- a/apps/web/src/lib/players/recompute-display-name.test.ts
+++ b/apps/web/src/lib/players/recompute-display-name.test.ts
@@ -101,14 +101,14 @@ describe('recomputePlayerDisplayNames', () => {
     expect((await getPlayer(id)).displayName).toBe('山﨑')
   })
 
-  it('A1b: first-wins が少数派なら最頻表記へ更新する（山崎が先勝→山﨑が最頻）', async () => {
-    // 大会1: 「山崎」が先に1回入り display_name = 「山崎」(first-wins・少数派)
+  it('A1b: 少数派の stale な display_name を最頻表記へ更新する（山崎→山﨑）', async () => {
+    // 大会1: 「山崎」が先に1回（少数派の表記）
     await seedTournament({
       name: '大会1',
       eventDate: '2026-01-01',
       classes: [{ className: 'D級', participants: ['山崎'] }],
     })
-    // 大会2: 「山﨑」を2回 → 最頻は「山﨑」
+    // 大会2: 「山﨑」を2回 → 全 participation の最頻は「山﨑」
     await seedTournament({
       name: '大会2',
       eventDate: '2026-02-01',
@@ -119,7 +119,10 @@ describe('recomputePlayerDisplayNames', () => {
     })
 
     const id = (await testDb.select().from(players))[0]!.id
-    expect((await getPlayer(id)).displayName).toBe('山崎') // first-wins
+    // materialize は末尾で recompute するため既に「山﨑」に補正済み。これを backfill
+    // 対象の「first-wins で stale な少数派表記」へ意図的に戻し、recompute の是正を検証する。
+    await testDb.update(players).set({ displayName: '山崎' }).where(eq(players.id, id))
+    expect((await getPlayer(id)).displayName).toBe('山崎') // stale な少数派表記
 
     const updated = await recomputePlayerDisplayNames(testDb, [id])
     expect(updated).toBe(1)
@@ -127,7 +130,7 @@ describe('recomputePlayerDisplayNames', () => {
   })
 
   it('A2: 同数なら旧字/異体字を優先する（髙橋×1 / 高橋×1 → 髙橋）', async () => {
-    // 大会1: 「高橋」が先勝 → first-wins display_name = 「高橋」(plain)
+    // 大会1: 「高橋」(plain) を1回
     await seedTournament({
       name: '大会1',
       eventDate: '2026-01-01',
@@ -141,7 +144,10 @@ describe('recomputePlayerDisplayNames', () => {
     })
 
     const id = (await testDb.select().from(players))[0]!.id
-    expect((await getPlayer(id)).displayName).toBe('高橋') // first-wins(plain)
+    // materialize の末尾 recompute で既に「髙橋」に補正済み。tiebreak 検証のため
+    // stale な plain 表記「高橋」へ戻し、is_variant DESC が variant を選ぶことを見る。
+    await testDb.update(players).set({ displayName: '高橋' }).where(eq(players.id, id))
+    expect((await getPlayer(id)).displayName).toBe('高橋') // stale(plain)
 
     const updated = await recomputePlayerDisplayNames(testDb, [id])
     expect(updated).toBe(1)
@@ -165,7 +171,10 @@ describe('recomputePlayerDisplayNames', () => {
     })
 
     const id = (await testDb.select().from(players))[0]!.id
-    expect((await getPlayer(id)).displayName).toBe('渡邉') // first-wins(古い)
+    // materialize の末尾 recompute で既に latest の「渡邊」に補正済み。二重 tie の
+    // latest DESC を検証するため、stale な古い表記「渡邉」へ戻す。
+    await testDb.update(players).set({ displayName: '渡邉' }).where(eq(players.id, id))
+    expect((await getPlayer(id)).displayName).toBe('渡邉') // stale(古い)
 
     const updated = await recomputePlayerDisplayNames(testDb, [id])
     expect(updated).toBe(1)
@@ -215,13 +224,13 @@ describe('recomputePlayerDisplayNames', () => {
   })
 
   it('playerIds 無指定なら全 player を backfill する', async () => {
-    // 別所属で2人の player を作り、両方 first-wins が少数派になるよう仕込む。
+    // 別所属で2人の player を作る（既存ロード済みデータの backfill シナリオ）。
     await seedTournament({
       name: '大会A',
       eventDate: '2026-01-01',
       classes: [
-        { className: 'D級', participants: ['山崎'] }, // player1 first-wins=山崎
-        { className: 'E級', participants: ['髙橋'] }, // player2 first-wins=髙橋
+        { className: 'D級', participants: ['山崎'] }, // player1 (norm=山崎)
+        { className: 'E級', participants: ['髙橋'] }, // player2 (norm=高橋)
       ],
     })
     await seedTournament({
@@ -232,6 +241,11 @@ describe('recomputePlayerDisplayNames', () => {
         { className: 'E級', participants: ['高橋', '高橋'] }, // 高橋が最頻
       ],
     })
+
+    // materialize の末尾 recompute で両者とも最頻表記に補正済み。backfill 検証の
+    // ため、両 player を stale な少数派表記に意図的に戻す（= 旧データの状態を再現）。
+    await testDb.update(players).set({ displayName: '山崎' }).where(eq(players.normalizedName, '山崎'))
+    await testDb.update(players).set({ displayName: '髙橋' }).where(eq(players.normalizedName, '高橋'))
 
     const updated = await recomputePlayerDisplayNames(testDb) // 無指定=全件
     expect(updated).toBe(2)

--- a/apps/web/src/lib/players/recompute-display-name.test.ts
+++ b/apps/web/src/lib/players/recompute-display-name.test.ts
@@ -1,0 +1,244 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { players } from '@kagetra/shared/schema'
+import type { ParsedResultPayload } from '@kagetra/mail-worker/result-import/schema'
+import { closeTestDb, testDb, truncateAll } from '@/test-utils/db'
+import { materializeResultDraft } from '@/lib/result-import/materialize'
+import { recomputePlayerDisplayNames } from './recompute-display-name'
+
+beforeEach(async () => {
+  await truncateAll()
+})
+
+afterAll(async () => {
+  await closeTestDb()
+})
+
+/**
+ * A bare participant with a single name. affiliation is left null so that every
+ * spelling variant of the same name resolves to ONE player via the
+ * (normalized_name, affiliation) get-or-create key (normalizePlayerName folds
+ * 山﨑→山崎 / 髙橋→高橋, so the variant and plain forms share a normalized key).
+ */
+function participant(
+  seqNo: number,
+  name: string,
+): ParsedResultPayload['classes'][number]['participants'][number] {
+  return {
+    seqNo,
+    name,
+    nameKana: null,
+    affiliation: null,
+    prefecture: null,
+    dan: null,
+    memberNo: null,
+    finalRank: null,
+    matches: [],
+  }
+}
+
+/**
+ * Seed one tournament via the real materialize path (separate tx per call, like
+ * production where each draft approval is its own tx). The FIRST tournament that
+ * introduces a player fixes display_name = that raw name (first-wins) — exactly
+ * the state recompute is meant to correct.
+ */
+async function seedTournament(opts: {
+  name: string
+  eventDate: string | null
+  classes: { className: string; participants: string[] }[]
+}) {
+  const payload: ParsedResultPayload = {
+    parserVersion: '1.0.0',
+    classes: opts.classes.map((c) => ({
+      className: c.className,
+      grade: null,
+      sheetName: null,
+      participants: c.participants.map((n, i) => participant(i + 1, n)),
+    })),
+  }
+  return testDb.transaction((tx) =>
+    materializeResultDraft(tx, payload, {
+      tournamentName: opts.name,
+      eventDate: opts.eventDate,
+      venue: null,
+      sourceResultDraftId: 1,
+    }),
+  )
+}
+
+async function getPlayer(id: number) {
+  const rows = await testDb.select().from(players).where(eq(players.id, id))
+  return rows[0]!
+}
+
+describe('recomputePlayerDisplayNames', () => {
+  it('A1: 最頻表記を採用する（山﨑×2 / 山崎×1 → 山﨑）', async () => {
+    // 大会1: 「山﨑」を2回出場（2クラスとも同一 player に名寄せされる）
+    await seedTournament({
+      name: '大会1',
+      eventDate: '2026-01-01',
+      classes: [
+        { className: 'D級', participants: ['山﨑'] },
+        { className: 'E級', participants: ['山﨑'] },
+      ],
+    })
+    // 大会2: 「山崎」を1回。display_name は first-wins で「山﨑」のまま。
+    await seedTournament({
+      name: '大会2',
+      eventDate: '2026-02-01',
+      classes: [{ className: 'D級', participants: ['山崎'] }],
+    })
+
+    // 名寄せされて player は1行。id は RESTART IDENTITY で 1。
+    const all = await testDb.select().from(players)
+    expect(all).toHaveLength(1)
+    const id = all[0]!.id
+
+    const updated = await recomputePlayerDisplayNames(testDb, [id])
+    expect(updated).toBe(0) // 既に first-wins で「山﨑」= 最頻なので変化なし
+
+    expect((await getPlayer(id)).displayName).toBe('山﨑')
+  })
+
+  it('A1b: first-wins が少数派なら最頻表記へ更新する（山崎が先勝→山﨑が最頻）', async () => {
+    // 大会1: 「山崎」が先に1回入り display_name = 「山崎」(first-wins・少数派)
+    await seedTournament({
+      name: '大会1',
+      eventDate: '2026-01-01',
+      classes: [{ className: 'D級', participants: ['山崎'] }],
+    })
+    // 大会2: 「山﨑」を2回 → 最頻は「山﨑」
+    await seedTournament({
+      name: '大会2',
+      eventDate: '2026-02-01',
+      classes: [
+        { className: 'D級', participants: ['山﨑'] },
+        { className: 'E級', participants: ['山﨑'] },
+      ],
+    })
+
+    const id = (await testDb.select().from(players))[0]!.id
+    expect((await getPlayer(id)).displayName).toBe('山崎') // first-wins
+
+    const updated = await recomputePlayerDisplayNames(testDb, [id])
+    expect(updated).toBe(1)
+    expect((await getPlayer(id)).displayName).toBe('山﨑')
+  })
+
+  it('A2: 同数なら旧字/異体字を優先する（髙橋×1 / 高橋×1 → 髙橋）', async () => {
+    // 大会1: 「高橋」が先勝 → first-wins display_name = 「高橋」(plain)
+    await seedTournament({
+      name: '大会1',
+      eventDate: '2026-01-01',
+      classes: [{ className: 'D級', participants: ['高橋'] }],
+    })
+    // 大会2: 「髙橋」(variant) を1回。cnt は 1:1 の tie。
+    await seedTournament({
+      name: '大会2',
+      eventDate: '2026-02-01',
+      classes: [{ className: 'D級', participants: ['髙橋'] }],
+    })
+
+    const id = (await testDb.select().from(players))[0]!.id
+    expect((await getPlayer(id)).displayName).toBe('高橋') // first-wins(plain)
+
+    const updated = await recomputePlayerDisplayNames(testDb, [id])
+    expect(updated).toBe(1)
+    // tie を is_variant DESC で割る → variant の「髙橋」が勝つ
+    expect((await getPlayer(id)).displayName).toBe('髙橋')
+  })
+
+  it('A3: tie 同士が両方 variant なら最新 event_date の表記', async () => {
+    // 「渡邉」と「渡邊」はどちらも normalizePlayerName で「渡辺」に畳まれる
+    // = 両方 variant。cnt 1:1 / is_variant true:true の二重 tie。
+    // 大会1(古い): 「渡邉」/ 大会2(新しい): 「渡邊」→ 最新 event_date の「渡邊」。
+    await seedTournament({
+      name: '大会1',
+      eventDate: '2025-01-01',
+      classes: [{ className: 'D級', participants: ['渡邉'] }],
+    })
+    await seedTournament({
+      name: '大会2',
+      eventDate: '2026-06-01',
+      classes: [{ className: 'D級', participants: ['渡邊'] }],
+    })
+
+    const id = (await testDb.select().from(players))[0]!.id
+    expect((await getPlayer(id)).displayName).toBe('渡邉') // first-wins(古い)
+
+    const updated = await recomputePlayerDisplayNames(testDb, [id])
+    expect(updated).toBe(1)
+    // cnt tie + is_variant tie → latest DESC で新しい「渡邊」を採用
+    expect((await getPlayer(id)).displayName).toBe('渡邊')
+  })
+
+  it('A4: 変化なしの player は更新されない（updated_at 不変）', async () => {
+    // first-wins が既に最頻表記と一致するケース。
+    await seedTournament({
+      name: '大会1',
+      eventDate: '2026-01-01',
+      classes: [
+        { className: 'D級', participants: ['田中'] },
+        { className: 'E級', participants: ['田中'] },
+      ],
+    })
+
+    const id = (await testDb.select().from(players))[0]!.id
+    const before = await getPlayer(id)
+    expect(before.displayName).toBe('田中')
+
+    const updated = await recomputePlayerDisplayNames(testDb, [id])
+    expect(updated).toBe(0) // IS DISTINCT FROM ガードで no-op
+
+    const after = await getPlayer(id)
+    expect(after.displayName).toBe('田中')
+    // updated_at が触られていない（変化分のみ UPDATE）
+    expect(after.updatedAt.getTime()).toBe(before.updatedAt.getTime())
+  })
+
+  it('空配列を渡したら SQL を実行せず 0 を返す（全件更新の事故防止）', async () => {
+    await seedTournament({
+      name: '大会1',
+      eventDate: '2026-01-01',
+      classes: [{ className: 'D級', participants: ['佐藤'] }],
+    })
+    const id = (await testDb.select().from(players))[0]!.id
+    const before = await getPlayer(id)
+
+    const updated = await recomputePlayerDisplayNames(testDb, [])
+    expect(updated).toBe(0)
+
+    // 全件更新の事故が起きていない（updated_at 不変）
+    const after = await getPlayer(id)
+    expect(after.updatedAt.getTime()).toBe(before.updatedAt.getTime())
+  })
+
+  it('playerIds 無指定なら全 player を backfill する', async () => {
+    // 別所属で2人の player を作り、両方 first-wins が少数派になるよう仕込む。
+    await seedTournament({
+      name: '大会A',
+      eventDate: '2026-01-01',
+      classes: [
+        { className: 'D級', participants: ['山崎'] }, // player1 first-wins=山崎
+        { className: 'E級', participants: ['髙橋'] }, // player2 first-wins=髙橋
+      ],
+    })
+    await seedTournament({
+      name: '大会B',
+      eventDate: '2026-02-01',
+      classes: [
+        { className: 'D級', participants: ['山﨑', '山﨑'] }, // 山﨑が最頻
+        { className: 'E級', participants: ['高橋', '高橋'] }, // 高橋が最頻
+      ],
+    })
+
+    const updated = await recomputePlayerDisplayNames(testDb) // 無指定=全件
+    expect(updated).toBe(2)
+
+    const rows = await testDb.select().from(players)
+    const byNormalized = new Map(rows.map((r) => [r.normalizedName, r.displayName]))
+    expect(byNormalized.get('山崎')).toBe('山﨑')
+    expect(byNormalized.get('高橋')).toBe('高橋')
+  })
+})

--- a/apps/web/src/lib/players/recompute-display-name.ts
+++ b/apps/web/src/lib/players/recompute-display-name.ts
@@ -1,0 +1,89 @@
+import { sql } from 'drizzle-orm'
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres'
+import * as schema from '@kagetra/shared/schema'
+
+// Works for both NodePgDatabase (main db) and NodePgTransaction (inside a tx
+// callback) — same alias as materialize.ts:15.
+type DbLike = NodePgDatabase<typeof schema>
+
+/**
+ * players.display_name を「その選手の全 participations 横断の最頻表記（mode）」に
+ * 再計算する。`tournament_participants.name` は生データ（ロスレス）で常に正、
+ * `players.display_name` は first-wins で固定された表示用の代表表記。これを真の
+ * 最頻表記へ寄せ直す（例: 「山﨑」が大多数なのに first-wins で「山崎」化けした行を是正）。
+ *
+ * 採用順（plan.md「再計算アルゴリズム」§57-91 と一致）:
+ *   1. cnt DESC          … 出現回数が最多の表記（最頻）
+ *   2. is_variant DESC   … name <> normalized_name を優先（旧字/異体字「山﨑/髙橋」を残す）
+ *   3. latest DESC NULLS LAST … その表記が使われた最新 event_date
+ *   4. name ASC          … 完全に決定的にするための tiebreak
+ *
+ * Postgres の集約 mode 関数（ordered-set aggregate）は tiebreak を制御できない
+ * ため使わず、ranked CTE（ROW_NUMBER）で 1 件に絞る（plan.md §47）。
+ *
+ * @param db        tx でも main db でも可（DbLike）。bulk は per-tournament の tx 内、
+ *                  backfill スクリプトは main db で呼ぶ。
+ * @param playerIds 指定時のみその player に絞る。**未指定なら全 player を backfill**。
+ *                  空配列 `[]` は「対象なし」として SQL を実行せず 0 を返す
+ *                  （`ANY('{}')` で全件更新してしまう事故を防ぐ early-return）。
+ * @returns         display_name が実際に更新された player の件数。
+ */
+export async function recomputePlayerDisplayNames(
+  db: DbLike,
+  playerIds?: number[],
+): Promise<number> {
+  // 空配列ガード: scoped 呼び出しで対象が空なら何もしない。これを入れないと
+  // 後段の `ANY(${[]}::int[])` が `ANY('{}')`（= 常に false の WHERE）にはなるが、
+  // 「対象を絞ったつもりが 0 件マッチ」と「絞らず全件」を取り違える事故を断つため
+  // 明示的に早期 return する（plan のタスク指示）。
+  if (playerIds !== undefined && playerIds.length === 0) return 0
+
+  // playerIds 指定時のみ WHERE で絞る。未指定（undefined）なら WHERE を外して
+  // 全 player を対象にする（backfill）。
+  //
+  // 配列バインドの注意: drizzle の sql 補間に JS 配列をそのまま渡すと単一スカラ
+  // パラメータ化され `ANY(($1)::int[])` が `"1"` を array literal として parse
+  // しようとして `malformed array literal` で落ちる。要素ごとにプレースホルダを
+  // 展開して `ANY(ARRAY[$1,$2,...]::int[])` を組む（各要素は確実にパラメータ化、
+  // SQL インジェクション安全）。plan.md §48「inArray または ANY(${...}::int[])」
+  // の inArray も内部は同じ要素展開方式。
+  const scope =
+    playerIds === undefined
+      ? sql``
+      : sql`WHERE tp.player_id = ANY(ARRAY[${sql.join(
+          playerIds.map((id) => sql`${id}`),
+          sql`, `,
+        )}]::int[])`
+
+  // db.execute(sql`...`) は node-postgres drizzle では pg の QueryResult を返す
+  // （node_modules/.../node-postgres/session.d.ts:57-59 NodePgQueryResultHKT）。
+  // UPDATE 行数は QueryResult.rowCount（number | null）。
+  const result = await db.execute(sql`
+    WITH cand AS (
+      SELECT tp.player_id, tp.name,
+             COUNT(*) AS cnt,
+             bool_or(tp.name <> pl.normalized_name) AS is_variant,
+             MAX(t.event_date) AS latest
+      FROM tournament_participants tp
+      JOIN players pl ON pl.id = tp.player_id
+      JOIN tournament_classes tc ON tc.id = tp.class_id
+      JOIN tournaments t ON t.id = tc.tournament_id
+      ${scope}
+      GROUP BY tp.player_id, tp.name
+    ),
+    ranked AS (
+      SELECT *, ROW_NUMBER() OVER (
+        PARTITION BY player_id
+        ORDER BY cnt DESC, is_variant DESC, latest DESC NULLS LAST, name ASC
+      ) AS rn
+      FROM cand
+    )
+    UPDATE players p
+    SET display_name = r.name, updated_at = now()
+    FROM ranked r
+    WHERE r.player_id = p.id AND r.rn = 1
+      AND p.display_name IS DISTINCT FROM r.name
+  `)
+
+  return result.rowCount ?? 0
+}

--- a/apps/web/src/lib/result-import/materialize.test.ts
+++ b/apps/web/src/lib/result-import/materialize.test.ts
@@ -512,3 +512,102 @@ describe('materializeResultDraft', () => {
     expect(allPlayers).toHaveLength(1)
   })
 })
+
+describe('materializeResultDraft — display_name 再計算配線 (Phase 2)', () => {
+  // bare な単一名 participant（affiliation=null で全表記揺れが 1 player に名寄せ）。
+  function bare(
+    seqNo: number,
+    name: string,
+  ): ParsedResultPayload['classes'][number]['participants'][number] {
+    return {
+      seqNo,
+      name,
+      nameKana: null,
+      affiliation: null,
+      prefecture: null,
+      dan: null,
+      memberNo: null,
+      finalRank: null,
+      matches: [],
+    }
+  }
+
+  // 1 大会を本番同様に「独立した tx」で materialize する（draft 承認ごとに別 tx）。
+  async function materializeTournament(opts: {
+    name: string
+    eventDate: string | null
+    classes: { className: string; participants: string[] }[]
+  }) {
+    const payload: ParsedResultPayload = {
+      parserVersion: '1.0.0',
+      classes: opts.classes.map((c) => ({
+        className: c.className,
+        grade: null,
+        sheetName: null,
+        participants: c.participants.map((n, i) => bare(i + 1, n)),
+      })),
+    }
+    return testDb.transaction((tx) =>
+      materializeResultDraft(tx, payload, {
+        tournamentName: opts.name,
+        eventDate: opts.eventDate,
+        venue: null,
+        sourceResultDraftId: 1,
+      }),
+    )
+  }
+
+  it('複数大会を別 tx で materialize → display_name が全期間の最頻表記になる（first-wins を是正）', async () => {
+    // 大会1（最初）: 少数派の「山崎」が先に入る → first-wins なら「山崎」固定。
+    await materializeTournament({
+      name: '大会1',
+      eventDate: '2026-01-01',
+      classes: [{ className: 'D級', participants: ['山崎'] }],
+    })
+    // 大会2: 「山﨑」を 2 回。ここまでの全 participation の最頻は「山﨑」。
+    await materializeTournament({
+      name: '大会2',
+      eventDate: '2026-02-01',
+      classes: [
+        { className: 'D級', participants: ['山﨑'] },
+        { className: 'E級', participants: ['山﨑'] },
+      ],
+    })
+    // 大会3: さらに「山﨑」を 1 回（最頻を確定）。
+    await materializeTournament({
+      name: '大会3',
+      eventDate: '2026-03-01',
+      classes: [{ className: 'D級', participants: ['山﨑'] }],
+    })
+
+    // 山崎/山﨑 は normalizePlayerName で同一キー → player は 1 行に名寄せ。
+    const allPlayers = await testDb.select().from(players)
+    expect(allPlayers).toHaveLength(1)
+    const player = allPlayers[0]!
+
+    // 全 participation の最頻表記「山﨑」が採用されている（first-wins の「山崎」ではない）。
+    // 配線が無ければ first-wins のまま「山崎」固定になるケース。
+    expect(player.displayName).toBe('山﨑')
+
+    // 生データは各表記のままロスレスで残る（participants.name は不変）。
+    // JS デフォルトソートは符号位置順（崎 U+5D0E < 﨑 U+FA11）で「山崎」が先頭。
+    const partNames = (await testDb.select().from(tournamentParticipants))
+      .map((p) => p.name)
+      .sort()
+    expect(partNames).toEqual(['山崎', '山﨑', '山﨑', '山﨑'])
+  })
+
+  it('単一大会でも touched 経由で recompute が走り display_name がその大会の最頻になる', async () => {
+    // 1 大会内に「山崎」1 回・「山﨑」2 回。first-wins(seqNo 順)では「山崎」だが、
+    // 末尾 recompute でその大会の最頻「山﨑」へ補正される。
+    await materializeTournament({
+      name: '単一大会',
+      eventDate: '2026-04-01',
+      classes: [{ className: 'D級', participants: ['山崎', '山﨑', '山﨑'] }],
+    })
+
+    const allPlayers = await testDb.select().from(players)
+    expect(allPlayers).toHaveLength(1)
+    expect(allPlayers[0]!.displayName).toBe('山﨑')
+  })
+})

--- a/apps/web/src/lib/result-import/materialize.ts
+++ b/apps/web/src/lib/result-import/materialize.ts
@@ -10,6 +10,7 @@ import {
 } from '@kagetra/shared/schema'
 import { normalizePlayerName } from '@kagetra/mail-worker/result-import/normalize'
 import type { ParsedResultPayload } from '@kagetra/mail-worker/result-import/schema'
+import { recomputePlayerDisplayNames } from '@/lib/players/recompute-display-name'
 
 // Works for both NodePgDatabase (main db) and NodePgTransaction (inside tx callback).
 type DbLike = NodePgDatabase<typeof schema>
@@ -52,6 +53,10 @@ export async function materializeResultDraft(
     })
     .returning({ id: tournaments.id })
   const tournamentId = tournament!.id
+
+  // この tournament で作成/参照した player を集め、末尾でまとめて全 participation
+  // 横断の display_name を再計算する（first-wins ではなく最頻表記に寄せ直す）。
+  const touched = new Set<number>()
 
   // 2. Process each parsed class.
   for (const cls of payload.classes) {
@@ -141,6 +146,8 @@ export async function materializeResultDraft(
           playerId = reselect[0]!.id
         }
       }
+      // player 確定（get-or-create 完了）。末尾の display_name 再計算対象に加える。
+      touched.add(playerId)
 
       const [participant] = await tx
         .insert(tournamentParticipants)
@@ -197,6 +204,10 @@ export async function materializeResultDraft(
       }
     }
   }
+
+  // この tournament で触れた player の display_name を全 participation 横断で再計算
+  // （bulk/live 共通。caller の tx 内で実行。空 set なら関数側が 0 を返す）。
+  await recomputePlayerDisplayNames(tx, [...touched])
 
   return { tournamentId }
 }

--- a/docs/features/player-display-name-mode/plan.md
+++ b/docs/features/player-display-name-mode/plan.md
@@ -1,0 +1,135 @@
+# 実装計画: players.display_name を「代表表記（最頻の生表記）」へ
+
+- 方針②（ユーザー承認済み 2026-06-24）。memory: `project_player_name_display_mode`
+- 関連: `impl_tournament_results` / `project_bulk_load_handover`
+
+## 背景 / 目的
+
+選手マスタ `players.display_name` が現状 first-wins（最初に取り込まれた表記で固定）。
+生データ `tournament_participants.name` は「山﨑」なのに表示が「山崎」へ化けるケースが実データで 140 件。
+これを **その選手の全 participations 横断の最頻表記（mode）** に変える。
+
+- **正規化（`normalizePlayerName`）は維持**（同定キー `normalized_name` と検索の両方）。検索は異体字非依存のまま。
+- **同定キー `(normalized_name, affiliation)` は不変 → migration なし**。
+- `participants.name` はロスレスのまま（生データ層は触らない）。
+
+## スコープ
+
+In:
+1. 再計算関数 `recomputePlayerDisplayNames(db, playerIds?)`（1 SQL）
+2. `materializeResultDraft` 末尾で touched player を再計算（bulk/live 両対応）
+3. 既存行向け backfill スクリプト（冪等・--dry-run）
+
+Out（やらない）:
+- `normalizePlayerName` / `normalized_name` / UNIQUE キー / migration の変更
+- `searchPlayers` のマッチ方式変更（normalized_name 一致のまま）
+- participants.name の改変、ついでリファクタ
+
+## Phase 0: Allowed APIs / 確定事実（読込済み・引用元つき）
+
+### コード入口・型
+- `materializeResultDraft(tx, payload, opts)` … [materialize.ts:39-202](../../../apps/web/src/lib/result-import/materialize.ts)。caller の tx 内で実行。
+  - player get-or-create: SELECT→INSERT `.onConflictDoNothing()`→re-SELECT（[materialize.ts:99-143](../../../apps/web/src/lib/result-import/materialize.ts)）。`displayName: p.name`（line 118）が first-wins の発生源。
+  - participant 挿入で `name: p.name`（raw, line 154）, `playerId` 紐付け（line 149）。
+  - **追加ポイント**: 関数先頭で `const touched = new Set<number>()`、participant ループ内 `touched.add(playerId)`（line 161 付近）、class ループ後・`return` 前（line 200 付近）で `await recomputePlayerDisplayNames(tx, [...touched])`。
+- 呼び出し元（改修不要・末尾 recompute を継承）:
+  - bulk loader `apps/web/_rehearse_load.mts:138-148`（per-tournament・`db.transaction` 内、git外scratch）
+  - 本番 `approveResultDraft` … `apps/web/src/app/(app)/admin/mail-inbox/actions.ts:1443`（`db.transaction`＋FOR UPDATE 内）
+- DbLike 型は materialize.ts と同じ `NodePgDatabase<typeof schema>`（tx でも main db でも可）。
+
+### スキーマ（変更なし・参照のみ）
+- `players`（display_name / normalized_name / affiliation / updated_at）… [players.ts](../../../packages/shared/src/schema/players.ts)
+- `tournament_participants`（name=raw / class_id / player_id）… index `idx_participants_player_id` あり
+- `tournament_classes`（class_id→tournament_id）, `tournaments`（event_date）
+
+### Drizzle / SQL
+- drizzle-orm ^0.45。`db.execute(sql\`...\`)` で raw SQL 可。`sql` は `drizzle-orm` から。
+- **アンチパターン**: Postgres `mode() WITHIN GROUP` は tiebreak 制御不可 → 使わない。ranked CTE で実装。
+- player id 配列は `inArray` または `ANY(${...}::int[])` で確実にパラメータ化（リポジトリ初の複雑 SQL）。
+
+### テスト基盤
+- DB ヘルパ `@/test-utils/db`（`testDb`, `truncateAll()`, `closeTestDb()`）。`beforeEach(truncateAll)` / `afterAll(closeTestDb)`。
+- `truncateAll` は RESTART IDENTITY（id 決定的）。
+- 実行: `pnpm --filter @kagetra/web test`（`vitest run`、`fileParallelism:false`）。
+- fixture: `ParsedResultPayload`（parserVersion, classes[]）。materialize 呼び出しは `await testDb.transaction(tx => materializeResultDraft(tx, payload, opts))`。雛形 = [materialize.test.ts](../../../apps/web/src/lib/result-import/materialize.test.ts) L22-160、[queries.test.ts](../../../apps/web/src/lib/players/queries.test.ts) L1-71。
+- スクリプト雛形 = `apps/web/scripts/cleanup-expired-tokens.ts`（dotenv→Pool→`drizzle(pool,{schema})`→main()→CLI guard→`pool.end()` in finally）。実行 `pnpm --filter @kagetra/web exec tsx scripts/<name>.ts [--dry-run]`。
+
+## 再計算アルゴリズム（確定仕様）
+
+対象 player ごとに `tournament_participants.name` を集計し以下の優先順で 1 つ選び `display_name` に採用:
+1. 出現回数 `cnt` 降順（最頻）
+2. `is_variant` 降順（`name <> normalized_name` を優先＝旧字/異体字を残す）
+3. `latest` 降順（その表記が使われた最新 `event_date`、NULLS LAST）
+4. `name` 昇順（決定的）
+
+参照 SQL（実装の指針。`playerIds` 無指定なら WHERE を外して全件 backfill）:
+```sql
+WITH cand AS (
+  SELECT tp.player_id, tp.name,
+         COUNT(*) AS cnt,
+         bool_or(tp.name <> pl.normalized_name) AS is_variant,
+         MAX(t.event_date) AS latest
+  FROM tournament_participants tp
+  JOIN players pl ON pl.id = tp.player_id
+  JOIN tournament_classes tc ON tc.id = tp.class_id
+  JOIN tournaments t ON t.id = tc.tournament_id
+  WHERE tp.player_id = ANY($1::int[])      -- backfill 時は省略
+  GROUP BY tp.player_id, tp.name
+),
+ranked AS (
+  SELECT *, ROW_NUMBER() OVER (
+    PARTITION BY player_id
+    ORDER BY cnt DESC, is_variant DESC, latest DESC NULLS LAST, name ASC
+  ) AS rn
+  FROM cand
+)
+UPDATE players p
+SET display_name = r.name, updated_at = now()
+FROM ranked r
+WHERE r.player_id = p.id AND r.rn = 1
+  AND p.display_name IS DISTINCT FROM r.name;   -- 変化分のみ更新
+```
+収束性: bulk では各大会の materialize が「その大会で触れた player」を、既コミット＋tx内の全 participation を見て再計算。最後にその player を触れた大会の recompute が全 participation を見るので、ロード完了時に display_name = 全期間の真の mode。
+
+## Phase 1: recompute 関数 + テスト（テストファースト）
+
+- 先にテスト `apps/web/src/lib/players/recompute-display-name.test.ts`:
+  - A1: 同一 player を 2 大会で seed（「山﨑」×2 / 「山崎」×1）→ recompute 後 display_name = 「山﨑」。
+  - A2: tie + 旧字優先（「髙橋」×1 /「高橋」×1、別大会）→「髙橋」。
+  - A3: tie 同士が両方 variant → 最新 event_date の表記。
+  - A4: 変化なしの player は更新されない（updated_at 不変）。
+  - seed は materialize 経由（複数 tx）または直接 insert。`@/test-utils/db` 使用。
+- 実装 `apps/web/src/lib/players/recompute-display-name.ts`: 上記 SQL を `db.execute(sql\`...\`)`。返り値=更新件数。
+- 検証: 上記テスト green / `pnpm --filter @kagetra/web typecheck` / lint。grep で `mode(` `within group` 不使用を確認。
+
+## Phase 2: materialize へ配線 + テスト
+
+- `materialize.ts`: `recomputePlayerDisplayNames` を import、`touched` 集合を集めて末尾（return 前・tx 内）で呼ぶ。player 作成時の `displayName: p.name` は placeholder として残す（NOT NULL 充足、recompute が上書き）。
+- テスト追加（materialize.test.ts かまたは新規）: 2 大会を別 tx で materialize し、同一 player の display_name が最頻表記になることを assert（end-to-end）。既存 materialize.test.ts の単一大会ケースが回帰しないことも確認。
+- 検証: `pnpm --filter @kagetra/web test` green。呼び出し元（bulk/live）は無改修で挙動継承。
+
+## Phase 3: backfill スクリプト
+
+- `apps/web/scripts/backfill-player-display-name.ts`（雛形 cleanup-expired-tokens.ts）。`recomputePlayerDisplayNames(db)`（全件）を呼ぶ。`--dry-run` は更新予定件数のみ表示。
+- 用途: 既にロード済みの環境（本番でメール承認由来の player が居る場合等）の是正。**新規ロードでは materialize が自己補正するため不要**だが冪等な保険として用意。
+- 検証: リハ DB（5433/kagetra_rehearsal）で `--dry-run`→件数、実行→「生は﨑だが display が崎」140 件が解消することを Phase 4 の診断 SQL で確認。
+
+## Phase 4: 最終検証
+
+- `pnpm --filter @kagetra/web test`（全 green, fileParallelism:false） / `typecheck` / `lint`。
+- アンチパターン grep ガード:
+  - `apps/mail-worker/src/result-import/normalize.ts` に diff が無い（normalizePlayerName 不変）。
+  - `packages/shared/drizzle/` に新規 migration が無い。
+  - `searchPlayers` が `players.normalizedName` 一致のまま（queries.ts 不変 or 表示のみ）。
+- 実データ検証（リハ DB）: 投入済み 320 大会に backfill→以下が 0 近傍へ:
+  ```sql
+  select count(*) from tournament_participants pa join players pl on pl.id=pa.player_id
+  where pa.name like '%﨑%' and pl.display_name not like '%﨑%';
+  ```
+  併せて山﨑系 player の display_name が﨑で表示されることを spot check。
+
+## リスク / 順序
+
+- **順序前提**: 本番投入（過去結果 bulk）より先に本 PR をマージ。本番 tournament 系は現在空なので、最初のロードから正しい display で入り backfill 不要（[[project_bulk_load_handover]] は GO 待ちのまま）。
+- 性能: bulk で大会ごとに recompute 1 SQL（touched ~270 player、`idx_participants_player_id` 利用）。全 1453 大会でも軽微。
+- 1 PR = 1 機能（テスト＋recompute＋materialize 配線＋backfill）。


### PR DESCRIPTION
## 概要（何を）
選手マスタ `players.display_name` の選び方を **first-wins**（最初に取り込まれた表記で固定）から、**その選手の全 participations 横断の最頻表記（mode）** へ変更する。

- `recomputePlayerDisplayNames(db, playerIds?)` を追加（ranked CTE / ROW_NUMBER で 1 件に決定）
- `materializeResultDraft` 末尾で、その大会で触れた player を再計算（caller の tx 内・bulk/live 共通で自己補正）
- backfill スクリプト `scripts/backfill-player-display-name.ts`（`--dry-run` 対応・冪等）

採用順: ① 出現回数 DESC（最頻）② `name <> normalized_name` DESC（旧字/異体字「山﨑/髙橋」を残す）③ 最新 event_date DESC ④ name ASC（決定的）。

## なぜ
`tournament_participants.name`（生データ・ロスレス）は「山﨑」なのに、first-wins で `display_name` が「山崎」へ化けるケースが実データで **140 件**。正規化（同定キー）は実利が明確なので維持し、**表示の代表表記だけ**を真の最頻へ寄せ直す（方針②・承認済み）。

## 変更しないもの（Out of scope）
- `normalizePlayerName` / `normalized_name` / `(normalized_name, affiliation)` UNIQUE キー → **migration なし**
- `searchPlayers` のマッチ方式（normalized_name 一致のまま・検索は異体字非依存）
- `tournament_participants.name`（生データ層）

## テスト方法
- **全テスト**: `pnpm --filter @kagetra/web exec vitest run --no-file-parallelism` → **592 passed / 1 skip(既存)**。materialize 配線による `approveResultDraft`（actions.test.ts 117）等の回帰なし。
- **recompute 単体（7ケース）**: 最頻採用 / stale 少数派→最頻更新 / tie で旧字優先 / tie 両 variant は最新 event_date / 変化なしは updated_at 不変 / 空配列ガード / 無指定で全件 backfill。
- **実データ（リハ DB・320大会/29,719 players）**: backfill で﨑 mismatch **140→78**（残留 78 は「崎が真の最頻」の正常ケースを spot check 確認）、山﨑系 player の表示が「山﨑」へ是正、**2 回目は updated 0（冪等）**。
- `check-types` 0 / `lint` 0 / アンチパターン grep（`mode()`/`within group` 不使用、normalize・queries・shared・drizzle 無変更）。

## 関連 / 順序
- 設計 plan: `docs/features/player-display-name-mode/plan.md`（本 PR に同梱）
- **マージ順**: 過去結果 bulk 投入（PR #166）より先に本 PR をマージする想定。両者とも `materializeResultDraft` を通るため、末尾 recompute は bulk loader にも自動継承される。#166 とは materialize.ts を共有するが編集領域が別（#166=`MaterializeOpts` 型 / 本PR=関数本体）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)