### PR TITLE
fix(senseki): 戦績詳細に各大会の所属会を復活

### DIFF
--- a/apps/web/src/app/(app)/players/[id]/SensekiTimeline.test.tsx
+++ b/apps/web/src/app/(app)/players/[id]/SensekiTimeline.test.tsx
@@ -13,6 +13,7 @@ const years: TimelineYear[] = [
         participantId: 1,
         dateLabel: '5/3',
         title: '北海道選手権A',
+        affiliation: '東京大学かるた会',
         rank: '優勝',
         rankEmphasis: true,
         matches: [
@@ -46,6 +47,7 @@ const years: TimelineYear[] = [
         participantId: 2,
         dateLabel: '9/1',
         title: '秋大会B',
+        affiliation: null,
         rank: 'ベスト8',
         rankEmphasis: false,
         matches: [],
@@ -87,6 +89,20 @@ describe('SensekiTimeline', () => {
     screen.getByText('×3')
   })
 
+  it('展開後、各大会に選手自身のその大会での所属会を表示する', () => {
+    render(<SensekiTimeline years={years} playerId={5} />)
+    fireEvent.click(screen.getByText('2026年'))
+    screen.getByText('東京大学かるた会')
+  })
+
+  it('所属会が null の大会は所属行を出さない', () => {
+    render(<SensekiTimeline years={years} playerId={5} />)
+    fireEvent.click(screen.getByText('2025年'))
+    // 秋大会B（affiliation: null）は所属行なし。大会名は出るが所属は無い。
+    screen.getByText('秋大会B')
+    expect(screen.queryByText('東京大学かるた会')).toBeNull()
+  })
+
   it('別選手データに差し替えると展開状態がリセットされる（同名年も畳む）', () => {
     const { rerender } = render(<SensekiTimeline years={years} playerId={5} />)
     fireEvent.click(screen.getByText('2026年'))
@@ -98,7 +114,7 @@ describe('SensekiTimeline', () => {
         wins: 1,
         losses: 0,
         tournaments: [
-          { participantId: 9, dateLabel: '3/3', title: '別大会X', rank: '優勝', rankEmphasis: true, matches: [] },
+          { participantId: 9, dateLabel: '3/3', title: '別大会X', affiliation: '別の会', rank: '優勝', rankEmphasis: true, matches: [] },
         ],
       },
       {
@@ -107,7 +123,7 @@ describe('SensekiTimeline', () => {
         wins: 0,
         losses: 1,
         tournaments: [
-          { participantId: 8, dateLabel: '4/4', title: '旧大会Y', rank: 'ベスト8', rankEmphasis: false, matches: [] },
+          { participantId: 8, dateLabel: '4/4', title: '旧大会Y', affiliation: null, rank: 'ベスト8', rankEmphasis: false, matches: [] },
         ],
       },
     ]

--- a/apps/web/src/app/(app)/players/[id]/SensekiTimeline.tsx
+++ b/apps/web/src/app/(app)/players/[id]/SensekiTimeline.tsx
@@ -27,6 +27,8 @@ export interface TimelineTournament {
   dateLabel: string
   /** 大会名（「第N回」除去・級letter後置, 例「北海道選手権A」）。 */
   title: string
+  /** その大会での選手自身の所属会（participant スナップショット）。大会名の下に表示。無ければ null。 */
+  affiliation: string | null
   rank: string | null
   /** 優勝・準優勝（bracket<=2）は藍で強調。 */
   rankEmphasis: boolean
@@ -110,9 +112,16 @@ export function SensekiTimeline({
                             {t.dateLabel}
                           </span>
                         )}
-                        <span className="truncate font-display text-[15px] font-medium text-ink">
-                          {t.title}
-                        </span>
+                        <div className="min-w-0">
+                          <span className="block truncate font-display text-[15px] font-medium text-ink">
+                            {t.title}
+                          </span>
+                          {t.affiliation && (
+                            <span className="block truncate text-[11px] text-ink-muted">
+                              {t.affiliation}
+                            </span>
+                          )}
+                        </div>
                       </div>
                       {t.rank && (
                         <span

--- a/apps/web/src/app/(app)/players/[id]/page.tsx
+++ b/apps/web/src/app/(app)/players/[id]/page.tsx
@@ -94,6 +94,7 @@ export default async function PlayerDetailPage({
       participantId: part.participantId,
       dateLabel,
       title: `${stripKai(part.tournamentName)}${part.grade ?? ''}`,
+      affiliation: part.affiliation,
       rank: part.rank,
       rankEmphasis:
         part.rankBracket != null ? part.rankBracket <= 2 : /優勝/.test(part.rank ?? ''),


### PR DESCRIPTION
## Summary
- 戦績詳細タイムラインの各大会行に、その大会での選手自身の所属会を復活（大会名の下に薄字1行・null は非表示）
- エディトリアル改修(PR #183)で `TimelineTournament` が `affiliation` を持たなくなり表示が落ちていた回帰。データ層 `getPlayerRecord` は今も大会ごとの所属を返しており、UI 表示のみの修正
- 疑われた PR #194（検索結果の所属会）は無関係（`searchPlayers` のみ）

## Bug
Fixes #197

## Changes
- `SensekiTimeline.tsx`: `TimelineTournament` に `affiliation: string | null` を追加し大会行に表示
- `page.tsx`: マッピングで `part.affiliation` を渡す
- `SensekiTimeline.test.tsx`: フィクスチャ更新＋「自分の所属表示」「null 非表示」テスト追加

## Test plan
- [x] `tsc --noEmit`（web）パス
- [x] コンポーネントテスト 7件パス（既存5＋新規2）
- [ ] スマホ実機で各大会の所属会が出ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)