### PR TITLE
fix(web): モバイルのピンチズーム/入力フォーカス時ズームを抑制

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -38,6 +38,13 @@ export const metadata: Metadata = {
 
 export const viewport: Viewport = {
   themeColor: '#ffffff',
+  // Suppress pinch-to-zoom in browser tabs so the app feels native, matching
+  // the sister app match-tracker (which uses maximum-scale=1.0). width and
+  // initialScale are inherited from Next.js' default viewport. userScalable is
+  // an iOS-leaning reinforcement; iOS Safari ignores it on its own but it
+  // helps on Android Chrome where maximum-scale alone can be bypassed.
+  maximumScale: 1,
+  userScalable: false,
   // Required for env(safe-area-inset-*) to be non-zero on iOS notch/home-
   // indicator devices; MobileShell's BottomNav relies on it to extend its
   // background into the home indicator area.


### PR DESCRIPTION
## Summary
モバイルでの画面ピンチズーム、およびテキスト入力フォーカス時の iOS 自動ズームを抑制する。姉妹アプリ match-tracker（`maximum-scale=1.0`）と同等の挙動にする。

`apps/web/src/app/layout.tsx` の `viewport` export に2フィールド追加（ルート layout なので全ルートに一律で効く）:

- `maximumScale: 1` … ピンチ拡大を抑制（本体）。ベース font-size が 15px(<16px) のため iOS はテキスト入力フォーカス時に自動ズームするが、ズーム上限 1x により**この自動ズームも no-op** になる
- `userScalable: false` … iOS Safari 単体では無視されるが、Android Chrome 側でフォーカスズーム/ピンチを止める補強

`width`/`initialScale` は Next.js のデフォルト viewport（`width=device-width, initial-scale=1`）から merge 継承されるため不記載。`viewportFit: 'cover'` は safe-area 用に維持（MobileShell の BottomNav が依存）。

### なぜ CSS の font-size:16px ガードを使わないか
入力欄を 16px に強制すれば iOS フォーカスズームを font-size 側で確実に止められるが、設計の 15px タイプスケール（`--kg-text-base: 0.9375rem`）を全画面で崩し、match-tracker とも非等価になる。`maximum-scale=1` が同じ目的を達成するため CSS は変更しない。

## 影響範囲
- ルート layout の `viewport` export のみ。ロジック・データ・API・DB への影響なし。
- 既存の `width=device-width` / `initial-scale=1` / `viewport-fit=cover` の出力は不変で、`maximum-scale=1` / `user-scalable=no` が増えるのみ。
- PWA standalone では元々ズームしにくいが、ブラウザタブで開いた場合に効くようになる。

## 既知の制約
- PC ブラウザの Ctrl+ホイール / Ctrl+= (ページズーム) は viewport の管轄外なので止まらない（要望にも含まれていないため対象外）。
- ズーム禁止はアクセシビリティ上は一般に非推奨だが、身内運営アプリ前提で許容。

## Test plan
- [x] `pnpm --filter web check-types`（tsc --noEmit）green
- [x] `pnpm --filter web lint`（next lint）warnings/errors 0
- [ ] iPhone 実機 or モバイルエミュレータで**ピンチ拡大ができない**こと
- [ ] iPhone 実機で**テキストボックス（input/textarea/select）フォーカス時にズームしない**こと
- [ ] 既存レイアウト（MobileShell の h-dvh / viewport-fit=cover 周り）に視覚的な崩れが出ていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)