### PR TITLE
fix(web): 戦績検索結果の所属会を直近大会の所属に

### DIFF
--- a/apps/web/src/lib/players/queries.test.ts
+++ b/apps/web/src/lib/players/queries.test.ts
@@ -66,8 +66,9 @@ describe('searchPlayers', () => {
     const results = await searchPlayers('山田 太郎')
     expect(results).toHaveLength(1)
     expect(results[0]!.displayName).toBe('山田太郎')
-    // player は所属を持たない（同定は姓名のみ・所属は per-大会）。
-    expect(results[0]!.affiliation).toBeNull()
+    // player 行は所属を持たない（常に null）が、検索結果は直近大会の participant
+    // スナップショットの所属を出す（戦績詳細ヘッダと一致）。
+    expect(results[0]!.affiliation).toBe('札幌')
     expect(results[0]!.participationCount).toBe(1)
   })
 
@@ -97,6 +98,41 @@ describe('searchPlayers', () => {
     const results = await searchPlayers('佐藤')
     expect(results).toHaveLength(1)
     expect(results[0]!.displayName).toBe('佐藤花子')
+  })
+
+  it('複数大会で所属が変わる場合、直近の大会（event_date 最新）の所属を返す', async () => {
+    const part = (affiliation: string | null) => ({
+      seqNo: 1,
+      name: '移籍太郎',
+      nameKana: null,
+      affiliation,
+      prefecture: null,
+      dan: null,
+      memberNo: null,
+      finalRank: null,
+      matches: [],
+    })
+    // 古い大会（札幌）→ 新しい大会（東京）→ 開催日 null の大会（どこか会）を
+    // この順で投入（= どこか会が最大 id）。直近は event_date 最新の「東京」で、
+    // 開催日 null は NULLS LAST で直近扱いしない（id 降順だけなら誤って「どこか会」を
+    // 拾ってしまうのを弾く）。同名なので materialize で同一 player に名寄せされる。
+    await seedTournament(
+      { parserVersion: '1.0.0', classes: [classWith('D級', 'D', [part('札幌')])] },
+      { name: '古い大会', eventDate: '2024-01-01' },
+    )
+    await seedTournament(
+      { parserVersion: '1.0.0', classes: [classWith('D級', 'D', [part('東京')])] },
+      { name: '新しい大会', eventDate: '2026-05-01' },
+    )
+    await seedTournament(
+      { parserVersion: '1.0.0', classes: [classWith('D級', 'D', [part('どこか会')])] },
+      { name: '日付不明大会', eventDate: null },
+    )
+
+    const results = await searchPlayers('移籍太郎')
+    expect(results).toHaveLength(1)
+    expect(results[0]!.affiliation).toBe('東京')
+    expect(results[0]!.participationCount).toBe(3)
   })
 
   it('空クエリは空配列を返す', async () => {

--- a/apps/web/src/lib/players/queries.ts
+++ b/apps/web/src/lib/players/queries.ts
@@ -3,7 +3,9 @@ import { db } from '@/lib/db'
 import {
   matches,
   players,
+  tournamentClasses,
   tournamentParticipants,
+  tournaments,
 } from '@kagetra/shared/schema'
 import { normalizePlayerName } from '@kagetra/mail-worker/result-import/normalize'
 import {
@@ -97,7 +99,19 @@ export async function searchPlayers(query: string): Promise<PlayerSearchResult[]
     .select({
       id: players.id,
       displayName: players.displayName,
-      affiliation: players.affiliation,
+      // 所属会は player 行には持たない（常に null・「人 × 大会」属性）。戦績詳細
+      // ヘッダ（participations[0].affiliation）と同じく、直近の大会（event_date
+      // 降順・NULLS LAST、同日は tournament id 降順）の participant スナップショット
+      // の所属を相関サブクエリで 1 件引く。詳細ヘッダと検索結果の所属が一致する。
+      affiliation: sql<string | null>`(
+        select tp.affiliation
+        from ${tournamentParticipants} tp
+        join ${tournamentClasses} tc on tc.id = tp.class_id
+        join ${tournaments} t on t.id = tc.tournament_id
+        where tp.player_id = ${players.id}
+        order by t.event_date desc nulls last, t.id desc
+        limit 1
+      )`,
       prefecture: players.prefecture,
       participationCount: sql<number>`count(${tournamentParticipants.id})::int`,
     })


### PR DESCRIPTION
## Summary
- 戦績検索（/players）の検索結果の所属会が常に「所属不明」になっていた問題を修正。
- 原因: 検索結果は `players.affiliation` を表示していたが、migration 0029（選手同定を姓名のみ化）以降 **`players.affiliation` は常に null**（所属は「人 × 大会」属性で participant 側の生スナップショットが正）。
- 修正: `searchPlayers` の `affiliation` を相関サブクエリ化し、**直近の大会**（`event_date` 降順・NULLS LAST、同日は tournament id 降順）の participant スナップショットの所属を引く。戦績詳細ヘッダ（`participations[0].affiliation`）・対戦相手の所属（`opponentAffiliation`）と同じ「直近大会の所属」を表示するようになり、検索結果と詳細で所属が一致する。
- DB スキーマ変更なし。フロント（players/page.tsx）は `p.affiliation` をそのまま使うため変更不要。表示行の都道府県（`p.prefecture`）は据え置き（依頼スコープ外）。

## 変更ファイル
- `apps/web/src/lib/players/queries.ts`: `searchPlayers` の affiliation を相関サブクエリ化（tournaments / tournament_classes を join）
- `apps/web/src/lib/players/queries.test.ts`: 既存テストの期待値を更新（null→直近所属）＋複数大会で所属が変わる場合に直近を返す（NULLS LAST 検証込み）テストを追加

## Test plan
- [x] `vitest run src/lib/players/queries.test.ts` 16/16 green
- [x] `check-types`（tsc --noEmit）クリーン
- [x] `lint`（next lint）クリーン
- [ ] 本番反映後、実機で選手検索→所属会が直近大会の所属で表示されることを目視

🤖 Generated with [Claude Code](https://claude.com/claude-code)