### PR TITLE
feat(invite-link-registration): 招待リンクによる会員セルフ登録

### DIFF
--- a/apps/web/e2e/invite-link-registration.spec.ts
+++ b/apps/web/e2e/invite-link-registration.spec.ts
@@ -1,0 +1,186 @@
+import { expect, test } from '@playwright/test'
+import { eq } from 'drizzle-orm'
+import { registrationInvites, users } from '@kagetra/shared/schema'
+import {
+  AUTHJS_SESSION_COOKIE,
+  issueUnboundLineSession,
+  seedAdminSession,
+  seedMemberSession,
+} from '../src/test-utils/playwright-auth'
+import { createUser } from '../src/test-utils/seed'
+import { testDb, truncateAll } from '../src/test-utils/db'
+
+/**
+ * invite-link-registration E2E.
+ *
+ * Covers the registrant side (welcome → form → create, expired-link rejection,
+ * already-bound redirect) and the admin issue side. The real LINE OAuth
+ * round-trip is skipped: the "logged in via LINE, not yet bound" state is
+ * injected directly via issueUnboundLineSession (lineUserId set, id unset) —
+ * the same technique self-identify-flow.spec.ts uses.
+ */
+async function addSessionCookie(
+  context: import('@playwright/test').BrowserContext,
+  token: string,
+) {
+  await context.addCookies([
+    {
+      name: AUTHJS_SESSION_COOKIE,
+      value: token,
+      domain: 'localhost',
+      path: '/',
+      httpOnly: true,
+      sameSite: 'Lax',
+    },
+  ])
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/** Seed a registration_invites row (with a throwaway issuer for the FK). */
+async function seedInvite(
+  token: string,
+  opts?: { expiresAt?: Date; revokedAt?: Date | null },
+) {
+  const issuer = await createUser({ name: `issuer-${token}`, role: 'admin' })
+  await testDb.insert(registrationInvites).values({
+    token,
+    expiresAt: opts?.expiresAt ?? new Date(Date.now() + 7 * DAY_MS),
+    createdBy: issuer.id,
+    revokedAt: opts?.revokedAt ?? null,
+  })
+}
+
+test.describe('invite-link-registration', () => {
+  test.beforeEach(async () => {
+    await truncateAll()
+  })
+
+  test('未ログインで開くと ウェルカム + LINEで登録 ボタンが出る（フォームは出ない）', async ({
+    browser,
+  }) => {
+    await seedInvite('e2e-welcome')
+
+    const context = await browser.newContext()
+    const page = await context.newPage()
+
+    await page.goto('/register/e2e-welcome')
+    await expect(page.getByRole('button', { name: 'LINE で登録' })).toBeVisible()
+    // The name/grade form must not appear before LINE auth.
+    await expect(page.getByLabel('お名前（必須）')).toHaveCount(0)
+
+    await context.close()
+  })
+
+  test('LINEログイン済み・未紐付け → 氏名+級フォーム → 登録 → dashboard、DBに会員作成', async ({
+    browser,
+  }) => {
+    await seedInvite('e2e-form')
+    const { sessionToken } = await issueUnboundLineSession('Ureg-e2e-1')
+
+    const context = await browser.newContext()
+    await addSessionCookie(context, sessionToken)
+    const page = await context.newPage()
+
+    await page.goto('/register/e2e-form')
+    // Unbound + /register/* is the middleware exception → the form renders.
+    const nameInput = page.getByLabel('お名前（必須）')
+    await expect(nameInput).toBeVisible()
+
+    await nameInput.fill('E2E 新人')
+    await page.getByLabel('級（任意）').selectOption('B')
+    await page.getByRole('button', { name: '登録する' }).click()
+
+    // registerViaInvite redirects to /; bound users may be routed on to /dashboard.
+    await page.waitForURL(/\/(dashboard)?$/, { timeout: 5000 })
+
+    const created = await testDb.query.users.findFirst({
+      where: eq(users.name, 'E2E 新人'),
+    })
+    expect(created?.role).toBe('member')
+    expect(created?.isInvited).toBe(true)
+    expect(created?.grade).toBe('B')
+    expect(created?.lineUserId).toBe('Ureg-e2e-1')
+    expect(created?.lineLinkedMethod).toBe('invite_link')
+    expect(created?.lineLinkedAt).toBeInstanceOf(Date)
+
+    await context.close()
+  })
+
+  test('期限切れトークンは無効メッセージのみ（LINEボタンもフォームも出ない）', async ({
+    browser,
+  }) => {
+    await seedInvite('e2e-expired', { expiresAt: new Date(Date.now() - DAY_MS) })
+
+    const context = await browser.newContext()
+    const page = await context.newPage()
+
+    await page.goto('/register/e2e-expired')
+    await expect(
+      page.getByText('この招待リンクは無効か期限切れです。管理者にご連絡ください。'),
+    ).toBeVisible()
+    await expect(page.getByRole('button', { name: 'LINE で登録' })).toHaveCount(0)
+    await expect(page.getByLabel('お名前（必須）')).toHaveCount(0)
+
+    await context.close()
+  })
+
+  test('存在しないトークンも無効メッセージ', async ({ browser }) => {
+    const context = await browser.newContext()
+    const page = await context.newPage()
+
+    await page.goto('/register/no-such-token-at-all')
+    await expect(
+      page.getByText('この招待リンクは無効か期限切れです。管理者にご連絡ください。'),
+    ).toBeVisible()
+
+    await context.close()
+  })
+
+  test('既に紐付け済みの会員が開くと /register に留まらず dashboard へ', async ({
+    browser,
+  }) => {
+    await seedInvite('e2e-bound')
+    const { sessionToken } = await seedMemberSession({
+      name: 'Bound Member',
+      lineUserId: 'Ualready-bound',
+      lineLinkedAt: new Date(),
+      lineLinkedMethod: 'invite_link',
+    })
+
+    const context = await browser.newContext()
+    await addSessionCookie(context, sessionToken)
+    const page = await context.newPage()
+
+    await page.goto('/register/e2e-bound')
+    await page.waitForURL(/\/(dashboard)?$/, { timeout: 5000 })
+    expect(page.url()).not.toContain('/register/')
+
+    await context.close()
+  })
+
+  test('管理者が会員管理画面から招待リンクを発行 → モーダルにURL表示 + DBに行', async ({
+    browser,
+  }) => {
+    const { sessionToken } = await seedAdminSession({ name: 'Invite Issuer' })
+
+    const context = await browser.newContext()
+    await addSessionCookie(context, sessionToken)
+    const page = await context.newPage()
+
+    await page.goto('/admin/members')
+    await page.getByRole('button', { name: '招待リンクを発行' }).click()
+
+    await expect(
+      page.getByRole('heading', { name: '招待リンクを発行しました' }),
+    ).toBeVisible()
+    // The modal shows the full /register/<token> URL.
+    await expect(page.getByText(/\/register\//)).toBeVisible()
+
+    const rows = await testDb.select().from(registrationInvites)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.revokedAt).toBeNull()
+
+    await context.close()
+  })
+})

--- a/apps/web/src/app/(app)/admin/members/_line-link-format.ts
+++ b/apps/web/src/app/(app)/admin/members/_line-link-format.ts
@@ -4,7 +4,11 @@
  * per-member edit page so the two views stay consistent.
  */
 
-export type LineLinkMethod = 'self_identify' | 'admin_link' | 'account_switch'
+export type LineLinkMethod =
+  | 'self_identify'
+  | 'admin_link'
+  | 'account_switch'
+  | 'invite_link'
 
 /**
  * Format `line_linked_at` as `YYYY-MM-DD HH:mm` in the server's local time
@@ -19,12 +23,13 @@ export function formatLinkedAt(d: Date | null): string {
 }
 
 /**
- * Render the three enum values as short Japanese labels. Returns `'—'` for
+ * Render the enum values as short Japanese labels. Returns `'—'` for
  * null (not yet linked) so the column never shows an empty cell.
  */
 export function formatLinkMethod(m: LineLinkMethod | null): string {
   if (m === 'self_identify') return '自己申告'
   if (m === 'admin_link') return '管理者'
   if (m === 'account_switch') return '切替'
+  if (m === 'invite_link') return '招待リンク'
   return '—'
 }

--- a/apps/web/src/app/(app)/admin/members/actions.test.ts
+++ b/apps/web/src/app/(app)/admin/members/actions.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { eq } from 'drizzle-orm'
-import { users } from '@kagetra/shared/schema'
+import { registrationInvites, users } from '@kagetra/shared/schema'
 import { closeTestDb, testDb, truncateAll } from '@/test-utils/db'
 import { createAdmin, createUser, createViceAdmin } from '@/test-utils/seed'
 import { mockAuthModule, setAuthSession } from '@/test-utils/auth-mock'
@@ -8,7 +8,18 @@ import { mockAuthModule, setAuthSession } from '@/test-utils/auth-mock'
 vi.mock('@/auth', () => mockAuthModule())
 vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
 
-const { createMember } = await import('./actions')
+const {
+  createMember,
+  createRegistrationInvite,
+  revokeRegistrationInvite,
+  listActiveRegistrationInvites,
+} = await import('./actions')
+
+// Shared pool: close once after every describe in this file finishes (the
+// individual describes only truncate between tests).
+afterAll(async () => {
+  await closeTestDb()
+})
 
 function formOf(data: Record<string, string>) {
   const fd = new FormData()
@@ -23,9 +34,6 @@ async function findByName(name: string) {
 describe('createMember', () => {
   beforeEach(async () => {
     await truncateAll()
-  })
-  afterAll(async () => {
-    await closeTestDb()
   })
 
   it('管理者が名前のみで作成できる（grade=null, role=member, isInvited=true, 未紐付け）', async () => {
@@ -152,5 +160,205 @@ describe('createMember', () => {
 
     // 行は増えていない
     expect(await findByName('重複会員')).toHaveLength(1)
+  })
+})
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000
+
+describe('createRegistrationInvite', () => {
+  const ORIGINAL_BASE_URL = process.env.PUBLIC_BASE_URL
+
+  beforeEach(async () => {
+    await truncateAll()
+    // Pin the origin so the action returns a deterministic URL without needing
+    // a request context (resolveRegistrationBaseUrl checks env before headers()).
+    process.env.PUBLIC_BASE_URL = 'https://test.example.com'
+  })
+  afterAll(() => {
+    if (ORIGINAL_BASE_URL === undefined) delete process.env.PUBLIC_BASE_URL
+    else process.env.PUBLIC_BASE_URL = ORIGINAL_BASE_URL
+  })
+
+  it('管理者が発行すると行が作成され、完全URLと失効日時を返す', async () => {
+    const admin = await createAdmin({ name: 'inv-admin-1' })
+    await setAuthSession({ id: admin.id, role: 'admin' })
+
+    const before = Date.now()
+    const result = await createRegistrationInvite('7d')
+    const after = Date.now()
+
+    expect(result.error).toBeUndefined()
+    expect(result.url).toMatch(/^https:\/\/test\.example\.com\/register\/[A-Za-z0-9_-]{43}$/)
+    expect(result.expiresAt).toBeDefined()
+
+    const rows = await testDb.select().from(registrationInvites)
+    expect(rows).toHaveLength(1)
+    const row = rows[0]
+    expect(row?.createdBy).toBe(admin.id)
+    expect(row?.revokedAt).toBeNull()
+    // The returned URL ends with the stored token.
+    expect(result.url?.endsWith(row!.token)).toBe(true)
+    // Expiry ≈ now + 7d.
+    const exp = row!.expiresAt.getTime()
+    expect(exp).toBeGreaterThanOrEqual(before + SEVEN_DAYS_MS - 1000)
+    expect(exp).toBeLessThanOrEqual(after + SEVEN_DAYS_MS + 1000)
+  })
+
+  it('vice_admin も発行できる', async () => {
+    const vice = await createViceAdmin({ name: 'inv-vice-1' })
+    await setAuthSession({ id: vice.id, role: 'vice_admin' })
+
+    const result = await createRegistrationInvite('1d')
+    expect(result.url).toBeDefined()
+    expect(await testDb.select().from(registrationInvites)).toHaveLength(1)
+  })
+
+  it('一般会員が呼ぶと拒否され、行は作成されない', async () => {
+    const member = await createUser({ name: 'inv-member-1', role: 'member' })
+    await setAuthSession({ id: member.id, role: 'member' })
+
+    await expect(createRegistrationInvite('7d')).rejects.toThrow(/Unauthorized/)
+    expect(await testDb.select().from(registrationInvites)).toHaveLength(0)
+  })
+
+  it('未認証なら拒否される', async () => {
+    await setAuthSession(null)
+    await expect(createRegistrationInvite('7d')).rejects.toThrow(/Unauthorized/)
+    expect(await testDb.select().from(registrationInvites)).toHaveLength(0)
+  })
+
+  it('不正なプリセットはエラー、行は作成されない', async () => {
+    const admin = await createAdmin({ name: 'inv-admin-2' })
+    await setAuthSession({ id: admin.id, role: 'admin' })
+
+    const result = await createRegistrationInvite('999d')
+    expect(result.error).toBeDefined()
+    expect(result.url).toBeUndefined()
+    expect(await testDb.select().from(registrationInvites)).toHaveLength(0)
+  })
+})
+
+describe('revokeRegistrationInvite', () => {
+  beforeEach(async () => {
+    await truncateAll()
+  })
+
+  it('管理者が無効化すると revoked_at がセットされる', async () => {
+    const admin = await createAdmin({ name: 'rev-admin-1' })
+    await setAuthSession({ id: admin.id, role: 'admin' })
+    const [row] = await testDb
+      .insert(registrationInvites)
+      .values({
+        token: 'token-to-revoke',
+        expiresAt: new Date(Date.now() + SEVEN_DAYS_MS),
+        createdBy: admin.id,
+      })
+      .returning()
+
+    const before = Date.now()
+    const result = await revokeRegistrationInvite(row!.id)
+    expect(result.success).toBe(true)
+
+    const [after] = await testDb
+      .select()
+      .from(registrationInvites)
+      .where(eq(registrationInvites.id, row!.id))
+    expect(after?.revokedAt).toBeInstanceOf(Date)
+    expect(after!.revokedAt!.getTime()).toBeGreaterThanOrEqual(before - 1000)
+  })
+
+  it('一般会員が呼ぶと拒否され、revoked_at は変わらない', async () => {
+    const admin = await createAdmin({ name: 'rev-admin-2' })
+    const [row] = await testDb
+      .insert(registrationInvites)
+      .values({
+        token: 'token-stays',
+        expiresAt: new Date(Date.now() + SEVEN_DAYS_MS),
+        createdBy: admin.id,
+      })
+      .returning()
+    const member = await createUser({ name: 'rev-member-1', role: 'member' })
+    await setAuthSession({ id: member.id, role: 'member' })
+
+    await expect(revokeRegistrationInvite(row!.id)).rejects.toThrow(/Unauthorized/)
+    const [unchanged] = await testDb
+      .select()
+      .from(registrationInvites)
+      .where(eq(registrationInvites.id, row!.id))
+    expect(unchanged?.revokedAt).toBeNull()
+  })
+
+  it('二重無効化は最初の revoked_at を保持する（冪等）', async () => {
+    const admin = await createAdmin({ name: 'rev-admin-3' })
+    await setAuthSession({ id: admin.id, role: 'admin' })
+    const firstRevoked = new Date('2026-06-01T00:00:00Z')
+    const [row] = await testDb
+      .insert(registrationInvites)
+      .values({
+        token: 'token-already-revoked',
+        expiresAt: new Date(Date.now() + SEVEN_DAYS_MS),
+        createdBy: admin.id,
+        revokedAt: firstRevoked,
+      })
+      .returning()
+
+    const result = await revokeRegistrationInvite(row!.id)
+    expect(result.success).toBe(true)
+    const [after] = await testDb
+      .select()
+      .from(registrationInvites)
+      .where(eq(registrationInvites.id, row!.id))
+    expect(after?.revokedAt?.toISOString()).toBe(firstRevoked.toISOString())
+  })
+})
+
+describe('listActiveRegistrationInvites', () => {
+  beforeEach(async () => {
+    await truncateAll()
+  })
+
+  it('未失効・未無効化のリンクのみを新しい順で返す', async () => {
+    const admin = await createAdmin({ name: 'list-admin-1' })
+    await setAuthSession({ id: admin.id, role: 'admin' })
+    const now = new Date('2026-06-26T00:00:00Z')
+    const future = new Date(now.getTime() + 86_400_000)
+    const past = new Date(now.getTime() - 86_400_000)
+
+    await testDb.insert(registrationInvites).values([
+      {
+        token: 'active-old',
+        expiresAt: future,
+        createdBy: admin.id,
+        createdAt: new Date('2026-06-20T00:00:00Z'),
+      },
+      {
+        token: 'active-new',
+        expiresAt: future,
+        createdBy: admin.id,
+        createdAt: new Date('2026-06-25T00:00:00Z'),
+      },
+      {
+        token: 'expired',
+        expiresAt: past,
+        createdBy: admin.id,
+        createdAt: new Date('2026-06-24T00:00:00Z'),
+      },
+      {
+        token: 'revoked',
+        expiresAt: future,
+        createdBy: admin.id,
+        createdAt: new Date('2026-06-24T00:00:00Z'),
+        revokedAt: now,
+      },
+    ])
+
+    const list = await listActiveRegistrationInvites(now)
+    expect(list.map((l) => l.token)).toEqual(['active-new', 'active-old'])
+  })
+
+  it('一般会員が呼ぶと拒否される', async () => {
+    const member = await createUser({ name: 'list-member-1', role: 'member' })
+    await setAuthSession({ id: member.id, role: 'member' })
+    await expect(listActiveRegistrationInvites()).rejects.toThrow(/Unauthorized/)
   })
 })

--- a/apps/web/src/app/(app)/admin/members/actions.ts
+++ b/apps/web/src/app/(app)/admin/members/actions.ts
@@ -1,11 +1,18 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
+import { headers } from 'next/headers'
+import { and, desc, eq, gt, isNull } from 'drizzle-orm'
 import { z } from 'zod'
 import { auth } from '@/auth'
 import { db } from '@/lib/db'
 import { isUniqueViolation } from '@/lib/db-errors'
-import { users } from '@kagetra/shared/schema'
+import {
+  generateRegistrationToken,
+  isValidExpiryPreset,
+  registrationInviteExpiresAt,
+} from '@/lib/registration-invite'
+import { registrationInvites, users } from '@kagetra/shared/schema'
 
 const GRADES = ['A', 'B', 'C', 'D', 'E'] as const
 
@@ -86,4 +93,122 @@ export async function createMember(
 
   revalidatePath('/admin/members')
   return { success: true }
+}
+
+/**
+ * Resolve the public origin for a `/register/<token>` link.
+ *
+ * Prefers `PUBLIC_BASE_URL` (the explicit prod origin, also used by the LINE
+ * broadcast helpers and reliably set in production); falls back to the incoming
+ * request's host so dev / preview environments produce working links without
+ * extra config. The env path is checked first so unit tests can pin the origin
+ * without a request context.
+ */
+async function resolveRegistrationBaseUrl(): Promise<string> {
+  const envBase = process.env.PUBLIC_BASE_URL?.replace(/\/$/, '')
+  if (envBase) return envBase
+  const h = await headers()
+  const host = h.get('x-forwarded-host') ?? h.get('host')
+  if (!host) throw new Error('登録URLのホストを特定できません')
+  const proto = h.get('x-forwarded-proto') ?? 'http'
+  return `${proto}://${host}`
+}
+
+export type CreateRegistrationInviteState = {
+  error?: string
+  /** Full `/register/<token>` URL — shown + copied in the issue modal. */
+  url?: string
+  /** ISO expiry, for the modal countdown / failure date display. */
+  expiresAt?: string
+}
+
+/**
+ * Issue a self-registration link. admin / vice_admin only (same authz as
+ * createMember). One link is reusable by multiple people until it expires or is
+ * revoked — there is no usage cap (requirements §6). Returns the full URL so the
+ * modal can display and copy it; the token itself is never shown elsewhere.
+ */
+export async function createRegistrationInvite(
+  preset: string,
+): Promise<CreateRegistrationInviteState> {
+  const session = await assertAdminSession()
+  const createdBy = session.user?.id
+  if (!createdBy) {
+    // assertAdminSession guarantees a bound admin/vice_admin; defensive only.
+    throw new Error('Unauthorized')
+  }
+
+  if (!isValidExpiryPreset(preset)) {
+    return { error: '有効期限の指定が不正です' }
+  }
+
+  const now = new Date()
+  const expiresAt = registrationInviteExpiresAt(preset, now)
+  const token = generateRegistrationToken()
+
+  await db.insert(registrationInvites).values({
+    token,
+    expiresAt,
+    createdBy,
+    createdAt: now,
+  })
+
+  const baseUrl = await resolveRegistrationBaseUrl()
+  revalidatePath('/admin/members')
+  return { url: `${baseUrl}/register/${token}`, expiresAt: expiresAt.toISOString() }
+}
+
+export type RevokeRegistrationInviteState = {
+  error?: string
+  success?: boolean
+}
+
+/**
+ * Revoke an invite link (the mis-distribution safety valve). admin / vice_admin
+ * only. Idempotent: the `revoked_at IS NULL` guard means re-revoking is a no-op
+ * that preserves the original revoke time. Revoking a missing / already-revoked
+ * link is treated as success (the UI only ever lists active links anyway).
+ */
+export async function revokeRegistrationInvite(
+  id: string,
+): Promise<RevokeRegistrationInviteState> {
+  await assertAdminSession()
+
+  await db
+    .update(registrationInvites)
+    .set({ revokedAt: new Date() })
+    .where(and(eq(registrationInvites.id, id), isNull(registrationInvites.revokedAt)))
+
+  revalidatePath('/admin/members')
+  return { success: true }
+}
+
+export type ActiveRegistrationInvite = {
+  id: string
+  token: string
+  createdAt: Date
+  expiresAt: Date
+}
+
+/**
+ * List currently-valid invite links (not revoked, not expired), newest first,
+ * for the admin members page. admin / vice_admin only — this is a `'use server'`
+ * export, so it is reachable as an RPC and must guard authz itself rather than
+ * relying on the page's gate.
+ */
+export async function listActiveRegistrationInvites(
+  now: Date = new Date(),
+): Promise<ActiveRegistrationInvite[]> {
+  await assertAdminSession()
+
+  return db
+    .select({
+      id: registrationInvites.id,
+      token: registrationInvites.token,
+      createdAt: registrationInvites.createdAt,
+      expiresAt: registrationInvites.expiresAt,
+    })
+    .from(registrationInvites)
+    .where(and(isNull(registrationInvites.revokedAt), gt(registrationInvites.expiresAt, now)))
+    .orderBy(desc(registrationInvites.createdAt))
 }

--- a/apps/web/src/app/(app)/admin/members/page.tsx
+++ b/apps/web/src/app/(app)/admin/members/page.tsx
@@ -8,6 +8,8 @@ import { eq } from 'drizzle-orm'
 import { revalidatePath } from 'next/cache'
 import { formatLinkedAt, formatLinkMethod } from './_line-link-format'
 import { NewMemberForm } from './new-member-form'
+import { RegistrationInviteSection } from './registration-invite-section'
+import { listActiveRegistrationInvites } from './actions'
 
 const GRADES: readonly Grade[] = ['A', 'B', 'C', 'D', 'E'] as const
 
@@ -48,26 +50,30 @@ export default async function MembersPage() {
     redirect('/403')
   }
 
-  const memberList = await db.query.users.findMany({
-    columns: {
-      id: true,
-      name: true,
-      role: true,
-      grade: true,
-      isInvited: true,
-      createdAt: true,
-      deactivatedAt: true,
-      lineUserId: true,
-      lineLinkedAt: true,
-      lineLinkedMethod: true,
-    },
-    orderBy: (users, { asc }) => [asc(users.createdAt)],
-  })
+  const [memberList, activeInvites] = await Promise.all([
+    db.query.users.findMany({
+      columns: {
+        id: true,
+        name: true,
+        role: true,
+        grade: true,
+        isInvited: true,
+        createdAt: true,
+        deactivatedAt: true,
+        lineUserId: true,
+        lineLinkedAt: true,
+        lineLinkedMethod: true,
+      },
+      orderBy: (users, { asc }) => [asc(users.createdAt)],
+    }),
+    listActiveRegistrationInvites(),
+  ])
 
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-bold">会員管理</h2>
       <NewMemberForm />
+      <RegistrationInviteSection activeInvites={activeInvites} />
       <div className="overflow-x-auto rounded-lg bg-white shadow-sm">
         <table className="min-w-full divide-y divide-gray-200">
           <thead className="bg-gray-50">

--- a/apps/web/src/app/(app)/admin/members/registration-invite-section.tsx
+++ b/apps/web/src/app/(app)/admin/members/registration-invite-section.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import {
+  createRegistrationInvite,
+  revokeRegistrationInvite,
+  type ActiveRegistrationInvite,
+} from './actions'
+import {
+  RegistrationInviteModal,
+  type RegistrationInvitePayload,
+} from '@/components/admin/RegistrationInviteModal'
+import {
+  DEFAULT_EXPIRY_PRESET,
+  EXPIRY_PRESET_OPTIONS,
+  type RegistrationInviteExpiryPreset,
+} from '@/lib/registration-invite'
+
+const PRESET_LABELS: Record<RegistrationInviteExpiryPreset, string> = {
+  '1d': '1日',
+  '7d': '7日',
+  '30d': '30日',
+}
+
+function formatDateTime(d: Date): string {
+  return d.toLocaleString('ja-JP', { dateStyle: 'short', timeStyle: 'short' })
+}
+
+/**
+ * Admin "招待リンク" section: pick an expiry preset, issue a link (opens the
+ * URL/copy modal), and revoke any currently-active link. `activeInvites` is
+ * fetched server-side and refreshed automatically — both actions call
+ * revalidatePath('/admin/members'), so issuing/revoking re-renders this list.
+ */
+export function RegistrationInviteSection({
+  activeInvites,
+}: {
+  activeInvites: ActiveRegistrationInvite[]
+}) {
+  const [preset, setPreset] = useState<RegistrationInviteExpiryPreset>(DEFAULT_EXPIRY_PRESET)
+  const [payload, setPayload] = useState<RegistrationInvitePayload | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [issuing, startIssue] = useTransition()
+  const [revokingId, setRevokingId] = useState<string | null>(null)
+  const [, startRevoke] = useTransition()
+
+  function handleIssue() {
+    setError(null)
+    startIssue(async () => {
+      const result = await createRegistrationInvite(preset)
+      if (result.error) {
+        setError(result.error)
+        return
+      }
+      if (result.url && result.expiresAt) {
+        setPayload({ url: result.url, expiresAt: new Date(result.expiresAt) })
+      }
+    })
+  }
+
+  function handleRevoke(id: string) {
+    setRevokingId(id)
+    startRevoke(async () => {
+      try {
+        await revokeRegistrationInvite(id)
+      } finally {
+        setRevokingId(null)
+      }
+    })
+  }
+
+  return (
+    <section className="space-y-3 rounded-lg bg-white p-4 shadow-sm">
+      <div>
+        <h3 className="text-sm font-semibold text-gray-900">招待リンク</h3>
+        <p className="mt-1 text-xs text-gray-500">
+          URLを渡すだけで本人が会員登録できます。期限内なら複数の人が利用できます。
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-end gap-2">
+        <label className="text-sm text-gray-700">
+          有効期限
+          <select
+            value={preset}
+            onChange={(e) => setPreset(e.target.value as RegistrationInviteExpiryPreset)}
+            className="ml-2 rounded-md border border-gray-300 px-2 py-1 text-sm"
+            aria-label="招待リンクの有効期限"
+          >
+            {EXPIRY_PRESET_OPTIONS.map((p) => (
+              <option key={p} value={p}>
+                {PRESET_LABELS[p]}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button
+          type="button"
+          onClick={handleIssue}
+          disabled={issuing}
+          className="rounded-md bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand/90 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {issuing ? '発行中…' : '招待リンクを発行'}
+        </button>
+      </div>
+
+      {error && (
+        <p role="alert" className="text-sm text-red-600">
+          {error}
+        </p>
+      )}
+
+      {activeInvites.length > 0 && (
+        <div className="space-y-2">
+          <h4 className="text-xs font-semibold text-gray-700">現在有効な招待リンク</h4>
+          <ul className="divide-y divide-gray-200 rounded-md border border-gray-200">
+            {activeInvites.map((inv) => (
+              <li
+                key={inv.id}
+                className="flex flex-wrap items-center justify-between gap-2 px-3 py-2 text-xs"
+              >
+                <span className="text-gray-600">
+                  発行 {formatDateTime(inv.createdAt)} ／ 失効 {formatDateTime(inv.expiresAt)}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => handleRevoke(inv.id)}
+                  disabled={revokingId === inv.id}
+                  className="rounded-md bg-gray-100 px-3 py-1 text-xs text-gray-700 hover:bg-gray-200 disabled:opacity-60"
+                >
+                  {revokingId === inv.id ? '無効化中…' : '無効化'}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <RegistrationInviteModal payload={payload} onClose={() => setPayload(null)} />
+    </section>
+  )
+}

--- a/apps/web/src/app/register/[token]/actions.test.ts
+++ b/apps/web/src/app/register/[token]/actions.test.ts
@@ -1,0 +1,182 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { registrationInvites, users } from '@kagetra/shared/schema'
+import { closeTestDb, testDb, truncateAll } from '@/test-utils/db'
+import { createUser } from '@/test-utils/seed'
+import { mockAuthModule, setAuthSession } from '@/test-utils/auth-mock'
+
+vi.mock('@/auth', () => {
+  const mod = mockAuthModule() as unknown as Record<string, unknown>
+  mod.unstable_update = vi.fn().mockResolvedValue(null)
+  return mod
+})
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+const { registerViaInvite } = await import('./actions')
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+function formOf(data: Record<string, string>): FormData {
+  const fd = new FormData()
+  for (const [k, v] of Object.entries(data)) fd.set(k, v)
+  return fd
+}
+
+function expectRedirect(err: unknown, pathPart: string) {
+  if (typeof err !== 'object' || err === null) throw err
+  const digest = (err as { digest?: unknown }).digest
+  if (typeof digest !== 'string' || !digest.includes('NEXT_REDIRECT')) throw err
+  if (!digest.includes(pathPart)) {
+    throw new Error(`expected redirect to include "${pathPart}", got "${digest}"`)
+  }
+}
+
+async function seedInvite(
+  createdBy: string,
+  opts?: { token?: string; expiresAt?: Date; revokedAt?: Date | null },
+): Promise<string> {
+  const token = opts?.token ?? 'valid-token'
+  await testDb.insert(registrationInvites).values({
+    token,
+    expiresAt: opts?.expiresAt ?? new Date(Date.now() + 7 * DAY_MS),
+    createdBy,
+    revokedAt: opts?.revokedAt ?? null,
+  })
+  return token
+}
+
+const NEXT_REDIRECT = { digest: expect.stringContaining('NEXT_REDIRECT') }
+
+describe('registerViaInvite', () => {
+  beforeEach(async () => {
+    await truncateAll()
+  })
+  afterEach(() => vi.restoreAllMocks())
+  afterAll(async () => {
+    await closeTestDb()
+  })
+
+  it('正常系: 氏名+級 → role=member / method=invite_link / lineUserId 紐付け で作成され / へ', async () => {
+    const issuer = await createUser({ name: 'issuer-1', role: 'admin' })
+    const token = await seedInvite(issuer.id)
+    await setAuthSession({ id: '', role: 'member', lineUserId: 'Unew-1' })
+
+    await expect(
+      registerViaInvite(token, {}, formOf({ name: '新人太郎', grade: 'C' })),
+    ).rejects.toMatchObject(NEXT_REDIRECT)
+
+    const created = await testDb.query.users.findFirst({ where: eq(users.name, '新人太郎') })
+    expect(created).toBeDefined()
+    expect(created?.role).toBe('member')
+    expect(created?.isInvited).toBe(true)
+    expect(created?.invitedAt).toBeInstanceOf(Date)
+    expect(created?.grade).toBe('C')
+    expect(created?.lineUserId).toBe('Unew-1')
+    expect(created?.lineLinkedMethod).toBe('invite_link')
+    expect(created?.lineLinkedAt).toBeInstanceOf(Date)
+  })
+
+  it('級未選択でも作成できる（grade=null）', async () => {
+    const issuer = await createUser({ name: 'issuer-2', role: 'admin' })
+    const token = await seedInvite(issuer.id)
+    await setAuthSession({ id: '', role: 'member', lineUserId: 'Unew-2' })
+
+    await expect(
+      registerViaInvite(token, {}, formOf({ name: '級なし花子', grade: '' })),
+    ).rejects.toMatchObject(NEXT_REDIRECT)
+
+    const created = await testDb.query.users.findFirst({ where: eq(users.name, '級なし花子') })
+    expect(created?.grade).toBeNull()
+    expect(created?.lineLinkedMethod).toBe('invite_link')
+  })
+
+  it('期限切れトークンは拒否、会員は作成されない', async () => {
+    const issuer = await createUser({ name: 'issuer-3', role: 'admin' })
+    const token = await seedInvite(issuer.id, { expiresAt: new Date(Date.now() - DAY_MS) })
+    await setAuthSession({ id: '', role: 'member', lineUserId: 'Unew-3' })
+
+    const result = await registerViaInvite(token, {}, formOf({ name: '期限切れ人', grade: '' }))
+    expect(result.error).toBeDefined()
+    expect(await testDb.query.users.findFirst({ where: eq(users.lineUserId, 'Unew-3') })).toBeUndefined()
+  })
+
+  it('無効化済みトークンは拒否', async () => {
+    const issuer = await createUser({ name: 'issuer-4', role: 'admin' })
+    const token = await seedInvite(issuer.id, { revokedAt: new Date() })
+    await setAuthSession({ id: '', role: 'member', lineUserId: 'Unew-4' })
+
+    const result = await registerViaInvite(token, {}, formOf({ name: '無効化人', grade: '' }))
+    expect(result.error).toBeDefined()
+    expect(await testDb.query.users.findFirst({ where: eq(users.lineUserId, 'Unew-4') })).toBeUndefined()
+  })
+
+  it('存在しないトークンは拒否', async () => {
+    await setAuthSession({ id: '', role: 'member', lineUserId: 'Unew-5' })
+    const result = await registerViaInvite('no-such-token', {}, formOf({ name: '幽霊', grade: '' }))
+    expect(result.error).toBeDefined()
+    expect(await testDb.query.users.findFirst({ where: eq(users.lineUserId, 'Unew-5') })).toBeUndefined()
+  })
+
+  it('氏名未入力はエラー、会員は作成されない', async () => {
+    const issuer = await createUser({ name: 'issuer-6', role: 'admin' })
+    const token = await seedInvite(issuer.id)
+    await setAuthSession({ id: '', role: 'member', lineUserId: 'Unew-6' })
+
+    const result = await registerViaInvite(token, {}, formOf({ name: '   ', grade: '' }))
+    expect(result.error).toBeDefined()
+    expect(await testDb.query.users.findFirst({ where: eq(users.lineUserId, 'Unew-6') })).toBeUndefined()
+  })
+
+  it('同名の会員が既に存在するとエラー（退会済み含む）', async () => {
+    const issuer = await createUser({ name: 'issuer-7', role: 'admin' })
+    const token = await seedInvite(issuer.id)
+    await createUser({ name: '重複君', deactivatedAt: new Date(), lineUserId: null })
+    await setAuthSession({ id: '', role: 'member', lineUserId: 'Unew-7' })
+
+    const result = await registerViaInvite(token, {}, formOf({ name: '重複君', grade: '' }))
+    expect(result.error).toBe('同名の会員が既に存在します。管理者にご連絡ください。')
+    // The new LINE account was not bound to anything.
+    expect(await testDb.query.users.findFirst({ where: eq(users.lineUserId, 'Unew-7') })).toBeUndefined()
+  })
+
+  it('同一LINEアカウントの二重登録は / へ誘導し、新規行は作られない', async () => {
+    const issuer = await createUser({ name: 'issuer-8', role: 'admin' })
+    const token = await seedInvite(issuer.id)
+    // This LINE account already has a member row (different name).
+    await createUser({ name: '既存会員', lineUserId: 'Udup', isInvited: true })
+    await setAuthSession({ id: '', role: 'member', lineUserId: 'Udup' })
+
+    await expect(
+      registerViaInvite(token, {}, formOf({ name: '別名前', grade: '' })),
+    ).rejects.toMatchObject(NEXT_REDIRECT)
+
+    // No new row for the new name; the LINE account still maps to exactly one row.
+    expect(await testDb.query.users.findFirst({ where: eq(users.name, '別名前') })).toBeUndefined()
+    expect(await testDb.select().from(users).where(eq(users.lineUserId, 'Udup'))).toHaveLength(1)
+  })
+
+  it('既にバインド済み (session.user.id あり) は / へ、作成しない', async () => {
+    const issuer = await createUser({ name: 'issuer-9', role: 'admin' })
+    const token = await seedInvite(issuer.id)
+    await setAuthSession({ id: 'some-internal-id', role: 'member', lineUserId: 'Ubound' })
+
+    await expect(
+      registerViaInvite(token, {}, formOf({ name: 'バインド済み', grade: '' })),
+    ).rejects.toMatchObject(NEXT_REDIRECT)
+    expect(await testDb.query.users.findFirst({ where: eq(users.name, 'バインド済み') })).toBeUndefined()
+  })
+
+  it('LINEセッションが無い場合は /register/<token> へ戻す', async () => {
+    const issuer = await createUser({ name: 'issuer-10', role: 'admin' })
+    const token = await seedInvite(issuer.id)
+    await setAuthSession(null)
+
+    try {
+      await registerViaInvite(token, {}, formOf({ name: 'セッション無し', grade: '' }))
+      throw new Error('expected redirect')
+    } catch (err) {
+      expectRedirect(err, `/register/${token}`)
+    }
+    expect(await testDb.query.users.findFirst({ where: eq(users.name, 'セッション無し') })).toBeUndefined()
+  })
+})

--- a/apps/web/src/app/register/[token]/actions.ts
+++ b/apps/web/src/app/register/[token]/actions.ts
@@ -1,0 +1,131 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { redirect } from 'next/navigation'
+import { eq } from 'drizzle-orm'
+import { z } from 'zod'
+import { auth, unstable_update } from '@/auth'
+import { db } from '@/lib/db'
+import { isUniqueViolation, uniqueViolationConstraint } from '@/lib/db-errors'
+import { isRegistrationInviteUsable } from '@/lib/registration-invite'
+import { registrationInvites, users } from '@kagetra/shared/schema'
+
+const GRADES = ['A', 'B', 'C', 'D', 'E'] as const
+
+// Mirrors createMember's input contract (name 1–50, grade A–E or null). Kept
+// local so the public register flow doesn't depend on the admin actions module.
+const registerSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, '名前を入力してください')
+    .max(50, '名前は50文字以内で入力してください'),
+  grade: z.enum(GRADES).nullable(),
+})
+
+function gradeEntryOrNull(raw: FormDataEntryValue | null): string | null {
+  if (typeof raw !== 'string') return null
+  const s = raw.trim()
+  return s.length === 0 ? null : s
+}
+
+export type RegisterViaInviteState = {
+  error?: string
+}
+
+/**
+ * Complete invite-link self-registration: create the member row and bind it to
+ * the current LINE session.
+ *
+ * `token` is bound via `.bind(null, token)` in the form so this stays a
+ * useActionState `(prevState, formData)` action. Flow:
+ *   1. Already bound (session.user.id) → nothing to do, go to dashboard.
+ *      No LINE session yet → bounce back to the link to (re)start OAuth.
+ *   2. Re-validate the token (not revoked, not expired) — the page also checked
+ *      at render, but an open tab can cross the expiry, so re-check at submit.
+ *   3. Validate name/grade.
+ *   4. INSERT users(role=member, isInvited, lineUserId, method=invite_link).
+ *      users.name UNIQUE → contact-admin message; users.line_user_id UNIQUE
+ *      (double-submit / race — this LINE account already registered) → just log
+ *      them in.
+ *   5. Best-effort JWT refresh (self-heals via nodeJwtCallback if it fails) →
+ *      dashboard.
+ */
+export async function registerViaInvite(
+  token: string,
+  _prev: RegisterViaInviteState,
+  formData: FormData,
+): Promise<RegisterViaInviteState> {
+  const session = await auth()
+  // Already a fully-bound member → registration is unnecessary.
+  if (session?.user?.id) redirect('/')
+  // LINE OAuth not completed (or session expired between render and submit):
+  // send them back to the link, which shows the "LINEで登録" button.
+  const lineUserId = session?.user?.lineUserId
+  if (!lineUserId) redirect(`/register/${token}`)
+
+  // Re-validate the token at submit time (revoked / expired since render).
+  const invite = await db.query.registrationInvites.findFirst({
+    where: eq(registrationInvites.token, token),
+    columns: { revokedAt: true, expiresAt: true },
+  })
+  if (!isRegistrationInviteUsable(invite)) {
+    return { error: '招待リンクの有効期限が切れています。' }
+  }
+
+  const parsed = registerSchema.safeParse({
+    name: typeof formData.get('name') === 'string' ? formData.get('name') : '',
+    grade: gradeEntryOrNull(formData.get('grade')),
+  })
+  if (!parsed.success) {
+    return { error: parsed.error.issues[0]?.message ?? '入力が不正です' }
+  }
+
+  const now = new Date()
+  try {
+    await db.insert(users).values({
+      name: parsed.data.name,
+      grade: parsed.data.grade,
+      role: 'member',
+      isInvited: true,
+      invitedAt: now,
+      lineUserId,
+      lineLinkedAt: now,
+      lineLinkedMethod: 'invite_link',
+    })
+  } catch (err) {
+    // redirect() throws a sentinel — let Next.js handle it.
+    if (isRedirectError(err)) throw err
+    if (isUniqueViolation(err)) {
+      const constraint = uniqueViolationConstraint(err) ?? ''
+      // Same LINE account already has a member row (double-submit / race):
+      // the registration effectively already happened → log them straight in.
+      if (constraint.includes('line_user_id')) {
+        redirect('/')
+      }
+      // Otherwise the name collided (users.name UNIQUE, incl. deactivated).
+      return { error: '同名の会員が既に存在します。管理者にご連絡ください。' }
+    }
+    throw err
+  }
+
+  try {
+    await unstable_update({
+      user: {
+        lineLinkedAt: now.toISOString(),
+        lineLinkedMethod: 'invite_link',
+      },
+    })
+  } catch {
+    // JWT refresh failure self-heals on the next Node render via nodeJwtCallback.
+  }
+
+  revalidatePath('/')
+  redirect('/')
+}
+
+function isRedirectError(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false
+  const digest = (err as { digest?: unknown }).digest
+  return typeof digest === 'string' && digest.includes('NEXT_REDIRECT')
+}

--- a/apps/web/src/app/register/[token]/page.tsx
+++ b/apps/web/src/app/register/[token]/page.tsx
@@ -1,0 +1,101 @@
+import type { ReactNode } from 'react'
+import { redirect } from 'next/navigation'
+import { eq } from 'drizzle-orm'
+import { auth, signIn } from '@/auth'
+import { db } from '@/lib/db'
+import { registrationInvites } from '@kagetra/shared/schema'
+import { isRegistrationInviteUsable } from '@/lib/registration-invite'
+import { RegisterForm } from './register-form'
+
+/**
+ * Invite-link self-registration page. Rendered outside the (app) shell (no
+ * mobile nav), like /auth/signin and /self-identify. Middleware lets the
+ * unauthenticated and authenticated-but-unbound states through here; this page
+ * does the DB-backed token check that middleware (Edge, DB-free) cannot.
+ *
+ * Branches (in order):
+ *   1. already a bound member → dashboard
+ *   2. invalid / expired / revoked token → error (no LINE button, no form)
+ *   3. not logged in → welcome + "LINEで登録" (returns to this same URL)
+ *   4. logged in via LINE, unbound → name/grade registration form
+ */
+export default async function RegisterPage({
+  params,
+}: {
+  params: Promise<{ token: string }>
+}) {
+  const { token } = await params
+  const session = await auth()
+
+  // 1. Already bound → registration is unnecessary.
+  if (session?.user?.id) redirect('/')
+
+  // 2. Validate the token before exposing any button/form.
+  const invite = await db.query.registrationInvites.findFirst({
+    where: eq(registrationInvites.token, token),
+    columns: { revokedAt: true, expiresAt: true },
+  })
+  if (!isRegistrationInviteUsable(invite)) {
+    return (
+      <Shell>
+        <div>
+          <h1 className="text-xl font-bold">招待リンクが無効です</h1>
+          <p className="mt-2 text-sm text-gray-600">
+            この招待リンクは無効か期限切れです。管理者にご連絡ください。
+          </p>
+        </div>
+      </Shell>
+    )
+  }
+
+  // 3. Not logged in → welcome + LINE login (comes back to this URL).
+  const lineUserId = session?.user?.lineUserId
+  if (!lineUserId) {
+    return (
+      <Shell>
+        <div>
+          <h1 className="text-xl font-bold">かげとら 会員登録</h1>
+          <p className="mt-2 text-sm text-gray-600">
+            招待リンクから会員登録します。まず LINE アカウントで認証してください。
+          </p>
+        </div>
+        <form
+          action={async () => {
+            'use server'
+            await signIn('line', { redirectTo: `/register/${token}` })
+          }}
+        >
+          <button
+            type="submit"
+            className="w-full rounded-md bg-[#06c755] px-4 py-3 text-sm font-semibold text-white hover:bg-[#05a648]"
+          >
+            LINE で登録
+          </button>
+        </form>
+      </Shell>
+    )
+  }
+
+  // 4. Logged in via LINE but unbound → name/grade form.
+  return (
+    <Shell>
+      <div>
+        <h1 className="text-xl font-bold">会員登録</h1>
+        <p className="mt-2 text-sm text-gray-600">
+          お名前と級を入力して登録を完了してください。級は任意で、後から変更できます。
+        </p>
+      </div>
+      <RegisterForm token={token} />
+    </Shell>
+  )
+}
+
+function Shell({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-8">
+      <div className="w-full max-w-md space-y-6 rounded-lg bg-white p-6 shadow-lg">
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/register/[token]/register-form.tsx
+++ b/apps/web/src/app/register/[token]/register-form.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { useActionState, useState } from 'react'
+import { registerViaInvite, type RegisterViaInviteState } from './actions'
+
+const GRADES = ['A', 'B', 'C', 'D', 'E'] as const
+const initialState: RegisterViaInviteState = {}
+
+/**
+ * Name (required) + grade (optional) form for invite-link registration.
+ *
+ * `token` is fixed via `.bind`, so this stays a useActionState
+ * `(prevState, formData)` action. Inputs are controlled so a validation /
+ * duplicate error keeps what the user typed (React 19 resets uncontrolled
+ * fields after a form action). On success the action redirects to the
+ * dashboard, so there is no success state to render here.
+ */
+export function RegisterForm({ token }: { token: string }) {
+  const [name, setName] = useState('')
+  const [grade, setGrade] = useState('')
+  const boundAction = registerViaInvite.bind(null, token)
+  const [state, formAction, pending] = useActionState(boundAction, initialState)
+
+  return (
+    <form action={formAction} className="space-y-4">
+      <div>
+        <label htmlFor="register-name" className="block text-sm font-medium text-gray-700">
+          お名前（必須）
+        </label>
+        <input
+          id="register-name"
+          name="name"
+          type="text"
+          required
+          maxLength={50}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="register-grade" className="block text-sm font-medium text-gray-700">
+          級（任意）
+        </label>
+        <select
+          id="register-grade"
+          name="grade"
+          value={grade}
+          onChange={(e) => setGrade(e.target.value)}
+          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+        >
+          <option value="">未選択</option>
+          {GRADES.map((g) => (
+            <option key={g} value={g}>
+              {g}級
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {state.error && (
+        <p role="alert" className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+          {state.error}
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={pending}
+        className="w-full rounded-md bg-brand px-4 py-3 text-sm font-semibold text-white hover:bg-brand/90 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {pending ? '登録中…' : '登録する'}
+      </button>
+    </form>
+  )
+}

--- a/apps/web/src/auth.config.ts
+++ b/apps/web/src/auth.config.ts
@@ -11,8 +11,8 @@ import Line from 'next-auth/providers/line'
  * (deactivation check + LINE user ID → internal user id resolution) is added in
  * auth.ts via a wrapper over this jwt callback.
  *
- * `line_link_method` enum values (self_identify / admin_link / account_switch) are
- * written by Server Actions (not here).
+ * `line_link_method` enum values (self_identify / admin_link / account_switch /
+ * invite_link) are written by Server Actions (not here).
  */
 export const authConfig = {
   providers: [
@@ -51,7 +51,12 @@ export const authConfig = {
         type Patch = {
           lineUserId?: string | null
           lineLinkedAt?: string | null
-          lineLinkedMethod?: 'self_identify' | 'admin_link' | 'account_switch' | null
+          lineLinkedMethod?:
+            | 'self_identify'
+            | 'admin_link'
+            | 'account_switch'
+            | 'invite_link'
+            | null
         }
         const s = session as Patch & { user?: Patch }
         const patch: Patch = s.user ?? s
@@ -65,7 +70,8 @@ export const authConfig = {
           patch.lineLinkedMethod === null ||
           patch.lineLinkedMethod === 'self_identify' ||
           patch.lineLinkedMethod === 'admin_link' ||
-          patch.lineLinkedMethod === 'account_switch'
+          patch.lineLinkedMethod === 'account_switch' ||
+          patch.lineLinkedMethod === 'invite_link'
         ) {
           token.lineLinkedMethod = patch.lineLinkedMethod
         }
@@ -84,7 +90,13 @@ export const authConfig = {
         session.user.lineUserId = (token.lineUserId as string | null | undefined) ?? null
         session.user.lineLinkedAt = (token.lineLinkedAt as string | null | undefined) ?? null
         session.user.lineLinkedMethod =
-          (token.lineLinkedMethod as 'self_identify' | 'admin_link' | 'account_switch' | null | undefined) ?? null
+          (token.lineLinkedMethod as
+            | 'self_identify'
+            | 'admin_link'
+            | 'account_switch'
+            | 'invite_link'
+            | null
+            | undefined) ?? null
       }
       return session
     },

--- a/apps/web/src/components/admin/RegistrationInviteModal.tsx
+++ b/apps/web/src/components/admin/RegistrationInviteModal.tsx
@@ -1,0 +1,130 @@
+'use client'
+
+import { useEffect, useState, useTransition } from 'react'
+import { Btn } from '@/components/ui'
+
+export interface RegistrationInvitePayload {
+  /** Full `/register/<token>` URL to hand out. */
+  url: string
+  expiresAt: Date
+}
+
+export interface RegistrationInviteModalProps {
+  /** When non-null, the modal is open with this payload. Reset to null to close. */
+  payload: RegistrationInvitePayload | null
+  onClose: () => void
+}
+
+function formatExpiry(expiresAt: Date): string {
+  return expiresAt.toLocaleString('ja-JP', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  })
+}
+
+/**
+ * Coarse "time left" string. Unlike InviteCodeModal's mm:ss (30-minute TTL),
+ * registration links live 1–30 days, so we show days/hours and refresh once a
+ * minute rather than every second.
+ */
+function useRemaining(expiresAt: Date | null): string {
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    if (!expiresAt) return
+    const id = setInterval(() => setNow(Date.now()), 60_000)
+    return () => clearInterval(id)
+  }, [expiresAt])
+  if (!expiresAt) return ''
+  const diffMs = Math.max(0, expiresAt.getTime() - now)
+  const totalMin = Math.floor(diffMs / 60_000)
+  const days = Math.floor(totalMin / (60 * 24))
+  const hours = Math.floor((totalMin % (60 * 24)) / 60)
+  const mins = totalMin % 60
+  if (totalMin <= 0) return '期限切れ'
+  if (days > 0) return `あと ${days}日 ${hours}時間`
+  if (hours > 0) return `あと ${hours}時間 ${mins}分`
+  return `あと ${mins}分`
+}
+
+/**
+ * Post-issue modal for an invite link. Shows the full URL (selectable +
+ * copy button), the remaining time, and the absolute expiry. Mirrors the
+ * InviteCodeModal layout/interaction (bottom-sheet on mobile, copy-with-badge).
+ */
+export function RegistrationInviteModal({ payload, onClose }: RegistrationInviteModalProps) {
+  const [copied, setCopied] = useState(false)
+  const [, startTransition] = useTransition()
+  const remaining = useRemaining(payload?.expiresAt ?? null)
+
+  useEffect(() => {
+    if (payload) setCopied(false)
+  }, [payload])
+
+  if (!payload) return null
+
+  function handleCopy() {
+    if (!payload) return
+    const url = payload.url
+    startTransition(async () => {
+      try {
+        await navigator.clipboard.writeText(url)
+        setCopied(true)
+      } catch {
+        // Clipboard may be blocked (PWA permissions etc.) — the URL is still
+        // selectable in the box, so degrade to a no-op rather than throwing.
+      }
+    })
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="招待リンク"
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40"
+      onClick={onClose}
+    >
+      <div
+        className="w-full sm:max-w-md bg-surface rounded-t-2xl sm:rounded-2xl p-4 flex flex-col gap-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="flex items-start justify-between gap-3">
+          <h2 className="text-base font-semibold text-ink">招待リンクを発行しました</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="閉じる"
+            className="text-ink-meta hover:text-ink text-xl leading-none"
+          >
+            ×
+          </button>
+        </header>
+
+        <div className="flex flex-col gap-2 p-3 bg-surface-alt rounded-xl">
+          <div className="text-[11px] text-ink-meta">このURLを新入会者に渡してください</div>
+          <div className="text-xs font-mono text-ink break-all select-all bg-surface rounded-lg p-2 border border-border">
+            {payload.url}
+          </div>
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-[11px] text-ink-meta tabular-nums">
+              {remaining} · {formatExpiry(payload.expiresAt)} まで
+            </span>
+            <Btn type="button" kind="ghost" size="sm" onClick={handleCopy}>
+              {copied ? 'コピーしました' : 'URLをコピー'}
+            </Btn>
+          </div>
+        </div>
+
+        <p className="text-[10px] text-ink-meta">
+          期限内なら複数の人がこのリンクから会員登録できます。配布をやめたいときは一覧から無効化してください。
+        </p>
+
+        <div className="flex justify-end pt-1">
+          <Btn type="button" kind="secondary" size="sm" onClick={onClose}>
+            閉じる
+          </Btn>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/lib/db-errors.ts
+++ b/apps/web/src/lib/db-errors.ts
@@ -20,3 +20,24 @@ export function isUniqueViolation(err: unknown): boolean {
   }
   return false
 }
+
+/**
+ * Name of the violated constraint for a unique_violation, or null.
+ *
+ * Lets a caller branch on WHICH unique constraint fired when a table has more
+ * than one (e.g. users.name vs users.line_user_id during invite registration).
+ * Checks the error itself and the wrapped `cause`, mirroring isUniqueViolation.
+ * Returns null when it is not a unique violation or the driver did not surface
+ * a constraint name.
+ */
+export function uniqueViolationConstraint(err: unknown): string | null {
+  if (!isUniqueViolation(err)) return null
+  const direct = (err as { constraint?: unknown }).constraint
+  if (typeof direct === 'string') return direct
+  const cause = (err as { cause?: unknown }).cause
+  if (typeof cause === 'object' && cause !== null) {
+    const c = (cause as { constraint?: unknown }).constraint
+    if (typeof c === 'string') return c
+  }
+  return null
+}

--- a/apps/web/src/lib/registration-invite.test.ts
+++ b/apps/web/src/lib/registration-invite.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import {
+  DEFAULT_EXPIRY_PRESET,
+  EXPIRY_PRESETS,
+  EXPIRY_PRESET_OPTIONS,
+  generateRegistrationToken,
+  isRegistrationInviteExpired,
+  isRegistrationInviteUsable,
+  isValidExpiryPreset,
+  registrationInviteExpiresAt,
+} from './registration-invite'
+
+describe('generateRegistrationToken', () => {
+  it('returns a 43-char URL-safe base64url string (32 random bytes)', () => {
+    for (let i = 0; i < 200; i++) {
+      const token = generateRegistrationToken()
+      // base64url alphabet only: A-Z a-z 0-9 - _ , no padding
+      expect(token).toMatch(/^[A-Za-z0-9_-]{43}$/)
+    }
+  })
+
+  it('produces unique tokens (no collisions across many draws)', () => {
+    const tokens = new Set<string>()
+    for (let i = 0; i < 1000; i++) tokens.add(generateRegistrationToken())
+    expect(tokens.size).toBe(1000)
+  })
+})
+
+describe('EXPIRY_PRESETS', () => {
+  it('maps each preset to its day count in ms', () => {
+    expect(EXPIRY_PRESETS['1d']).toBe(86_400_000)
+    expect(EXPIRY_PRESETS['7d']).toBe(7 * 86_400_000)
+    expect(EXPIRY_PRESETS['30d']).toBe(30 * 86_400_000)
+  })
+
+  it('defaults to 7 days and lists presets shortest-first', () => {
+    expect(DEFAULT_EXPIRY_PRESET).toBe('7d')
+    expect(EXPIRY_PRESET_OPTIONS).toEqual(['1d', '7d', '30d'])
+  })
+})
+
+describe('isValidExpiryPreset', () => {
+  it.each(['1d', '7d', '30d'])('accepts %s', (p) => {
+    expect(isValidExpiryPreset(p)).toBe(true)
+  })
+
+  it.each(['', '2d', '7', 'd7', '365d', ' 7d', null, undefined, 7])(
+    'rejects %s',
+    (input) => {
+      expect(isValidExpiryPreset(input)).toBe(false)
+    },
+  )
+})
+
+describe('registrationInviteExpiresAt', () => {
+  const now = new Date('2026-06-26T00:00:00Z')
+
+  it('adds the preset TTL to the given timestamp', () => {
+    expect(registrationInviteExpiresAt('1d', now).toISOString()).toBe('2026-06-27T00:00:00.000Z')
+    expect(registrationInviteExpiresAt('7d', now).toISOString()).toBe('2026-07-03T00:00:00.000Z')
+    expect(registrationInviteExpiresAt('30d', now).toISOString()).toBe('2026-07-26T00:00:00.000Z')
+  })
+
+  it('defaults `now` to the current time', () => {
+    const before = Date.now()
+    const expires = registrationInviteExpiresAt('1d').getTime()
+    const after = Date.now()
+    expect(expires - before).toBeGreaterThanOrEqual(EXPIRY_PRESETS['1d'] - 50)
+    expect(expires - after).toBeLessThanOrEqual(EXPIRY_PRESETS['1d'])
+  })
+})
+
+describe('isRegistrationInviteExpired', () => {
+  const now = new Date('2026-06-26T03:00:00Z')
+
+  it('returns true for null / undefined', () => {
+    expect(isRegistrationInviteExpired(null, now)).toBe(true)
+    expect(isRegistrationInviteExpired(undefined, now)).toBe(true)
+  })
+
+  it('returns false for a future expiry', () => {
+    expect(isRegistrationInviteExpired(new Date('2026-06-26T03:00:01Z'), now)).toBe(false)
+  })
+
+  it('returns true for a past expiry', () => {
+    expect(isRegistrationInviteExpired(new Date('2026-06-26T02:59:59Z'), now)).toBe(true)
+  })
+
+  it('treats an equal timestamp as expired (closed interval)', () => {
+    expect(isRegistrationInviteExpired(new Date('2026-06-26T03:00:00Z'), now)).toBe(true)
+  })
+})
+
+describe('isRegistrationInviteUsable', () => {
+  const now = new Date('2026-06-26T03:00:00Z')
+  const future = new Date('2026-06-27T03:00:00Z')
+  const past = new Date('2026-06-25T03:00:00Z')
+
+  it('returns true for an unrevoked, unexpired invite', () => {
+    expect(isRegistrationInviteUsable({ revokedAt: null, expiresAt: future }, now)).toBe(true)
+  })
+
+  it('returns false when the invite row is missing', () => {
+    expect(isRegistrationInviteUsable(null, now)).toBe(false)
+    expect(isRegistrationInviteUsable(undefined, now)).toBe(false)
+  })
+
+  it('returns false when revoked, even if not yet expired', () => {
+    expect(
+      isRegistrationInviteUsable({ revokedAt: new Date('2026-06-26T02:00:00Z'), expiresAt: future }, now),
+    ).toBe(false)
+  })
+
+  it('returns false when expired, even if not revoked', () => {
+    expect(isRegistrationInviteUsable({ revokedAt: null, expiresAt: past }, now)).toBe(false)
+  })
+})

--- a/apps/web/src/lib/registration-invite.ts
+++ b/apps/web/src/lib/registration-invite.ts
@@ -1,5 +1,3 @@
-import { randomBytes } from 'node:crypto'
-
 /**
  * Pure helpers for the invite-link self-registration flow. DB-free so they can
  * be unit-tested in isolation; the Server Actions and the /register page wrap
@@ -8,6 +6,11 @@ import { randomBytes } from 'node:crypto'
  * Mirrors the shape of invite-code.ts, but the token here is a high-entropy
  * random (it rides in a URL, not spoken aloud) and validity is guarded purely
  * by an expiry preset plus a manual revoke — there is no per-person cap.
+ *
+ * NOTE: this module is imported by the admin section (a client component) for
+ * the expiry presets, so it must stay client-bundle-safe — i.e. NO `node:*`
+ * imports. Token generation therefore uses the Web Crypto global rather than
+ * `node:crypto` (a top-level `node:crypto` import breaks the browser build).
  */
 
 export type RegistrationInviteExpiryPreset = '1d' | '7d' | '30d'
@@ -39,13 +42,22 @@ export function isValidExpiryPreset(value: unknown): value is RegistrationInvite
 /**
  * Generate a fresh URL-safe invite token.
  *
- * 32 random bytes → 43 base64url characters. base64url avoids `+` / `/` / `=`
+ * 32 CSPRNG bytes → 43 base64url characters. base64url avoids `+` / `/` / `=`
  * so the token drops straight into `/register/<token>` without escaping. The
  * entropy is overkill for a link with operator-limited distribution, but it
  * costs nothing and keeps the URL unguessable (requirements §6).
+ *
+ * Uses `crypto.getRandomValues` (the Web Crypto global, a CSPRNG present in
+ * Node 18+, the browser, and Edge) instead of `node:crypto.randomBytes` to keep
+ * this module free of `node:*` imports — see the file-level note. Only ever
+ * called server-side regardless.
  */
 export function generateRegistrationToken(): string {
-  return randomBytes(32).toString('base64url')
+  const bytes = new Uint8Array(32)
+  crypto.getRandomValues(bytes)
+  let binary = ''
+  for (const b of bytes) binary += String.fromCharCode(b)
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
 }
 
 /**

--- a/apps/web/src/lib/registration-invite.ts
+++ b/apps/web/src/lib/registration-invite.ts
@@ -1,0 +1,87 @@
+import { randomBytes } from 'node:crypto'
+
+/**
+ * Pure helpers for the invite-link self-registration flow. DB-free so they can
+ * be unit-tested in isolation; the Server Actions and the /register page wrap
+ * these around the actual `registration_invites` row lookup.
+ *
+ * Mirrors the shape of invite-code.ts, but the token here is a high-entropy
+ * random (it rides in a URL, not spoken aloud) and validity is guarded purely
+ * by an expiry preset plus a manual revoke — there is no per-person cap.
+ */
+
+export type RegistrationInviteExpiryPreset = '1d' | '7d' | '30d'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/**
+ * Expiry preset → lifetime in milliseconds. These are the only durations the
+ * admin UI offers; the action validates the incoming preset against this map's
+ * keys so an arbitrary TTL can never be injected.
+ */
+export const EXPIRY_PRESETS: Record<RegistrationInviteExpiryPreset, number> = {
+  '1d': 1 * DAY_MS,
+  '7d': 7 * DAY_MS,
+  '30d': 30 * DAY_MS,
+}
+
+/** Pre-selected option in the issue dialog. */
+export const DEFAULT_EXPIRY_PRESET: RegistrationInviteExpiryPreset = '7d'
+
+/** Ordered list for rendering the preset selector. */
+export const EXPIRY_PRESET_OPTIONS: RegistrationInviteExpiryPreset[] = ['1d', '7d', '30d']
+
+/** Narrow an untrusted string (form value) to a known preset. */
+export function isValidExpiryPreset(value: unknown): value is RegistrationInviteExpiryPreset {
+  return value === '1d' || value === '7d' || value === '30d'
+}
+
+/**
+ * Generate a fresh URL-safe invite token.
+ *
+ * 32 random bytes → 43 base64url characters. base64url avoids `+` / `/` / `=`
+ * so the token drops straight into `/register/<token>` without escaping. The
+ * entropy is overkill for a link with operator-limited distribution, but it
+ * costs nothing and keeps the URL unguessable (requirements §6).
+ */
+export function generateRegistrationToken(): string {
+  return randomBytes(32).toString('base64url')
+}
+
+/**
+ * Compute the expiry timestamp for an invite issued at `now` with `preset`.
+ * Centralised so the DB column and the modal countdown agree on the TTL.
+ */
+export function registrationInviteExpiresAt(
+  preset: RegistrationInviteExpiryPreset,
+  now: Date = new Date(),
+): Date {
+  return new Date(now.getTime() + EXPIRY_PRESETS[preset])
+}
+
+/**
+ * True when `expiresAt` is missing or at/before `now`. Equal timestamps count
+ * as already-expired (closed interval), matching invite-code.ts.
+ */
+export function isRegistrationInviteExpired(
+  expiresAt: Date | null | undefined,
+  now: Date = new Date(),
+): boolean {
+  if (!expiresAt) return true
+  return expiresAt.getTime() <= now.getTime()
+}
+
+/**
+ * The single source of truth for "can this invite still be used to register":
+ * the row must exist, not be revoked, and not be expired. Both the page render
+ * and the submit action call this so an open tab that crosses the expiry (or a
+ * link revoked between render and submit) is rejected consistently.
+ */
+export function isRegistrationInviteUsable(
+  invite: { revokedAt: Date | null; expiresAt: Date } | null | undefined,
+  now: Date = new Date(),
+): boolean {
+  if (!invite) return false
+  if (invite.revokedAt !== null) return false
+  return !isRegistrationInviteExpired(invite.expiresAt, now)
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -14,11 +14,19 @@ import { authConfig } from './auth.config'
  *   - token.id unset  → LINE login succeeded but no matching internal user row
  *                        yet; force /self-identify so the user can claim
  *   - no session      → force /auth/signin
+ *
+ * `/register/*` (invite-link self-registration) is a special category:
+ *   - no session            → allow through (welcome + "LINEで登録" button)
+ *   - session, id unset      → allow through (the deliberate exception to the
+ *                              /self-identify force — the registrant fills the
+ *                              name/grade form here after LINE OAuth)
+ *   - session, id set (bound) → redirect to / (already a member, nothing to do)
  */
 const { auth } = NextAuth(authConfig)
 
 const PUBLIC_PATHS = ['/auth/signin', '/auth/error']
 const SELF_IDENTIFY_PATHS = ['/self-identify']
+const REGISTER_PATHS = ['/register']
 
 function startsWithAny(pathname: string, prefixes: string[]): boolean {
   return prefixes.some(
@@ -30,29 +38,38 @@ export default auth((req) => {
   const { nextUrl } = req
   const session = req.auth
   const pathname = nextUrl.pathname
+  const isRegister = startsWithAny(pathname, REGISTER_PATHS)
 
-  // Unauthenticated: only /auth/signin is reachable; /auth/error too for LINE errors.
+  // Unauthenticated: /auth/signin (+ /auth/error for LINE errors) and the
+  // public /register/* welcome screen are reachable; everything else → signin.
   if (!session) {
-    if (startsWithAny(pathname, PUBLIC_PATHS)) return NextResponse.next()
+    if (startsWithAny(pathname, PUBLIC_PATHS) || isRegister) return NextResponse.next()
     const url = nextUrl.clone()
     url.pathname = '/auth/signin'
     return NextResponse.redirect(url)
   }
 
   // Authenticated but no internal id yet → /self-identify (LINE user ID is set,
-  // but the user hasn't claimed an invited member row).
+  // but the user hasn't claimed an invited member row). /register/* is exempt:
+  // an invite-link registrant is unbound by design and fills the form there.
   if (
     !session.user?.id &&
     !startsWithAny(pathname, SELF_IDENTIFY_PATHS) &&
-    !startsWithAny(pathname, PUBLIC_PATHS)
+    !startsWithAny(pathname, PUBLIC_PATHS) &&
+    !isRegister
   ) {
     const url = nextUrl.clone()
     url.pathname = '/self-identify'
     return NextResponse.redirect(url)
   }
 
-  // Authenticated + bound user visiting /auth/signin → dashboard.
-  if (startsWithAny(pathname, PUBLIC_PATHS)) {
+  // Bound user (id set) visiting /auth/signin, or any bound user landing on
+  // /register/* (registration already done) → dashboard. The `id` guard keeps
+  // an unbound registrant on /register/* instead of bouncing them here.
+  if (
+    startsWithAny(pathname, PUBLIC_PATHS) ||
+    (isRegister && !!session.user?.id)
+  ) {
     const url = nextUrl.clone()
     url.pathname = '/'
     return NextResponse.redirect(url)

--- a/apps/web/src/next-auth.d.ts
+++ b/apps/web/src/next-auth.d.ts
@@ -10,7 +10,7 @@ declare module 'next-auth' {
       role: 'admin' | 'vice_admin' | 'member'
       lineUserId: string | null
       lineLinkedAt: string | null
-      lineLinkedMethod: 'self_identify' | 'admin_link' | 'account_switch' | null
+      lineLinkedMethod: 'self_identify' | 'admin_link' | 'account_switch' | 'invite_link' | null
       name?: string | null
       email?: string | null
       image?: string | null
@@ -22,7 +22,7 @@ declare module 'next-auth' {
     isInvited?: boolean
     lineUserId?: string | null
     lineLinkedAt?: string | null
-    lineLinkedMethod?: 'self_identify' | 'admin_link' | 'account_switch' | null
+    lineLinkedMethod?: 'self_identify' | 'admin_link' | 'account_switch' | 'invite_link' | null
   }
 }
 
@@ -32,7 +32,7 @@ declare module 'next-auth/jwt' {
     role?: 'admin' | 'vice_admin' | 'member'
     lineUserId?: string | null
     lineLinkedAt?: string | null
-    lineLinkedMethod?: 'self_identify' | 'admin_link' | 'account_switch' | null
+    lineLinkedMethod?: 'self_identify' | 'admin_link' | 'account_switch' | 'invite_link' | null
   }
 }
 
@@ -42,7 +42,7 @@ declare module '@auth/core/types' {
     isInvited?: boolean
     lineUserId?: string | null
     lineLinkedAt?: string | null
-    lineLinkedMethod?: 'self_identify' | 'admin_link' | 'account_switch' | null
+    lineLinkedMethod?: 'self_identify' | 'admin_link' | 'account_switch' | 'invite_link' | null
   }
 }
 
@@ -52,6 +52,6 @@ declare module '@auth/core/adapters' {
     isInvited?: boolean
     lineUserId?: string | null
     lineLinkedAt?: string | null
-    lineLinkedMethod?: 'self_identify' | 'admin_link' | 'account_switch' | null
+    lineLinkedMethod?: 'self_identify' | 'admin_link' | 'account_switch' | 'invite_link' | null
   }
 }

--- a/apps/web/src/test-utils/auth-mock.ts
+++ b/apps/web/src/test-utils/auth-mock.ts
@@ -1,7 +1,7 @@
 import { vi } from 'vitest'
 
 type UserRole = 'admin' | 'vice_admin' | 'member'
-type LineLinkedMethod = 'self_identify' | 'admin_link' | 'account_switch'
+type LineLinkedMethod = 'self_identify' | 'admin_link' | 'account_switch' | 'invite_link'
 
 export type MockSessionUser = {
   id: string

--- a/apps/web/src/test-utils/db.ts
+++ b/apps/web/src/test-utils/db.ts
@@ -22,6 +22,9 @@ export const testDb = drizzle(testPool, { schema })
 // tournament-results added the players/tournaments/result-drafts cluster. CASCADE
 // already follows their FKs (e.g. result_drafts via mail_messages), but list each
 // explicitly so RESTART IDENTITY resets their identity sequences too.
+//
+// invite-link-registration added `registration_invites` (created_by ON DELETE
+// CASCADE — cleared with users anyway, but listed explicitly per convention).
 export async function truncateAll() {
   await testDb.execute(sql`
     TRUNCATE TABLE
@@ -41,6 +44,7 @@ export async function truncateAll() {
       schedule_items,
       events,
       event_groups,
+      registration_invites,
       sessions,
       accounts,
       verification_tokens,

--- a/apps/web/src/test-utils/playwright-auth.ts
+++ b/apps/web/src/test-utils/playwright-auth.ts
@@ -24,7 +24,7 @@ export type SeededSession = {
   sessionToken: string
 }
 
-type LineLinkedMethod = 'self_identify' | 'admin_link' | 'account_switch'
+type LineLinkedMethod = 'self_identify' | 'admin_link' | 'account_switch' | 'invite_link'
 
 type IssueOptions = {
   role: 'admin' | 'vice_admin' | 'member'

--- a/docs/features/invite-link-registration/implementation-plan.md
+++ b/docs/features/invite-link-registration/implementation-plan.md
@@ -58,7 +58,7 @@ status: completed
 - **対応Issue:** #178
 
 ### タスク5: middleware の /register/* ルーティング拡張
-- [ ] 完了
+- [x] 完了
 - **概要:** `/register/*` を新カテゴリとして扱い、未ログイン通過・未紐付け時の self-identify 例外・紐付け済みは `/` へ、を実装。
 - **変更対象ファイル:**
   - [apps/web/src/middleware.ts](apps/web/src/middleware.ts) — `REGISTER_PREFIX = '/register'` を追加し、(1) `!session` かつ register → 通す、(2) `session && !user.id` かつ register → 通す（self-identify 強制の例外）、(3) `session && user.id` かつ register → `/` へ

--- a/docs/features/invite-link-registration/implementation-plan.md
+++ b/docs/features/invite-link-registration/implementation-plan.md
@@ -86,7 +86,7 @@ status: completed
 - **対応Issue:** #179
 
 ### タスク8: E2E（Playwright）招待リンク発行→登録→ログイン フロー
-- [ ] 完了
+- [x] 完了
 - **概要:** 発行から登録・ログイン到達までの主要動線、期限切れ拒否、未ログイン→（LINE モック）→フォーム→作成を検証。
 - **変更対象ファイル:**
   - `apps/web/e2e/invite-link-registration.spec.ts`（新規）— [self-identify-flow.spec.ts](apps/web/e2e/self-identify-flow.spec.ts) / [admin-member-create.spec.ts](apps/web/e2e/admin-member-create.spec.ts) の認証モック（[playwright-auth.ts](apps/web/src/test-utils/playwright-auth.ts)）を流用

--- a/docs/features/invite-link-registration/implementation-plan.md
+++ b/docs/features/invite-link-registration/implementation-plan.md
@@ -1,0 +1,104 @@
+---
+status: completed
+---
+# invite-link-registration 実装手順書
+
+要件定義書: `docs/features/invite-link-registration/requirements.md`
+親Issue: #173
+
+テストファースト（API/lib テスト → 実装 → フロント → E2E）で進める。マイグレーションの新規連番は **0030**（`drizzle-kit generate` で確定）。
+
+## 実装タスク
+
+### タスク1: DB スキーマ（registration_invites）＋ enum invite_link ＋ 型横断更新 ＋ マイグレーション
+- [ ] 完了
+- **概要:** 招待トークンを保持する新規テーブルを追加し、`line_link_method` enum に `invite_link` を追加。enum 追加に伴う TS 文字列リテラル型を横断更新する。
+- **変更対象ファイル:**
+  - `packages/shared/src/schema/registration-invites.ts`（新規）— `id` / `token`(UNIQUE) / `expires_at` / `created_by`(FK→users.id) / `created_at` / `revoked_at`。[attachment-share-tokens.ts](packages/shared/src/schema/attachment-share-tokens.ts) のパターンを踏襲
+  - `packages/shared/src/schema/index.ts` — 新テーブルを export
+  - `packages/shared/src/schema/relations.ts` — 必要なら createdBy → users の relation（一覧で発行者表示する場合のみ。不要なら省略）
+  - [packages/shared/src/schema/enums.ts](packages/shared/src/schema/enums.ts) — `lineLinkMethodEnum` に `'invite_link'` 追加
+  - [apps/web/src/auth.config.ts](apps/web/src/auth.config.ts) — `lineLinkedMethod` の型 union に `'invite_link'` 追加（jwt/session 両コールバック）
+  - [apps/web/src/next-auth.d.ts](apps/web/src/next-auth.d.ts) — Session/JWT 型の `lineLinkedMethod` union に追加
+  - [apps/web/src/lib/node-jwt-callback.ts](apps/web/src/lib/node-jwt-callback.ts) — 型が enum を参照していれば追従
+  - `packages/shared/drizzle/0030_*.sql` — `drizzle-kit generate` で生成（CREATE TABLE ＋ ALTER TYPE ADD VALUE）
+- **依存タスク:** なし
+- **対応Issue:** #174
+
+### タスク2: registration-invite ライブラリ（純関数）＋ ユニットテスト
+- [ ] 完了
+- **概要:** トークン生成・有効期限算出・検証の純関数を実装。[invite-code.ts](apps/web/src/lib/invite-code.ts) / [invite-code.test.ts](apps/web/src/lib/invite-code.test.ts) のパターンを踏襲し、DB 非依存でテスト可能にする。
+- **変更対象ファイル:**
+  - `apps/web/src/lib/registration-invite.ts`（新規）— `generateRegistrationToken()`（`crypto.randomBytes(32).toString('base64url')`）／`registrationInviteExpiresAt(preset, now?)`（preset: `'1d'|'7d'|'30d'`）／`isRegistrationInviteExpired(expiresAt, now?)`／`EXPIRY_PRESETS` 定義
+  - `apps/web/src/lib/registration-invite.test.ts`（新規）— 期限算出・失効判定・プリセット網羅のテスト（先に作成）
+- **依存タスク:** なし
+- **対応Issue:** #175
+
+### タスク3: 発行／無効化 Server Actions ＋ テスト
+- [ ] 完了
+- **概要:** 管理者が招待リンクを発行・無効化するアクション。authz は `admin`/`vice_admin`（createMember と同一）。
+- **変更対象ファイル:**
+  - `apps/web/src/app/(app)/admin/members/actions.ts`（拡張）— `createRegistrationInvite(preset)`（authz → INSERT → 完全URL を返す。`NEXT_PUBLIC_APP_URL` 等のベースURL利用）／`revokeRegistrationInvite(id)`（authz → `revoked_at=now` UPDATE）／有効リンク取得用クエリ
+  - `apps/web/src/app/(app)/admin/members/actions.test.ts`（拡張）— 権限拒否（member）／発行で行作成＋URL形状／無効化で revoked_at セット、をテスト DB で検証（先に作成）
+- **依存タスク:** タスク1, タスク2
+- **対応Issue:** #177
+
+### タスク4: 登録確定 Server Action（registerViaInvite）＋ テスト
+- [ ] 完了
+- **概要:** トークンを再検証し、セッションの LINE ユーザーIDで会員レコードを作成・紐付けするアクション。self-identify の claim と createMember の INSERT を組み合わせた形。
+- **変更対象ファイル:**
+  - `apps/web/src/app/register/[token]/actions.ts`（新規）— `registerViaInvite(token, formData)`:
+    1. `session.user.id` 有り → `/` へ。`lineUserId` 無し → `/register/<token>` で再ログイン誘導
+    2. トークン再検証（`revoked_at IS NULL` かつ未失効）。無効 → エラー
+    3. 入力 zod 検証（name 必須1〜50 / grade A〜E nullable、createMember の schema 流用）
+    4. `users` INSERT（role='member', isInvited=true, invitedAt, lineUserId, lineLinkedAt, lineLinkedMethod='invite_link'）。`users.name` / `users.line_user_id` の UNIQUE 違反を文言ハンドリング
+    5. `unstable_update` → `revalidatePath('/')` → `redirect('/')`
+  - `apps/web/src/app/register/[token]/actions.test.ts`（新規）— 期限切れ拒否／正常作成（role/method/紐付け）／同名衝突／同一LINE二重作成のガード（先に作成）
+- **依存タスク:** タスク1, タスク2
+- **対応Issue:** #178
+
+### タスク5: middleware の /register/* ルーティング拡張
+- [ ] 完了
+- **概要:** `/register/*` を新カテゴリとして扱い、未ログイン通過・未紐付け時の self-identify 例外・紐付け済みは `/` へ、を実装。
+- **変更対象ファイル:**
+  - [apps/web/src/middleware.ts](apps/web/src/middleware.ts) — `REGISTER_PREFIX = '/register'` を追加し、(1) `!session` かつ register → 通す、(2) `session && !user.id` かつ register → 通す（self-identify 強制の例外）、(3) `session && user.id` かつ register → `/` へ
+- **依存タスク:** なし（型は タスク1 と独立）
+- **対応Issue:** #176
+- **備考:** middleware の単体テストは無いため、ルーティング挙動は タスク8 の E2E で担保する。
+
+### タスク6: 登録ページ /register/[token] UI ＋ フォーム
+- [ ] 完了
+- **概要:** トークン状態に応じて出し分ける登録ページ。signin / self-identify と同じ独立レイアウト（`(app)` 外）。
+- **変更対象ファイル:**
+  - `apps/web/src/app/register/[token]/page.tsx`（新規, Server Component）— トークン検証 → 無効/期限切れ=エラー表示、未ログイン=ウェルカム＋「LINEで登録」（server action `signIn('line', { redirectTo: '/register/<token>' })`）、未紐付け=登録フォーム、紐付け済み=`/` へ
+  - `apps/web/src/app/register/[token]/register-form.tsx`（新規, Client）— 氏名（必須）＋級（任意セレクト）フォーム。`registerViaInvite` を呼ぶ。エラー表示
+  - 必要に応じて `apps/web/src/app/register/layout.tsx`（独立レイアウトが必要な場合）
+- **依存タスク:** タスク4, タスク5
+- **対応Issue:** #180
+
+### タスク7: 会員管理画面に招待リンク発行セクション ＋ モーダル ＋ 有効リンク一覧
+- [ ] 完了
+- **概要:** 管理画面に発行UIを追加。発行後モーダルでURL/期限/コピーを表示し、有効リンク一覧と無効化ボタンを出す。
+- **変更対象ファイル:**
+  - [apps/web/src/app/(app)/admin/members/page.tsx](apps/web/src/app/(app)/admin/members/page.tsx)（拡張）— 「招待リンク」セクション（期限プリセット選択＋発行ボタン＋有効リンク一覧＋無効化）
+  - `apps/web/src/components/admin/RegistrationInviteModal.tsx`（新規, Client）— URL/残り時間カウントダウン/失効日時/コピー。[InviteCodeModal](apps/web/src/components/events/InviteCodeModal.tsx) を参考に新規作成
+- **依存タスク:** タスク3
+- **対応Issue:** #179
+
+### タスク8: E2E（Playwright）招待リンク発行→登録→ログイン フロー
+- [ ] 完了
+- **概要:** 発行から登録・ログイン到達までの主要動線、期限切れ拒否、未ログイン→（LINE モック）→フォーム→作成を検証。
+- **変更対象ファイル:**
+  - `apps/web/e2e/invite-link-registration.spec.ts`（新規）— [self-identify-flow.spec.ts](apps/web/e2e/self-identify-flow.spec.ts) / [admin-member-create.spec.ts](apps/web/e2e/admin-member-create.spec.ts) の認証モック（[playwright-auth.ts](apps/web/src/test-utils/playwright-auth.ts)）を流用
+- **依存タスク:** タスク6, タスク7
+- **対応Issue:** #181
+
+## 実装順序
+1. タスク1 #174（DB スキーマ＋enum＋型）— 依存なし、基盤
+2. タスク2 #175（lib 純関数＋テスト）— 依存なし
+3. タスク5 #176（middleware）— 依存なし（並行可）
+4. タスク3 #177（発行/無効化 actions）— タスク1,2 に依存
+5. タスク4 #178（登録確定 action）— タスク1,2 に依存
+6. タスク7 #179（発行UI＋モーダル）— タスク3 に依存
+7. タスク6 #180（登録ページUI）— タスク4,5 に依存
+8. タスク8 #181（E2E）— タスク6,7 に依存

--- a/docs/features/invite-link-registration/implementation-plan.md
+++ b/docs/features/invite-link-registration/implementation-plan.md
@@ -26,7 +26,7 @@ status: completed
 - **対応Issue:** #174
 
 ### タスク2: registration-invite ライブラリ（純関数）＋ ユニットテスト
-- [ ] 完了
+- [x] 完了
 - **概要:** トークン生成・有効期限算出・検証の純関数を実装。[invite-code.ts](apps/web/src/lib/invite-code.ts) / [invite-code.test.ts](apps/web/src/lib/invite-code.test.ts) のパターンを踏襲し、DB 非依存でテスト可能にする。
 - **変更対象ファイル:**
   - `apps/web/src/lib/registration-invite.ts`（新規）— `generateRegistrationToken()`（`crypto.randomBytes(32).toString('base64url')`）／`registrationInviteExpiresAt(preset, now?)`（preset: `'1d'|'7d'|'30d'`）／`isRegistrationInviteExpired(expiresAt, now?)`／`EXPIRY_PRESETS` 定義

--- a/docs/features/invite-link-registration/implementation-plan.md
+++ b/docs/features/invite-link-registration/implementation-plan.md
@@ -35,7 +35,7 @@ status: completed
 - **対応Issue:** #175
 
 ### タスク3: 発行／無効化 Server Actions ＋ テスト
-- [ ] 完了
+- [x] 完了
 - **概要:** 管理者が招待リンクを発行・無効化するアクション。authz は `admin`/`vice_admin`（createMember と同一）。
 - **変更対象ファイル:**
   - `apps/web/src/app/(app)/admin/members/actions.ts`（拡張）— `createRegistrationInvite(preset)`（authz → INSERT → 完全URL を返す。`NEXT_PUBLIC_APP_URL` 等のベースURL利用）／`revokeRegistrationInvite(id)`（authz → `revoked_at=now` UPDATE）／有効リンク取得用クエリ

--- a/docs/features/invite-link-registration/implementation-plan.md
+++ b/docs/features/invite-link-registration/implementation-plan.md
@@ -67,7 +67,7 @@ status: completed
 - **備考:** middleware の単体テストは無いため、ルーティング挙動は タスク8 の E2E で担保する。
 
 ### タスク6: 登録ページ /register/[token] UI ＋ フォーム
-- [ ] 完了
+- [x] 完了
 - **概要:** トークン状態に応じて出し分ける登録ページ。signin / self-identify と同じ独立レイアウト（`(app)` 外）。
 - **変更対象ファイル:**
   - `apps/web/src/app/register/[token]/page.tsx`（新規, Server Component）— トークン検証 → 無効/期限切れ=エラー表示、未ログイン=ウェルカム＋「LINEで登録」（server action `signIn('line', { redirectTo: '/register/<token>' })`）、未紐付け=登録フォーム、紐付け済み=`/` へ

--- a/docs/features/invite-link-registration/implementation-plan.md
+++ b/docs/features/invite-link-registration/implementation-plan.md
@@ -44,7 +44,7 @@ status: completed
 - **対応Issue:** #177
 
 ### タスク4: 登録確定 Server Action（registerViaInvite）＋ テスト
-- [ ] 完了
+- [x] 完了
 - **概要:** トークンを再検証し、セッションの LINE ユーザーIDで会員レコードを作成・紐付けするアクション。self-identify の claim と createMember の INSERT を組み合わせた形。
 - **変更対象ファイル:**
   - `apps/web/src/app/register/[token]/actions.ts`（新規）— `registerViaInvite(token, formData)`:

--- a/docs/features/invite-link-registration/implementation-plan.md
+++ b/docs/features/invite-link-registration/implementation-plan.md
@@ -77,7 +77,7 @@ status: completed
 - **対応Issue:** #180
 
 ### タスク7: 会員管理画面に招待リンク発行セクション ＋ モーダル ＋ 有効リンク一覧
-- [ ] 完了
+- [x] 完了
 - **概要:** 管理画面に発行UIを追加。発行後モーダルでURL/期限/コピーを表示し、有効リンク一覧と無効化ボタンを出す。
 - **変更対象ファイル:**
   - [apps/web/src/app/(app)/admin/members/page.tsx](apps/web/src/app/(app)/admin/members/page.tsx)（拡張）— 「招待リンク」セクション（期限プリセット選択＋発行ボタン＋有効リンク一覧＋無効化）

--- a/docs/features/invite-link-registration/implementation-plan.md
+++ b/docs/features/invite-link-registration/implementation-plan.md
@@ -11,7 +11,7 @@ status: completed
 ## 実装タスク
 
 ### タスク1: DB スキーマ（registration_invites）＋ enum invite_link ＋ 型横断更新 ＋ マイグレーション
-- [ ] 完了
+- [x] 完了
 - **概要:** 招待トークンを保持する新規テーブルを追加し、`line_link_method` enum に `invite_link` を追加。enum 追加に伴う TS 文字列リテラル型を横断更新する。
 - **変更対象ファイル:**
   - `packages/shared/src/schema/registration-invites.ts`（新規）— `id` / `token`(UNIQUE) / `expires_at` / `created_by`(FK→users.id) / `created_at` / `revoked_at`。[attachment-share-tokens.ts](packages/shared/src/schema/attachment-share-tokens.ts) のパターンを踏襲

--- a/docs/features/invite-link-registration/requirements.md
+++ b/docs/features/invite-link-registration/requirements.md
@@ -1,0 +1,164 @@
+---
+status: completed
+---
+# invite-link-registration（招待リンクによる会員セルフ登録）要件定義書
+
+## 1. 概要
+
+### 目的
+管理者が発行した**招待URL**を新規会員に渡すだけで、本人が「会員登録 → LINE 紐付け → ログイン」までを自己完結できるようにする。これまで必須だった「管理者が事前に会員レコードを作成する（[admin createMember](apps/web/src/app/(app)/admin/members/actions.ts)）」工程を、本人セルフ登録で代替できる導線を追加する。
+
+### 背景・動機
+- 現状の入会導線は **管理者が先に会員行を作成 → 本人が LINE ログイン → [/self-identify](apps/web/src/app/self-identify/page.tsx) で自分の名前を選択** の2段構え。新入会者が出るたびに管理者が手入力する必要がある。
+- 「URLを渡せば本人が登録〜ログインまで済む」形にしたい。配布先は管理者が限定するため、**不正登録対策（レート制限・本人性検証・CAPTCHA等）は不要**。ガードは**有効期限のみ**とする（ユーザー明示）。
+- アプリの認証は LINE のみ・招待制という前提は維持する。招待URL経由でも **LINE ログインを通す**ことで、再ログイン・LINE通知が成立する。
+
+## 2. ユーザーストーリー
+
+### 対象ユーザー
+- **管理者・副管理者**: 招待URLを発行し、新入会者に配布する。
+- **新規会員（未登録の人）**: 受け取ったURLから自分で会員登録してログインする。
+
+### 利用シナリオ
+1. 管理者が会員管理画面で「招待リンクを発行」し、有効期限（1日/7日/30日）を選んでURLを得る。
+2. 管理者がそのURLを新入会者（1人または複数人のグループ）に配布する。
+3. 新入会者がURLを開く → 「LINEで登録」→ LINE ログイン → 氏名（必須）と級（任意）を入力 → 登録完了し、そのままログイン状態でダッシュボードへ。
+4. 期限が切れたURLを開くと「期限切れ」表示となり登録できない。
+
+### ゴール
+- 管理者: 新入会者ごとの手入力をなくし、URL配布だけで入会を完了させる。
+- 新規会員: 1つのURLから迷わず登録・ログインまで到達する。
+
+## 3. 機能要件
+
+### 3.1 画面仕様
+
+#### (A) 招待リンク発行 UI（管理者・副管理者）
+- 設置場所: [/admin/members](apps/web/src/app/(app)/admin/members/page.tsx)（既存の会員追加と同じ画面）に「招待リンク」セクションを追加。
+- 操作:
+  - 「招待リンクを発行」ボタン → 有効期限プリセット（**1日 / 7日 / 30日**、既定 7日）を選択 → 発行。
+  - 発行後モーダルに **完全なURL**、有効期限（残り時間カウントダウン＋失効日時）、**コピー**ボタンを表示（[InviteCodeModal](apps/web/src/components/events/InviteCodeModal.tsx) のUIパターンを踏襲）。
+  - 「現在有効な招待リンク」一覧（発行日時・失効日時・無効化ボタン）を表示。
+- 権限: `admin` / `vice_admin` のみ（createMember と同じ authz）。一般会員には発行 UI を出さない。
+
+#### (B) 登録ページ `/register/[token]`（未ログイン〜登録完了）
+- **未ログインで開いた場合**: ウェルカム画面（会名・案内文）＋「LINEで登録」ボタン。押下で LINE OAuth を開始し、完了後この同じURLへ戻る（`signIn('line', { redirectTo: '/register/<token>' })`）。
+- **LINEログイン済み・未紐付けで戻ってきた場合**: 登録フォームを表示。
+  - 入力項目: **氏名（必須, 1〜50文字）**、**級（任意, A〜E のセレクト、未選択可）**。
+  - 「登録する」ボタン → 会員レコード作成＋LINE紐付け → ダッシュボード（`/`）へ。
+- **トークンが無効/期限切れ/無効化済みの場合**: 「この招待リンクは無効か期限切れです。管理者にご連絡ください。」を表示し、登録フォーム・LINEボタンは出さない。
+- **既にLINE紐付け済み（既存会員）が開いた場合**: 登録不要のためダッシュボード（`/`）へリダイレクト。
+
+#### エラー表示（登録ページ）
+- 氏名未入力 / 50文字超: フォール内バリデーションメッセージ。
+- 同名の会員が既に存在（UNIQUE 衝突, 退会済み含む）: 「同名の会員が既に存在します。管理者にご連絡ください。」（createMember の文言を踏襲）。
+- 送信時点で期限切れ/無効化: 「招待リンクの有効期限が切れています。」
+- 同一LINEアカウントが既に登録済み（二重送信等の race）: ダッシュボードへ誘導。
+
+### 3.2 ビジネスルール
+
+- **登録で作成される会員**は常に `role = 'member'`（管理者/副管理者はセルフ登録不可）。`isInvited = true`、`invitedAt = now`、`lineUserId = <セッションのLINE ID>`、`lineLinkedAt = now`、`lineLinkedMethod = 'invite_link'`（enum 新値）。
+- 1つの招待URLは**有効期限内なら複数人が利用可能**。利用上限・人数カウントは設けない。
+- **同一LINEアカウント＝1会員**: `users.line_user_id` の UNIQUE 制約で、同じLINEアカウントからの二重作成を防止。
+- **トークン有効性**: `revoked_at IS NULL` かつ `now < expires_at` のときのみ有効。ページ表示時と**送信時の両方**で再判定する（ページを開いたまま期限を跨ぐケース対策）。
+- 有効期限はガードの中心。**無効化（revoke）**は配布ミス時の安全弁として用意するが、必須要件ではない補助機能。
+- 不正登録対策（レート制限・本人性検証・CAPTCHA・メール確認）は**実装しない**（配布先限定＋期限で受容、ユーザー明示）。
+- 既存の入会導線（admin createMember ＋ self-identify）は**そのまま残す**（移行済み会員・既存招待会員向けに併存）。本機能は追加導線。
+
+### 境界・例外
+- 期限切れ・無効化済みトークン、存在しないトークン → 一律「無効」表示（理由は出し分けない）。
+- 退会済み（`deactivatedAt`）のLINEアカウントで招待URLを開く → 既存の signIn コールバックが `?error=deactivated` を返すため、退会者は登録できない（再入会は管理者経由）。
+- 級は任意。未選択時は `grade = null`（後から管理者が会員編集で補完）。
+
+## 4. 技術設計
+
+### 4.1 ルーティング / 認証フロー
+- 新規ページ: `apps/web/src/app/register/[token]/page.tsx`（`(app)` レイアウト外＝モバイルシェルを被せない、signin/self-identify と同じ独立レイアウト）。
+- [middleware.ts](apps/web/src/middleware.ts) を拡張し、`/register/` プレフィックスを新カテゴリとして扱う:
+  - 未ログイン＋ `/register/*` → 通す（ウェルカム＋LINEボタンを表示）。
+  - ログイン済み・未紐付け（`!session.user.id`）＋ `/register/*` → 通す（self-identify への強制リダイレクトの**例外**にする）。
+  - ログイン済み・紐付け済み＋ `/register/*` → `/` へリダイレクト（登録不要）。
+- LINE OAuth の往復はサーバーアクション `signIn('line', { redirectTo: '/register/<token>' })` で `redirectTo` にトークン付きURLを渡して維持する。
+- 登録確定後は self-identify と同様に `unstable_update` で JWT を更新しつつ、失敗しても [nodeJwtCallback](apps/web/src/lib/node-jwt-callback.ts) が次回 render で `lineUserId → users.id` を解決する（自己回復）。
+
+### 4.2 DB 設計
+
+**新規テーブル `registration_invites`**（`packages/shared/src/schema/` に追加）:
+
+| カラム | 型 | 制約 | 説明 |
+|---|---|---|---|
+| id | text | PK, default uuid | |
+| token | text | NOT NULL, UNIQUE | URLに載る高エントロピー乱数（`crypto.randomBytes(32).toString('base64url')`） |
+| expires_at | timestamptz | NOT NULL | 失効日時 |
+| created_by | text | NOT NULL, FK→users.id | 発行した管理者 |
+| created_at | timestamptz | NOT NULL, default now | |
+| revoked_at | timestamptz | NULL | 無効化日時（NULL=有効） |
+
+**enum 変更**: [enums.ts](packages/shared/src/schema/enums.ts) の `lineLinkMethodEnum` に `'invite_link'` を追加（`ALTER TYPE ... ADD VALUE` のマイグレーション）。
+
+**`users` テーブルは変更なし**（既存の `isInvited` / `invitedAt` / `lineUserId` / `lineLinkedMethod` を再利用）。どの招待リンク経由かのFKは持たない（監査は `lineLinkedMethod='invite_link'` で十分、スコープ外）。
+
+マイグレーションは Drizzle journal ベースで新規連番を1つ追加（テーブル作成＋enum値追加）。本番は `db:migrate`（非interactive）で適用。
+
+### 4.3 フロントエンド設計
+- `register/[token]/page.tsx`（Server Component）: トークン検証 → 状態に応じて以下を出し分け。
+  - 無効 → エラー表示コンポーネント。
+  - 未ログイン → ウェルカム＋「LINEで登録」フォーム（server action で signIn）。
+  - 未紐付け → 登録フォーム（氏名・級）クライアントコンポーネント。
+- `RegistrationInviteModal`（クライアント）: 発行後のURL/期限/コピー表示。InviteCodeModal を参考にした新規コンポーネント。
+- 会員管理画面に「招待リンク」セクション（発行ボタン＋期限選択＋有効リンク一覧）を追加。
+
+### 4.4 バックエンド設計（Server Actions / lib）
+- `lib/registration-invite.ts`: トークン生成・有効期限算出・検証（`generateRegistrationToken` / `invitedExpiresAt(preset)` / `verifyRegistrationToken`）。[invite-code.ts](apps/web/src/lib/invite-code.ts) の純関数パターンを踏襲しユニットテスト可能に。
+- 発行アクション `createRegistrationInvite(preset)`: admin/vice_admin チェック → `registration_invites` に INSERT → URL を返す。
+- 無効化アクション `revokeRegistrationInvite(id)`: admin/vice_admin チェック → `revoked_at = now` UPDATE。
+- 登録確定アクション `registerViaInvite(token, formData)`:
+  1. セッションの `lineUserId` 取得（無ければ `/register/<token>` で再ログイン誘導）。既に `session.user.id` 有り → `/` へ。
+  2. トークン再検証（無効/期限切れ → エラー）。
+  3. `users` に INSERT（name, grade, role='member', isInvited=true, invitedAt, lineUserId, lineLinkedAt, lineLinkedMethod='invite_link'）。`users.name` / `users.line_user_id` の UNIQUE 違反をそれぞれ文言ハンドリング。
+  4. `unstable_update` → `revalidatePath('/')` → `redirect('/')`。
+
+### 処理フロー（正常系）
+```
+管理者: /admin/members で「発行」(期限選択)
+  → createRegistrationInvite → registration_invites INSERT → URL をモーダル表示 → 配布
+
+新規会員: /register/<token> を開く（未ログイン）
+  → middleware 通過 → ウェルカム表示 →「LINEで登録」
+  → signIn('line', {redirectTo:'/register/<token>'}) → LINE OAuth
+  → /register/<token> へ復帰（未紐付け, middleware 例外で通過）
+  → 氏名+級 フォーム → registerViaInvite
+  → users INSERT(role=member, lineLinkedMethod=invite_link) → JWT更新 → / へ
+```
+
+## 5. 影響範囲
+
+### 変更が必要な既存ファイル
+- [apps/web/src/middleware.ts](apps/web/src/middleware.ts) — `/register/*` の通過ルール追加（未ログイン通過＋未紐付け時の self-identify 例外＋紐付け済みは `/` へ）。
+- [packages/shared/src/schema/enums.ts](packages/shared/src/schema/enums.ts) — `lineLinkMethodEnum` に `invite_link` 追加。
+- `packages/shared/src/schema/` — `registration_invites` テーブル追加（＋ relations 必要なら）。
+- [apps/web/src/app/(app)/admin/members/page.tsx](apps/web/src/app/(app)/admin/members/page.tsx) — 招待リンク発行セクション追加。
+- [apps/web/src/app/(app)/admin/members/actions.ts](apps/web/src/app/(app)/admin/members/actions.ts) または新規 actions — 発行/無効化アクション。
+- `apps/web/src/auth.config.ts` の `lineLinkLinkedMethod` 型（`'self_identify' | 'admin_link' | 'account_switch'`）に `'invite_link'` を追加（[auth.config.ts](apps/web/src/auth.config.ts) / [next-auth.d.ts](apps/web/src/next-auth.d.ts) / [node-jwt-callback.ts](apps/web/src/lib/node-jwt-callback.ts) の型を横断更新）。
+
+### 新規ファイル
+- `apps/web/src/app/register/[token]/page.tsx`、登録フォームクライアントコンポーネント、`register/[token]/actions.ts`。
+- `apps/web/src/lib/registration-invite.ts`（＋ `.test.ts`）。
+- `apps/web/src/components/admin/RegistrationInviteModal.tsx`。
+- Drizzle マイグレーション（新規連番）。
+
+### 既存機能への影響
+- **認証/ルーティング**: middleware にパスカテゴリが増えるのみ。既存の signin / self-identify / (app) 配下のゲートは不変。
+- **self-identify**: 招待リンク登録者は作成時点で `lineUserId` が埋まるため self-identify 候補（`lineUserId IS NULL`）には現れず、二重 claim は起きない。既存導線はそのまま併存。
+- **会員一意性**: `users.name` UNIQUE は不変。同名衝突は従来どおりエラー。
+- **LINE通知**: 既存どおり `lineLinkedMethod` 値が1つ増えるだけ。配信ロジックへの影響なし。
+
+## 6. 設計判断の根拠
+
+- **LINEログインを必須にする**: アプリ全体が LINE 認証のみ。LINE を通さないと再ログイン手段も通知手段も成立しないため、招待リンクでも LINE ログインを経由させる（ユーザー選択）。
+- **1本のURLを期限内で複数人**（per-person 単発トークンにしない）: 「URLを渡す人を限定するので不正登録は考えなくてよい／期限だけ設ければよい」というユーザー方針に最も素直。新入会者グループへまとめて配布でき、運用が最小。
+- **入力は氏名＋級のみ**: 氏名は `users.name`（UNIQUE）の必須キー、級はかるた会で最も使う属性。段位・所属・性別は後から管理者が補完できるため初回入力から外し、入力負担と誤入力を抑える。
+- **トークンは高エントロピー乱数（6桁コードにしない）**: 6桁コードは LINE グループで口頭発言する用途（[invite-code.ts](apps/web/src/lib/invite-code.ts)）。本機能はURLに載るため、不正対策不要でも推測可能URLは避け、`crypto.randomBytes` で生成する（コスト0）。
+- **`lineLinkMethod='invite_link'` を追加**: 入会経路を監査可能にする。既存3値と衝突しない追加のみ。
+- **revoke は補助**: ユーザーは「期限だけでよい」としているため有効期限を主ガードとし、配布ミス時の安全弁として無効化を軽量に用意（必須ではない）。
+- **既存導線を残す**: self-identify は移行済み/既存招待会員に必要。置き換えず追加導線とすることで後方互換とリグレッション回避。

--- a/packages/shared/drizzle/0030_worthless_colleen_wing.sql
+++ b/packages/shared/drizzle/0030_worthless_colleen_wing.sql
@@ -1,0 +1,12 @@
+ALTER TYPE "public"."line_link_method" ADD VALUE 'invite_link';--> statement-breakpoint
+CREATE TABLE "registration_invites" (
+	"id" text PRIMARY KEY NOT NULL,
+	"token" text NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"created_by" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"revoked_at" timestamp with time zone,
+	CONSTRAINT "registration_invites_token_unique" UNIQUE("token")
+);
+--> statement-breakpoint
+ALTER TABLE "registration_invites" ADD CONSTRAINT "registration_invites_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;

--- a/packages/shared/drizzle/meta/0030_snapshot.json
+++ b/packages/shared/drizzle/meta/0030_snapshot.json
@@ -1,0 +1,3776 @@
+{
+  "id": "07e1a6ed-e81a-4e3f-b566-1a5a1e47883b",
+  "prevId": "26e1dc53-c5db-4305-997b-1c45bf0fd4af",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_user_id": {
+          "name": "line_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "grade": {
+          "name": "grade",
+          "type": "grade",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_invited": {
+          "name": "is_invited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affiliation": {
+          "name": "affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dan": {
+          "name": "dan",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zen_nichikyo": {
+          "name": "zen_nichikyo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_linked_at": {
+          "name": "line_linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_link_method": {
+          "name": "line_link_method",
+          "type": "line_link_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notification_line_user_id": {
+          "name": "notification_line_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_name_unique": {
+          "name": "users_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_line_user_id_unique": {
+          "name": "users_line_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "line_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_dan_range": {
+          "name": "users_dan_range",
+          "value": "\"users\".\"dan\" BETWEEN 0 AND 9 OR \"users\".\"dan\" IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.registration_invites": {
+      "name": "registration_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "registration_invites_created_by_users_id_fk": {
+          "name": "registration_invites_created_by_users_id_fk",
+          "tableFrom": "registration_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "registration_invites_token_unique": {
+          "name": "registration_invites_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_groups": {
+      "name": "event_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_groups_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_groups_name_unique": {
+          "name": "event_groups_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "events_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formal_name": {
+          "name": "formal_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official": {
+          "name": "official",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'individual'"
+        },
+        "entry_deadline": {
+          "name": "entry_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_deadline": {
+          "name": "internal_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_group_id": {
+          "name": "event_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligible_grades": {
+          "name": "eligible_grades",
+          "type": "grade[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_jpy": {
+          "name": "fee_jpy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_deadline": {
+          "name": "payment_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lottery_date": {
+          "name": "lottery_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_info": {
+          "name": "payment_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_method": {
+          "name": "entry_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizer": {
+          "name": "organizer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_a": {
+          "name": "capacity_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_b": {
+          "name": "capacity_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_c": {
+          "name": "capacity_c",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_d": {
+          "name": "capacity_d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_e": {
+          "name": "capacity_e",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_status": {
+          "name": "entry_status",
+          "type": "event_entry_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_applied'"
+        },
+        "entry_applied_at": {
+          "name": "entry_applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_type": {
+          "name": "payment_type",
+          "type": "event_payment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "event_payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unpaid'"
+        },
+        "payment_paid_at": {
+          "name": "payment_paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournament_draft_id": {
+          "name": "tournament_draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournament_draft_unit_key": {
+          "name": "tournament_draft_unit_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_tournament_draft_unit_key_uniq": {
+          "name": "events_tournament_draft_unit_key_uniq",
+          "columns": [
+            {
+              "expression": "tournament_draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tournament_draft_unit_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"events\".\"tournament_draft_id\" IS NOT NULL AND \"events\".\"tournament_draft_unit_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_created_by_users_id_fk": {
+          "name": "events_created_by_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_event_group_id_event_groups_id_fk": {
+          "name": "events_event_group_id_event_groups_id_fk",
+          "tableFrom": "events",
+          "tableTo": "event_groups",
+          "columnsFrom": [
+            "event_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_attendances": {
+      "name": "event_attendances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_attendances_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attend": {
+          "name": "attend",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_attendances_event_id_events_id_fk": {
+          "name": "event_attendances_event_id_events_id_fk",
+          "tableFrom": "event_attendances",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_attendances_user_id_users_id_fk": {
+          "name": "event_attendances_user_id_users_id_fk",
+          "tableFrom": "event_attendances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_attendances_event_id_user_id_unique": {
+          "name": "event_attendances_event_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_items": {
+      "name": "schedule_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "schedule_items_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "schedule_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_items_owner_id_users_id_fk": {
+          "name": "schedule_items_owner_id_users_id_fk",
+          "tableFrom": "schedule_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_messages": {
+      "name": "mail_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_messages_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_addresses": {
+          "name": "to_addresses",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_message_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "mail_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imap_uid": {
+          "name": "imap_uid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imap_box": {
+          "name": "imap_box",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "triage_status": {
+          "name": "triage_status",
+          "type": "mail_triage_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unprocessed'"
+        },
+        "triaged_at": {
+          "name": "triaged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triaged_by_user_id": {
+          "name": "triaged_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_event_id": {
+          "name": "linked_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_messages_received_at_desc_idx": {
+          "name": "mail_messages_received_at_desc_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_messages_triage_status_idx": {
+          "name": "mail_messages_triage_status_idx",
+          "columns": [
+            {
+              "expression": "triage_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_messages_linked_event_id_idx": {
+          "name": "mail_messages_linked_event_id_idx",
+          "columns": [
+            {
+              "expression": "linked_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"mail_messages\".\"linked_event_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_messages_triaged_by_user_id_users_id_fk": {
+          "name": "mail_messages_triaged_by_user_id_users_id_fk",
+          "tableFrom": "mail_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triaged_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mail_messages_linked_event_id_events_id_fk": {
+          "name": "mail_messages_linked_event_id_events_id_fk",
+          "tableFrom": "mail_messages",
+          "tableTo": "events",
+          "columnsFrom": [
+            "linked_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mail_messages_message_id_unique": {
+          "name": "mail_messages_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_attachments": {
+      "name": "mail_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_attachments_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "mail_message_id": {
+          "name": "mail_message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extracted_text": {
+          "name": "extracted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_status": {
+          "name": "extraction_status",
+          "type": "attachment_extraction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mail_attachments_mail_message_id_idx": {
+          "name": "mail_attachments_mail_message_id_idx",
+          "columns": [
+            {
+              "expression": "mail_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_attachments_mail_message_id_mail_messages_id_fk": {
+          "name": "mail_attachments_mail_message_id_mail_messages_id_fk",
+          "tableFrom": "mail_attachments",
+          "tableTo": "mail_messages",
+          "columnsFrom": [
+            "mail_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tournament_drafts": {
+      "name": "tournament_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tournament_drafts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tournament_draft_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_correction": {
+          "name": "is_correction",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "references_subject": {
+          "name": "references_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_by_draft_id": {
+          "name": "superseded_by_draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracted_payload": {
+          "name": "extracted_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ai_raw_response": {
+          "name": "ai_raw_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_tokens_input": {
+          "name": "ai_tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_tokens_output": {
+          "name": "ai_tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_cost_usd": {
+          "name": "ai_cost_usd",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by_user_id": {
+          "name": "rejected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_drafts_status_created": {
+          "name": "idx_drafts_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_drafts_event_id": {
+          "name": "idx_drafts_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"tournament_drafts\".\"event_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tournament_drafts_message_id_mail_messages_id_fk": {
+          "name": "tournament_drafts_message_id_mail_messages_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "mail_messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tournament_drafts_event_id_events_id_fk": {
+          "name": "tournament_drafts_event_id_events_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tournament_drafts_approved_by_user_id_users_id_fk": {
+          "name": "tournament_drafts_approved_by_user_id_users_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tournament_drafts_rejected_by_user_id_users_id_fk": {
+          "name": "tournament_drafts_rejected_by_user_id_users_id_fk",
+          "tableFrom": "tournament_drafts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "rejected_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tournament_drafts_message_id_unique": {
+          "name": "tournament_drafts_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tournament_drafts_confidence_range": {
+          "name": "tournament_drafts_confidence_range",
+          "value": "\"tournament_drafts\".\"confidence\" BETWEEN 0 AND 1 OR \"tournament_drafts\".\"confidence\" IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.line_channels": {
+      "name": "line_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "line_channels_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_secret": {
+          "name": "channel_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_access_token": {
+          "name": "channel_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "line_channel_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "line_channel_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system_notify'"
+        },
+        "assigned_user_id": {
+          "name": "assigned_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_event_id": {
+          "name": "assigned_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_destination_id": {
+          "name": "webhook_destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_line_user_id": {
+          "name": "notification_line_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "line_channels_assigned_user_id_users_id_fk": {
+          "name": "line_channels_assigned_user_id_users_id_fk",
+          "tableFrom": "line_channels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "line_channels_assigned_event_id_events_id_fk": {
+          "name": "line_channels_assigned_event_id_events_id_fk",
+          "tableFrom": "line_channels",
+          "tableTo": "events",
+          "columnsFrom": [
+            "assigned_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "line_channels_channel_id_unique": {
+          "name": "line_channels_channel_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "channel_id"
+          ]
+        },
+        "line_channels_assigned_user_id_unique": {
+          "name": "line_channels_assigned_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "assigned_user_id"
+          ]
+        },
+        "line_channels_assigned_event_id_unique": {
+          "name": "line_channels_assigned_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "assigned_event_id"
+          ]
+        },
+        "line_channels_webhook_destination_id_unique": {
+          "name": "line_channels_webhook_destination_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "webhook_destination_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_worker_jobs": {
+      "name": "mail_worker_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_worker_jobs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "since": {
+          "name": "since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_worker_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "mail_worker_job_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fetch'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_mail_worker_jobs_status_requested_at": {
+          "name": "idx_mail_worker_jobs_status_requested_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mail_worker_jobs_status_kind_requested_at": {
+          "name": "idx_mail_worker_jobs_status_kind_requested_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_worker_jobs_requested_by_user_id_users_id_fk": {
+          "name": "mail_worker_jobs_requested_by_user_id_users_id_fk",
+          "tableFrom": "mail_worker_jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mail_worker_jobs_run_id_mail_worker_runs_id_fk": {
+          "name": "mail_worker_jobs_run_id_mail_worker_runs_id_fk",
+          "tableFrom": "mail_worker_jobs",
+          "tableTo": "mail_worker_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_worker_runs": {
+      "name": "mail_worker_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mail_worker_runs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "mail_worker_run_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_worker_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_user_id": {
+          "name": "triggered_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "since": {
+          "name": "since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_worker_runs_triggered_by_user_id_users_id_fk": {
+          "name": "mail_worker_runs_triggered_by_user_id_users_id_fk",
+          "tableFrom": "mail_worker_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggered_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_line_broadcasts": {
+      "name": "event_line_broadcasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_line_broadcasts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_channel_id": {
+          "name": "line_channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code_expires_at": {
+          "name": "invite_code_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_group_id": {
+          "name": "line_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_line_broadcast_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invite_pending'"
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extended_until": {
+          "name": "extended_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoke_reason": {
+          "name": "revoke_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_line_broadcasts_invite_code_active_uq": {
+          "name": "event_line_broadcasts_invite_code_active_uq",
+          "columns": [
+            {
+              "expression": "invite_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"event_line_broadcasts\".\"invite_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_line_broadcasts_event_id_events_id_fk": {
+          "name": "event_line_broadcasts_event_id_events_id_fk",
+          "tableFrom": "event_line_broadcasts",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "event_line_broadcasts_line_channel_id_line_channels_id_fk": {
+          "name": "event_line_broadcasts_line_channel_id_line_channels_id_fk",
+          "tableFrom": "event_line_broadcasts",
+          "tableTo": "line_channels",
+          "columnsFrom": [
+            "line_channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_line_broadcasts_event_id_unique": {
+          "name": "event_line_broadcasts_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_broadcast_messages": {
+      "name": "event_broadcast_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_broadcast_messages_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_line_broadcast_id": {
+          "name": "event_line_broadcast_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mail_message_id": {
+          "name": "mail_message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "event_broadcast_message_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "is_correction": {
+          "name": "is_correction",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lead_text": {
+          "name": "lead_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_lead_count": {
+          "name": "sent_lead_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_text_count": {
+          "name": "sent_text_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_image_count": {
+          "name": "sent_image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "fallback_link_count": {
+          "name": "fallback_link_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_broadcast_messages_event_line_broadcast_id_event_line_broadcasts_id_fk": {
+          "name": "event_broadcast_messages_event_line_broadcast_id_event_line_broadcasts_id_fk",
+          "tableFrom": "event_broadcast_messages",
+          "tableTo": "event_line_broadcasts",
+          "columnsFrom": [
+            "event_line_broadcast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_broadcast_messages_mail_message_id_mail_messages_id_fk": {
+          "name": "event_broadcast_messages_mail_message_id_mail_messages_id_fk",
+          "tableFrom": "event_broadcast_messages",
+          "tableTo": "mail_messages",
+          "columnsFrom": [
+            "mail_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_broadcast_messages_broadcast_mail_uq": {
+          "name": "event_broadcast_messages_broadcast_mail_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_line_broadcast_id",
+            "mail_message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachment_share_tokens": {
+      "name": "attachment_share_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "attachment_share_tokens_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "mail_attachment_id": {
+          "name": "mail_attachment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attachment_share_tokens_attachment_idx": {
+          "name": "attachment_share_tokens_attachment_idx",
+          "columns": [
+            {
+              "expression": "mail_attachment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachment_share_tokens_expires_at_idx": {
+          "name": "attachment_share_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attachment_share_tokens_mail_attachment_id_mail_attachments_id_fk": {
+          "name": "attachment_share_tokens_mail_attachment_id_mail_attachments_id_fk",
+          "tableFrom": "attachment_share_tokens",
+          "tableTo": "mail_attachments",
+          "columnsFrom": [
+            "mail_attachment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "attachment_share_tokens_mail_attachment_id_unique": {
+          "name": "attachment_share_tokens_mail_attachment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mail_attachment_id"
+          ]
+        },
+        "attachment_share_tokens_token_unique": {
+          "name": "attachment_share_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_lifecycle_notifications": {
+      "name": "event_lifecycle_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_lifecycle_notifications_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "event_lifecycle_notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "event_lifecycle_notification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sent'"
+        },
+        "line_group_id": {
+          "name": "line_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_lifecycle_notifications_event_type_uq": {
+          "name": "event_lifecycle_notifications_event_type_uq",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_lifecycle_notifications_event_id_events_id_fk": {
+          "name": "event_lifecycle_notifications_event_id_events_id_fk",
+          "tableFrom": "event_lifecycle_notifications",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "push_subscriptions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_id_idx": {
+          "name": "push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_id_fk": {
+          "name": "push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_subscriptions_endpoint_unique": {
+          "name": "push_subscriptions_endpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "endpoint"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.players": {
+      "name": "players",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "players_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_kana": {
+          "name": "name_kana",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affiliation": {
+          "name": "affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefecture": {
+          "name": "prefecture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_players_user_id": {
+          "name": "idx_players_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "players_user_id_users_id_fk": {
+          "name": "players_user_id_users_id_fk",
+          "tableFrom": "players",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "players_normalized_name_uq": {
+          "name": "players_normalized_name_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "normalized_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tournaments": {
+      "name": "tournaments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tournaments_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "venue": {
+          "name": "venue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_result_draft_id": {
+          "name": "source_result_draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tournament_classes": {
+      "name": "tournament_classes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tournament_classes_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_name": {
+          "name": "class_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade": {
+          "name": "grade",
+          "type": "grade",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_players": {
+          "name": "num_players",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sheet_name": {
+          "name": "sheet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tournament_classes_tournament_id_tournaments_id_fk": {
+          "name": "tournament_classes_tournament_id_tournaments_id_fk",
+          "tableFrom": "tournament_classes",
+          "tableTo": "tournaments",
+          "columnsFrom": [
+            "tournament_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tournament_participants": {
+      "name": "tournament_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tournament_participants_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seq_no": {
+          "name": "seq_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_kana": {
+          "name": "name_kana",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affiliation": {
+          "name": "affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefecture": {
+          "name": "prefecture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dan": {
+          "name": "dan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dan_rank": {
+          "name": "dan_rank",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_no": {
+          "name": "member_no",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_rank": {
+          "name": "final_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_participants_player_id": {
+          "name": "idx_participants_player_id",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_participants_class_id": {
+          "name": "idx_participants_class_id",
+          "columns": [
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tournament_participants_class_id_tournament_classes_id_fk": {
+          "name": "tournament_participants_class_id_tournament_classes_id_fk",
+          "tableFrom": "tournament_participants",
+          "tableTo": "tournament_classes",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tournament_participants_player_id_players_id_fk": {
+          "name": "tournament_participants_player_id_players_id_fk",
+          "tableFrom": "tournament_participants",
+          "tableTo": "players",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tournament_participants_id_class_id_uq": {
+          "name": "tournament_participants_id_class_id_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "class_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tournament_participants_dan_rank_range": {
+          "name": "tournament_participants_dan_rank_range",
+          "value": "\"tournament_participants\".\"dan_rank\" BETWEEN 1 AND 10 OR \"tournament_participants\".\"dan_rank\" IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.matches": {
+      "name": "matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "matches_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_label": {
+          "name": "round_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opponent_participant_id": {
+          "name": "opponent_participant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opponent_name": {
+          "name": "opponent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "match_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score_diff": {
+          "name": "score_diff",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "match_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        }
+      },
+      "indexes": {
+        "idx_matches_class_id": {
+          "name": "idx_matches_class_id",
+          "columns": [
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_matches_participant_id": {
+          "name": "idx_matches_participant_id",
+          "columns": [
+            {
+              "expression": "participant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matches_class_id_tournament_classes_id_fk": {
+          "name": "matches_class_id_tournament_classes_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "tournament_classes",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "matches_opponent_participant_id_tournament_participants_id_fk": {
+          "name": "matches_opponent_participant_id_tournament_participants_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "tournament_participants",
+          "columnsFrom": [
+            "opponent_participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "matches_participant_id_class_id_fk": {
+          "name": "matches_participant_id_class_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "tournament_participants",
+          "columnsFrom": [
+            "participant_id",
+            "class_id"
+          ],
+          "columnsTo": [
+            "id",
+            "class_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.result_drafts": {
+      "name": "result_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "result_drafts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "result_draft_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "extracted_payload": {
+          "name": "extracted_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "parser_version": {
+          "name": "parser_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parse_error": {
+          "name": "parse_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_by_draft_id": {
+          "name": "superseded_by_draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by_user_id": {
+          "name": "rejected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_result_drafts_status_created": {
+          "name": "idx_result_drafts_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "result_drafts_message_id_mail_messages_id_fk": {
+          "name": "result_drafts_message_id_mail_messages_id_fk",
+          "tableFrom": "result_drafts",
+          "tableTo": "mail_messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "result_drafts_tournament_id_tournaments_id_fk": {
+          "name": "result_drafts_tournament_id_tournaments_id_fk",
+          "tableFrom": "result_drafts",
+          "tableTo": "tournaments",
+          "columnsFrom": [
+            "tournament_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "result_drafts_approved_by_user_id_users_id_fk": {
+          "name": "result_drafts_approved_by_user_id_users_id_fk",
+          "tableFrom": "result_drafts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "result_drafts_rejected_by_user_id_users_id_fk": {
+          "name": "result_drafts_rejected_by_user_id_users_id_fk",
+          "tableFrom": "result_drafts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "rejected_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "result_drafts_message_id_unique": {
+          "name": "result_drafts_message_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attachment_extraction_status": {
+      "name": "attachment_extraction_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "extracted",
+        "failed",
+        "unsupported"
+      ]
+    },
+    "public.event_broadcast_message_status": {
+      "name": "event_broadcast_message_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sending",
+        "sent",
+        "partial",
+        "failed"
+      ]
+    },
+    "public.event_entry_status": {
+      "name": "event_entry_status",
+      "schema": "public",
+      "values": [
+        "not_applied",
+        "applied"
+      ]
+    },
+    "public.event_kind": {
+      "name": "event_kind",
+      "schema": "public",
+      "values": [
+        "individual",
+        "team"
+      ]
+    },
+    "public.event_lifecycle_notification_status": {
+      "name": "event_lifecycle_notification_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.event_lifecycle_notification_type": {
+      "name": "event_lifecycle_notification_type",
+      "schema": "public",
+      "values": [
+        "entry_applied",
+        "entry_deadline_advance",
+        "entry_deadline_day",
+        "payment_paid",
+        "payment_deadline_advance",
+        "payment_deadline_day",
+        "onsite_payment_advance",
+        "onsite_payment_day",
+        "entry_applied_treasurer"
+      ]
+    },
+    "public.event_line_broadcast_status": {
+      "name": "event_line_broadcast_status",
+      "schema": "public",
+      "values": [
+        "invite_pending",
+        "joined_waiting_code",
+        "linked",
+        "revoked",
+        "released"
+      ]
+    },
+    "public.event_payment_status": {
+      "name": "event_payment_status",
+      "schema": "public",
+      "values": [
+        "unpaid",
+        "paid"
+      ]
+    },
+    "public.event_payment_type": {
+      "name": "event_payment_type",
+      "schema": "public",
+      "values": [
+        "advance",
+        "onsite"
+      ]
+    },
+    "public.event_status": {
+      "name": "event_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "cancelled",
+        "done"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female"
+      ]
+    },
+    "public.grade": {
+      "name": "grade",
+      "schema": "public",
+      "values": [
+        "A",
+        "B",
+        "C",
+        "D",
+        "E"
+      ]
+    },
+    "public.line_channel_purpose": {
+      "name": "line_channel_purpose",
+      "schema": "public",
+      "values": [
+        "system_notify",
+        "event_broadcast"
+      ]
+    },
+    "public.line_channel_status": {
+      "name": "line_channel_status",
+      "schema": "public",
+      "values": [
+        "available",
+        "assigned",
+        "active",
+        "system",
+        "disabled"
+      ]
+    },
+    "public.line_link_method": {
+      "name": "line_link_method",
+      "schema": "public",
+      "values": [
+        "self_identify",
+        "admin_link",
+        "account_switch",
+        "invite_link"
+      ]
+    },
+    "public.mail_classification": {
+      "name": "mail_classification",
+      "schema": "public",
+      "values": [
+        "tournament",
+        "noise",
+        "unknown"
+      ]
+    },
+    "public.mail_message_status": {
+      "name": "mail_message_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "fetched",
+        "parse_failed",
+        "fetch_failed",
+        "ai_processing",
+        "ai_done",
+        "ai_failed",
+        "oversize_skipped",
+        "archived"
+      ]
+    },
+    "public.mail_triage_status": {
+      "name": "mail_triage_status",
+      "schema": "public",
+      "values": [
+        "unprocessed",
+        "processed"
+      ]
+    },
+    "public.mail_worker_job_kind": {
+      "name": "mail_worker_job_kind",
+      "schema": "public",
+      "values": [
+        "fetch",
+        "manual_extract",
+        "result_parse"
+      ]
+    },
+    "public.mail_worker_job_status": {
+      "name": "mail_worker_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "claimed",
+        "done",
+        "failed"
+      ]
+    },
+    "public.mail_worker_run_kind": {
+      "name": "mail_worker_run_kind",
+      "schema": "public",
+      "values": [
+        "cron",
+        "manual"
+      ]
+    },
+    "public.mail_worker_run_status": {
+      "name": "mail_worker_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "imap_failed",
+        "ai_failed",
+        "partial"
+      ]
+    },
+    "public.match_result": {
+      "name": "match_result",
+      "schema": "public",
+      "values": [
+        "win",
+        "lose"
+      ]
+    },
+    "public.match_status": {
+      "name": "match_status",
+      "schema": "public",
+      "values": [
+        "normal",
+        "walkover",
+        "forfeit"
+      ]
+    },
+    "public.result_draft_status": {
+      "name": "result_draft_status",
+      "schema": "public",
+      "values": [
+        "pending_review",
+        "approved",
+        "rejected",
+        "parse_failed",
+        "superseded"
+      ]
+    },
+    "public.schedule_kind": {
+      "name": "schedule_kind",
+      "schema": "public",
+      "values": [
+        "practice",
+        "meeting",
+        "social",
+        "other"
+      ]
+    },
+    "public.tournament_draft_status": {
+      "name": "tournament_draft_status",
+      "schema": "public",
+      "values": [
+        "pending_review",
+        "approved",
+        "rejected",
+        "ai_failed",
+        "superseded",
+        "ai_processing"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "vice_admin",
+        "member"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/shared/drizzle/meta/_journal.json
+++ b/packages/shared/drizzle/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1782360291713,
       "tag": "0029_player_name_only_uq",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1782458542663,
+      "tag": "0030_worthless_colleen_wing",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/schema/enums.ts
+++ b/packages/shared/src/schema/enums.ts
@@ -10,6 +10,9 @@ export const lineLinkMethodEnum = pgEnum('line_link_method', [
   'self_identify',
   'admin_link',
   'account_switch',
+  // invite-link-registration: member self-registered via an admin-issued
+  // /register/<token> link (the LINE binding happens at row creation time).
+  'invite_link',
 ])
 
 // mail-tournament-import (PR1)

--- a/packages/shared/src/schema/index.ts
+++ b/packages/shared/src/schema/index.ts
@@ -1,5 +1,6 @@
 export * from './enums'
 export * from './auth'
+export * from './registration-invites'
 export * from './event-groups'
 export * from './events'
 export * from './event-attendances'

--- a/packages/shared/src/schema/registration-invites.ts
+++ b/packages/shared/src/schema/registration-invites.ts
@@ -1,0 +1,36 @@
+import { pgTable, text, timestamp } from 'drizzle-orm/pg-core'
+import { users } from './auth'
+
+/**
+ * registration_invites: admin-issued self-registration links.
+ *
+ * An admin/vice_admin issues a link from the member admin page; the URL carries
+ * the high-entropy `token` (`crypto.randomBytes(32).toString('base64url')`). A
+ * new member opens `/register/<token>`, logs in with LINE, and self-registers a
+ * `role='member'` row (`line_link_method='invite_link'`).
+ *
+ * One link is reusable by multiple people while valid — there is deliberately
+ * NO per-person/usage cap (distribution is operator-limited, see requirements
+ * §6). A link is valid only while `revoked_at IS NULL AND now() < expires_at`;
+ * both the page render and the submit action re-check this, so an open tab that
+ * crosses the expiry cannot still register.
+ *
+ * `revoked_at` is a manual safety valve for mis-distribution (not a required
+ * guard — expiry is the primary one). No FK back from `users` is kept: the
+ * registration audit trail is `users.line_link_method='invite_link'`, which is
+ * sufficient and avoids coupling member rows to ephemeral invite rows.
+ */
+export const registrationInvites = pgTable('registration_invites', {
+  id: text('id')
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  token: text('token').notNull().unique(),
+  expiresAt: timestamp('expires_at', { mode: 'date', withTimezone: true }).notNull(),
+  createdBy: text('created_by')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  createdAt: timestamp('created_at', { mode: 'date', withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  revokedAt: timestamp('revoked_at', { mode: 'date', withTimezone: true }),
+})


### PR DESCRIPTION
## Summary
招待URLを渡すだけで本人が「会員登録 → LINE紐付け → ログイン」まで自己完結できる導線を追加（親 #173 / 子 #174-181）。既存の admin createMember ＋ /self-identify は置き換えず併存する追加導線。

### 何を
- 新規 `registration_invites` テーブル（token UNIQUE / expires_at / created_by FK→users / revoked_at）＋ `line_link_method` enum に `invite_link` 追加（migration 0030）
- `/admin/members` に「招待リンク」発行セクション（期限プリセット 1日/7日/30日・URL/カウントダウン/コピーのモーダル・有効リンク一覧＋無効化）
- `/register/[token]` 登録ページ（無効/期限切れ→エラー、未ログイン→「LINEで登録」、未紐付け→氏名+級フォーム、紐付け済み→ /）
- middleware に `/register/*` カテゴリ追加（未ログイン通過・未紐付け時の self-identify 強制の例外・紐付け済みは / へ）。既存ルーティングは非破壊
- 純関数 lib（トークン生成/期限算出/有効性判定）＋ 発行・無効化・一覧・登録確定の Server Actions

### なぜ
- 新入会のたびに管理者が会員行を手入力する手間をなくし、URL配布だけで入会完結。配布先を限定するためガードは有効期限のみ（要件 §6、不正対策なし）。LINE認証必須は維持（再ログイン・LINE通知が成立するため）。

### 主要な設計判断
- 1本のURLを期限内で複数人利用（per-person 単発トークンにしない）。LINE 1アカウント=1会員（users.line_user_id UNIQUE で二重作成防止）
- 登録は常に role=member / isInvited / lineLinkedMethod='invite_link'。監査は line_link_method で十分なため users 表は不変
- トークン有効性（revoked_at IS NULL かつ未失効）はページ表示時と送信時の両方で再判定
- 同名衝突→文言エラー、同一LINE二重登録（race）→ / へ誘導
- generateRegistrationToken は Web Crypto グローバル（crypto.getRandomValues）で client-bundle-safe（node:crypto を持たない／E2E が webpack ビルド破壊を検出して修正済み）

## Test plan
- [x] lib/API unit: registration-invite 26 ・ 発行系 actions 10 ・ registerViaInvite 10
- [x] E2E (Playwright) 6本: ウェルカム+LINEボタン / フォーム登録→dashboard+DB / 期限切れ / 存在しないトークン / 紐付け済みリダイレクト / 管理者発行→URL+DB
- [x] check-types 4/4 ・ lint クリーン ・ web unit 638 passed ・ shared 12 ・ mail-worker 401
- [ ] 本番反映後の実機確認（migration 0030 適用 ＋ スマホで発行→登録の通し）

🤖 Generated with [Claude Code](https://claude.com/claude-code)