### PR TITLE
fix(senseki): 戦績詳細の小修正（初期全畳み・相手リンク導線・遷移元へ戻る）

### DIFF
--- a/apps/web/src/app/(app)/players/[id]/SensekiTimeline.test.tsx
+++ b/apps/web/src/app/(app)/players/[id]/SensekiTimeline.test.tsx
@@ -55,64 +55,66 @@ const years: TimelineYear[] = [
 ]
 
 describe('SensekiTimeline', () => {
-  it('最新年は初期展開し、古い年は折りたたまれている', () => {
-    render(<SensekiTimeline years={years} />)
-    // getByText は見つからなければ throw する＝存在アサーション
+  it('初期は全年が畳まれている（年見出しのみ表示）', () => {
+    render(<SensekiTimeline years={years} playerId={5} />)
     screen.getByText('2026年')
     screen.getByText('2025年')
-    screen.getByText('北海道選手権A')
-    // 2025 は折りたたみ → 中身は描画されない
+    // 大会の中身はどの年も初期は出ない（全畳み）
+    expect(screen.queryByText('北海道選手権A')).toBeNull()
     expect(screen.queryByText('秋大会B')).toBeNull()
   })
 
   it('年見出しタップで展開する', () => {
-    render(<SensekiTimeline years={years} />)
-    fireEvent.click(screen.getByText('2025年'))
-    expect(screen.queryByText('秋大会B')).not.toBeNull()
+    render(<SensekiTimeline years={years} playerId={5} />)
+    fireEvent.click(screen.getByText('2026年'))
+    screen.getByText('北海道選手権A')
   })
 
-  it('解決済みの相手は戦績リンク、未解決はリンクにしない（黒テキスト）', () => {
-    render(<SensekiTimeline years={years} />)
+  it('展開後、解決済みの相手は ?from 付き戦績リンク・未解決はリンク無し', () => {
+    render(<SensekiTimeline years={years} playerId={5} />)
+    fireEvent.click(screen.getByText('2026年'))
     const link = screen.getByRole('link', { name: '渡辺大輔' })
-    expect(link.getAttribute('href')).toBe('/players/99')
+    expect(link.getAttribute('href')).toBe('/players/99?from=5')
     expect(screen.queryByRole('link', { name: '外部花子' })).toBeNull()
-    // 未解決の相手名はテキストとしては存在する
     screen.getByText('外部花子')
   })
 
-  it('相手の所属会と ○×トークンを表示する', () => {
-    render(<SensekiTimeline years={years} />)
+  it('展開後、相手の所属会と ○×トークンを表示する', () => {
+    render(<SensekiTimeline years={years} playerId={5} />)
+    fireEvent.click(screen.getByText('2026年'))
     screen.getByText('（東京暁星会）')
     screen.getByText('○7')
     screen.getByText('×3')
   })
 
-  it('別選手データに差し替えると最新年のみ展開にリセットされる（Codex R3 should_fix）', () => {
-    const { rerender } = render(<SensekiTimeline years={years} />)
-    fireEvent.click(screen.getByText('2025年')) // ユーザーが古い年も開く
+  it('別選手データに差し替えると展開状態がリセットされる（同名年も畳む）', () => {
+    const { rerender } = render(<SensekiTimeline years={years} playerId={5} />)
+    fireEvent.click(screen.getByText('2026年'))
+    screen.getByText('北海道選手権A')
     const other: TimelineYear[] = [
       {
-        year: '2020',
+        year: '2026',
         tournamentCount: 1,
         wins: 1,
         losses: 0,
         tournaments: [
-          { participantId: 9, dateLabel: '3/3', title: '別大会A', rank: '優勝', rankEmphasis: true, matches: [] },
+          { participantId: 9, dateLabel: '3/3', title: '別大会X', rank: '優勝', rankEmphasis: true, matches: [] },
         ],
       },
       {
-        year: '2019',
+        year: '2024',
         tournamentCount: 1,
         wins: 0,
         losses: 1,
         tournaments: [
-          { participantId: 8, dateLabel: '4/4', title: '旧大会B', rank: 'ベスト8', rankEmphasis: false, matches: [] },
+          { participantId: 8, dateLabel: '4/4', title: '旧大会Y', rank: 'ベスト8', rankEmphasis: false, matches: [] },
         ],
       },
     ]
-    rerender(<SensekiTimeline years={other} />)
-    // 最新年(2020)が開く・古い年(2019)は閉じる＝初期状態にリセット
-    screen.getByText('別大会A')
-    expect(screen.queryByText('旧大会B')).toBeNull()
+    rerender(<SensekiTimeline years={other} playerId={9} />)
+    // リセットで全畳み。同名年(2026)が開いたままにならない＝別大会X は出ない。
+    expect(screen.queryByText('別大会X')).toBeNull()
+    expect(screen.queryByText('北海道選手権A')).toBeNull()
+    screen.getByText('2026年')
   })
 })

--- a/apps/web/src/app/(app)/players/[id]/SensekiTimeline.tsx
+++ b/apps/web/src/app/(app)/players/[id]/SensekiTimeline.tsx
@@ -49,15 +49,22 @@ function scoreClass(tone: TimelineMatch['scoreTone']): string {
   return 'text-ink-muted'
 }
 
-export function SensekiTimeline({ years }: { years: TimelineYear[] }) {
-  // 最新年（先頭）のみ初期展開。選手間遷移で App Router が同じインスタンスを再利用し
-  // years だけ差し替わっても、年セットが変わったら初期状態（最新年のみ開く）に作り直す。
+export function SensekiTimeline({
+  years,
+  playerId,
+}: {
+  years: TimelineYear[]
+  /** 表示中の選手 id。相手リンクに `?from=` として付け、遷移先の戻る導線に使う。 */
+  playerId: number
+}) {
+  // 初期は全年を畳む。選手間遷移で App Router が同じインスタンスを再利用し years だけ
+  // 差し替わっても、年セットが変わったら全閉じの初期状態に作り直す。
   const yearsKey = years.map((y) => y.year).join(',')
   const [open, setOpen] = useState<Record<string, boolean>>({})
   const [prevKey, setPrevKey] = useState<string | null>(null)
   if (yearsKey !== prevKey) {
     setPrevKey(yearsKey)
-    setOpen(years.length > 0 ? { [years[0]!.year]: true } : {})
+    setOpen({})
   }
   const toggle = (year: string) =>
     setOpen((prev) => ({ ...prev, [year]: !prev[year] }))
@@ -128,7 +135,7 @@ export function SensekiTimeline({ years }: { years: TimelineYear[] }) {
                                 {m.opponentName ? (
                                   m.opponentPlayerId ? (
                                     <Link
-                                      href={`/players/${m.opponentPlayerId}`}
+                                      href={`/players/${m.opponentPlayerId}?from=${playerId}`}
                                       className="text-ink"
                                     >
                                       {m.opponentName}

--- a/apps/web/src/app/(app)/players/[id]/page.tsx
+++ b/apps/web/src/app/(app)/players/[id]/page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import { notFound, redirect } from 'next/navigation'
 import { auth } from '@/auth'
-import { getPlayerRecord, type PlayerMatchView } from '@/lib/players/queries'
+import { getPlayerName, getPlayerRecord, type PlayerMatchView } from '@/lib/players/queries'
 import { SensekiTimeline, type TimelineYear } from './SensekiTimeline'
 
 export const dynamic = 'force-dynamic'
@@ -33,8 +33,10 @@ function scoreToken(m: PlayerMatchView): {
 
 export default async function PlayerDetailPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>
+  searchParams: Promise<{ from?: string }>
 }) {
   const session = await auth()
   if (!session) redirect('/auth/signin')
@@ -45,6 +47,15 @@ export default async function PlayerDetailPage({
 
   const record = await getPlayerRecord(playerId)
   if (!record) notFound()
+
+  // 相手名タップで別選手から遷移してきた場合（?from=遷移元id）、戻る導線は
+  // 遷移元の選手詳細へ向ける。無効/自分自身/存在しない id は通常の検索へ戻る。
+  const { from } = await searchParams
+  const fromId = Number(from)
+  const fromName =
+    Number.isInteger(fromId) && fromId > 0 && fromId !== playerId
+      ? await getPlayerName(fromId)
+      : null
 
   const {
     player,
@@ -100,6 +111,10 @@ export default async function PlayerDetailPage({
     })
   }
   const years = [...yearMap.values()]
+  // 相手名タップ導線のヒントは、解決済み（リンク可能）な相手が1件でもある時だけ出す。
+  const hasTappableOpponent = participations.some((p) =>
+    p.matches.some((m) => m.opponentPlayerId != null),
+  )
 
   const spanLabel = activeYears
     ? activeYears.from === activeYears.to
@@ -116,9 +131,15 @@ export default async function PlayerDetailPage({
   return (
     <div className="flex flex-col gap-4 p-4">
       <div>
-        <Link href="/players" className="text-sm text-brand-fg">
-          ← 選手検索へ戻る
-        </Link>
+        {fromName ? (
+          <Link href={`/players/${fromId}`} className="text-sm text-brand-fg">
+            ← {fromName} の戦績へ戻る
+          </Link>
+        ) : (
+          <Link href="/players" className="text-sm text-brand-fg">
+            ← 選手検索へ戻る
+          </Link>
+        )}
       </div>
 
       {/* サマリー（箱なし・和紙地に直接） */}
@@ -159,6 +180,11 @@ export default async function PlayerDetailPage({
         </div>
 
         <div className="mt-2 text-xs text-ink-meta">{chips.join(' ・ ')}</div>
+        {hasTappableOpponent && (
+          <p className="mt-1.5 text-[11px] text-ink-muted">
+            ※ 試合表の相手名をタップすると、その選手の戦績へ移動します
+          </p>
+        )}
       </div>
 
       <hr className="border-t border-border-soft" />
@@ -166,7 +192,7 @@ export default async function PlayerDetailPage({
       {years.length === 0 ? (
         <p className="py-6 text-center text-sm text-ink-meta">出場記録がありません。</p>
       ) : (
-        <SensekiTimeline key={player.id} years={years} />
+        <SensekiTimeline key={player.id} years={years} playerId={player.id} />
       )}
     </div>
   )

--- a/apps/web/src/lib/players/queries.test.ts
+++ b/apps/web/src/lib/players/queries.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 import type { ParsedResultPayload } from '@kagetra/mail-worker/result-import/schema'
 import { closeTestDb, testDb, truncateAll } from '@/test-utils/db'
 import { materializeResultDraft } from '@/lib/result-import/materialize'
-import { getPlayerRecord, searchPlayers } from './queries'
+import { getPlayerName, getPlayerRecord, searchPlayers } from './queries'
 
 beforeEach(async () => {
   await truncateAll()
@@ -423,5 +423,34 @@ describe('getPlayerRecord — 順位導出・相手リンク・サマリー（T2
     const rec = (await getPlayerRecord((await searchPlayers('単独太郎'))[0]!.id))!
     expect(rec.participations[0]!.matches[0]!.opponentName).toBe('外部花子')
     expect(rec.participations[0]!.matches[0]!.opponentPlayerId).toBeNull()
+  })
+})
+
+describe('getPlayerName', () => {
+  it('表示名を引く / 存在しない id は null', async () => {
+    await seedTournament(
+      {
+        parserVersion: '1.0.0',
+        classes: [
+          classWith('D級', 'D', [
+            {
+              seqNo: 1,
+              name: '戻る太郎',
+              nameKana: null,
+              affiliation: null,
+              prefecture: null,
+              dan: null,
+              memberNo: null,
+              finalRank: null,
+              matches: [],
+            },
+          ]),
+        ],
+      },
+      { name: '大会1', eventDate: '2026-01-01' },
+    )
+    const player = (await searchPlayers('戻る太郎'))[0]!
+    expect(await getPlayerName(player.id)).toBe('戻る太郎')
+    expect(await getPlayerName(999_999)).toBeNull()
   })
 })

--- a/apps/web/src/lib/players/queries.ts
+++ b/apps/web/src/lib/players/queries.ts
@@ -111,6 +111,15 @@ export async function searchPlayers(query: string): Promise<PlayerSearchResult[]
   return rows
 }
 
+/** 選手の表示名のみを引く軽量クエリ（戻る導線のラベル用）。存在しなければ null。 */
+export async function getPlayerName(playerId: number): Promise<string | null> {
+  const row = await db.query.players.findFirst({
+    where: eq(players.id, playerId),
+    columns: { displayName: true },
+  })
+  return row?.displayName ?? null
+}
+
 /**
  * 選手の全戦績。participants（生スナップショット）を起点に大会/級/順位/各試合を
  * 読み取り専用で集約する。


### PR DESCRIPTION
## Summary
戦績詳細 `/players/[id]` の小修正3点（PR #183 のフォロー）。
- **初期は全年を畳む**（最新年の自動展開を廃止）。
- **相手名タップの導線ヒント**を小さく表示（解決済みの相手が1件でもある時のみ・muted）。
- **相手から遷移した先の「戻る」を遷移元の選手詳細へ**：相手リンクに `?from={選手id}` を付与し、`page` は `from` の選手名を引いて `← {名前} の戦績へ戻る`（リンク先 `/players/{from}`）、無ければ従来の `← 選手検索へ戻る`。軽量 `getPlayerName` 追加。

新規 API/DB/migration なし（読み取り層に軽量クエリ1つ追加のみ）。

## Test plan
- [x] queries.test（getPlayerName）/ SensekiTimeline.test（初期全畳み・`?from=` 付与・リセット）= 20 green
- [x] type-check / lint クリーン
- [ ] 本番デプロイ後の実機目視（初期折りたたみ／ヒント表示／相手タップ→戻るが遷移元へ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)