### PR TITLE
feat(stats): 「統計」タブ改称＋4セクションシェル＋ルート scaffold（senseki-stats PR-2 ナビ）

### DIFF
--- a/apps/web/e2e/senseki-stats-nav.spec.ts
+++ b/apps/web/e2e/senseki-stats-nav.spec.ts
@@ -1,0 +1,110 @@
+import { expect, test } from '@playwright/test'
+import {
+  AUTHJS_SESSION_COOKIE,
+  seedMemberSession,
+} from '../src/test-utils/playwright-auth'
+import { truncateAll } from '../src/test-utils/db'
+
+async function addSessionCookie(
+  context: import('@playwright/test').BrowserContext,
+  token: string,
+) {
+  await context.addCookies([
+    {
+      name: AUTHJS_SESSION_COOKIE,
+      value: token,
+      domain: 'localhost',
+      path: '/',
+      httpOnly: true,
+      sameSite: 'Lax',
+    },
+  ])
+}
+
+// senseki-stats PR-2（ナビ）：「統計」タブ配下の 4 セクション横断ナビ（SectionTabs）
+// で全セクションへ到達でき、既存の選手検索が非退行であることを担保する。
+test.describe('統計タブ 4セクションナビ（SectionTabs）', () => {
+  test.beforeEach(async () => {
+    await truncateAll()
+  })
+
+  test('一般会員: 4セクションを行き来でき、選手検索は非退行', async ({
+    browser,
+  }) => {
+    const member = await seedMemberSession({ name: 'Member User' })
+    const context = await browser.newContext()
+    await addSessionCookie(context, member.sessionToken)
+    const page = await context.newPage()
+
+    // 着地点＝選手検索（/players）。SectionTabs が出て 選手検索 が active。
+    await page.goto('/players')
+    const segA = page.getByRole('navigation', { name: '統計セクション' })
+    await expect(segA).toBeVisible()
+    await expect(segA.getByRole('link', { name: '選手検索' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    )
+    // 既存の検索フォーム（非退行）。
+    await expect(page.getByRole('searchbox', { name: '選手名' })).toBeVisible()
+
+    // ボトムナビの「統計」タブがアクティブ（/players 配下）。SectionTabs には
+    // ちょうど「統計」というラベルの項目が無い（大会統計など）ので exact 一致で
+    // ボトムナビのリンクだけを掴める。
+    const statsTab = page.getByRole('link', { name: '統計', exact: true })
+    await expect(statsTab).toHaveClass(/border-brand/)
+
+    // → 大会結果（/tournaments）
+    await segA.getByRole('link', { name: '大会結果', exact: true }).click()
+    await expect(page).toHaveURL(/\/tournaments$/)
+    await expect(
+      page.getByRole('heading', { name: '大会結果', exact: true }),
+    ).toBeVisible()
+
+    // → 選手ランキング（/players/ranking）
+    await segA.getByRole('link', { name: 'ランキング' }).click()
+    await expect(page).toHaveURL(/\/players\/ranking$/)
+    await expect(
+      page.getByRole('heading', { name: '選手ランキング' }),
+    ).toBeVisible()
+    await expect(
+      segA.getByRole('link', { name: 'ランキング' }),
+    ).toHaveAttribute('aria-current', 'page')
+
+    // → 大会統計（/tournaments/stats）
+    await segA.getByRole('link', { name: '大会統計' }).click()
+    await expect(page).toHaveURL(/\/tournaments\/stats$/)
+    await expect(
+      page.getByRole('heading', { name: '大会統計', exact: true }),
+    ).toBeVisible()
+
+    // → 選手検索へ戻れる（既存検索の非退行を再確認）
+    await segA.getByRole('link', { name: '選手検索' }).click()
+    await expect(page).toHaveURL(/\/players$/)
+    await expect(page.getByRole('searchbox', { name: '選手名' })).toBeVisible()
+
+    await context.close()
+  })
+
+  test('大会詳細（プッシュ表示）は SectionTabs を出さず戻れる', async ({
+    browser,
+  }) => {
+    const member = await seedMemberSession({ name: 'Member User' })
+    const context = await browser.newContext()
+    await addSessionCookie(context, member.sessionToken)
+    const page = await context.newPage()
+
+    await page.goto('/tournaments/123')
+    // プッシュ画面には横断ナビ（SectionTabs）を出さない（requirements §3.1）。
+    await expect(
+      page.getByRole('navigation', { name: '統計セクション' }),
+    ).toHaveCount(0)
+    // 戻る導線で大会結果へ。
+    await page.getByRole('link', { name: '大会結果へ戻る' }).click()
+    await expect(page).toHaveURL(/\/tournaments$/)
+    await expect(
+      page.getByRole('navigation', { name: '統計セクション' }),
+    ).toBeVisible()
+
+    await context.close()
+  })
+})

--- a/apps/web/src/app/(app)/players/page.tsx
+++ b/apps/web/src/app/(app)/players/page.tsx
@@ -2,16 +2,18 @@ import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { auth } from '@/auth'
 import { Card } from '@/components/ui'
+import { SectionTabs } from '@/components/stats/section-tabs'
 import { searchPlayers } from '@/lib/players/queries'
 import { PlayerSearchForm } from './components/PlayerSearchForm'
 
 export const dynamic = 'force-dynamic'
 
 /**
- * /players — 選手戦績の検索（全ログインユーザー）。
+ * /players — 選手戦績の検索（全ログインユーザー）＝「統計」タブの① 選手検索。
  *
- * 選手名で部分一致検索 → 候補一覧 → タップで戦績詳細へ。tournament-results
- * Task5。検索語は ?q= に載せてサーバー側で normalizePlayerName 正規化検索する。
+ * 選手名で部分一致検索 → 候補一覧 → タップで戦績詳細へ。senseki-stats PR-2 で
+ * `SectionTabs`（4 セクション横断ナビ）配下に収めた（検索ロジックは不変）。
+ * 検索語は ?q= に載せてサーバー側で normalizePlayerName 正規化検索する。
  */
 export default async function PlayersSearchPage({
   searchParams,
@@ -26,44 +28,49 @@ export default async function PlayersSearchPage({
   const results = query ? await searchPlayers(query) : []
 
   return (
-    <div className="flex flex-col gap-4">
-      <h1 className="font-display text-xl font-bold text-ink">選手戦績</h1>
+    <div>
+      <SectionTabs />
+      <div className="flex flex-col gap-4 p-4">
+        <PlayerSearchForm initialQuery={query} />
 
-      <PlayerSearchForm initialQuery={query} />
-
-      {query === '' ? (
-        <Card>
-          <p className="py-6 text-center text-sm text-ink-meta">
-            選手名を入力して検索してください。
-          </p>
-        </Card>
-      ) : results.length === 0 ? (
-        <Card>
-          <p className="py-6 text-center text-sm text-ink-meta">
-            「{query}」に一致する選手は見つかりませんでした。
-          </p>
-        </Card>
-      ) : (
-        <div className="flex flex-col gap-2">
-          {results.map((p) => (
-            <Link key={p.id} href={`/players/${p.id}`} className="block">
-              <Card>
-                <div className="flex items-center justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="truncate font-medium text-ink">{p.displayName}</div>
-                    <div className="mt-0.5 truncate text-xs text-ink-meta">
-                      {[p.affiliation, p.prefecture].filter(Boolean).join(' / ') || '所属不明'}
+        {query === '' ? (
+          <Card>
+            <p className="py-6 text-center text-sm text-ink-meta">
+              選手名を入力して検索してください。
+            </p>
+          </Card>
+        ) : results.length === 0 ? (
+          <Card>
+            <p className="py-6 text-center text-sm text-ink-meta">
+              「{query}」に一致する選手は見つかりませんでした。
+            </p>
+          </Card>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {results.map((p) => (
+              <Link key={p.id} href={`/players/${p.id}`} className="block">
+                <Card>
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="truncate font-medium text-ink">
+                        {p.displayName}
+                      </div>
+                      <div className="mt-0.5 truncate text-xs text-ink-meta">
+                        {[p.affiliation, p.prefecture]
+                          .filter(Boolean)
+                          .join(' / ') || '所属不明'}
+                      </div>
                     </div>
+                    <span className="shrink-0 text-xs text-ink-meta">
+                      {p.participationCount} 大会
+                    </span>
                   </div>
-                  <span className="shrink-0 text-xs text-ink-meta">
-                    {p.participationCount} 大会
-                  </span>
-                </div>
-              </Card>
-            </Link>
-          ))}
-        </div>
-      )}
+                </Card>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/apps/web/src/app/(app)/players/ranking/page.tsx
+++ b/apps/web/src/app/(app)/players/ranking/page.tsx
@@ -1,0 +1,25 @@
+import { SectionTabs } from '@/components/stats/section-tabs'
+import { Card } from '@/components/ui'
+
+/**
+ * /players/ranking — ③ 選手ランキング（統計）。senseki-stats PR-3 で実装予定。
+ * PR-2（ナビ）では 4 セクションシェル（SectionTabs）配下のプレースホルダ scaffold。
+ * 静的セグメント `ranking` は動的 `/players/[id]` より優先されるため衝突しない。
+ */
+export default function PlayerRankingPage() {
+  return (
+    <div>
+      <SectionTabs />
+      <div className="flex flex-col gap-4 p-4">
+        <h1 className="font-display text-xl font-bold text-ink">
+          選手ランキング
+        </h1>
+        <Card>
+          <p className="py-10 text-center text-sm text-ink-meta">
+            選手ランキングは準備中です（PR-3 で実装）。
+          </p>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/(app)/tournaments/[id]/page.tsx
+++ b/apps/web/src/app/(app)/tournaments/[id]/page.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link'
+import { Card } from '@/components/ui'
+
+/**
+ * /tournaments/[id] — 大会詳細（入賞者タブ＋級クロス表）。プッシュ表示のため
+ * SectionTabs は出さず戻る導線のみ（requirements §3.1）。senseki-stats PR-5 で実装予定。
+ */
+export default async function TournamentDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <Link href="/tournaments" className="text-sm text-brand">
+        ‹ 大会結果へ戻る
+      </Link>
+      <h1 className="font-display text-xl font-bold text-ink">大会詳細</h1>
+      <Card>
+        <p className="py-10 text-center text-sm text-ink-meta">
+          大会 #{id} の詳細（入賞者＋級クロス表）は準備中です（PR-5 で実装）。
+        </p>
+      </Card>
+    </div>
+  )
+}

--- a/apps/web/src/app/(app)/tournaments/page.tsx
+++ b/apps/web/src/app/(app)/tournaments/page.tsx
@@ -1,0 +1,24 @@
+import { SectionTabs } from '@/components/stats/section-tabs'
+import { Card } from '@/components/ui'
+
+/**
+ * /tournaments — ② 大会結果（年別ビュー・閲覧）。senseki-stats PR-5 で実装予定。
+ * PR-2（ナビ）では 4 セクションシェル配下のプレースホルダ scaffold。
+ * `/tournaments/series`（大会別トグル）と `/tournaments/stats`（大会統計）は
+ * 静的セグメントで、動的 `/tournaments/[id]`（大会詳細）より優先される。
+ */
+export default function TournamentsPage() {
+  return (
+    <div>
+      <SectionTabs />
+      <div className="flex flex-col gap-4 p-4">
+        <h1 className="font-display text-xl font-bold text-ink">大会結果</h1>
+        <Card>
+          <p className="py-10 text-center text-sm text-ink-meta">
+            大会結果一覧（年別／大会別）は準備中です（PR-5 で実装）。
+          </p>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/(app)/tournaments/series/[id]/page.tsx
+++ b/apps/web/src/app/(app)/tournaments/series/[id]/page.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link'
+import { Card } from '@/components/ui'
+
+/**
+ * /tournaments/series/[id] — シリーズ詳細（回次一覧＋参加者数推移）。プッシュ表示
+ * のため SectionTabs は出さず戻る導線のみ。senseki-stats PR-5 で実装予定。
+ */
+export default async function SeriesDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <Link href="/tournaments/series" className="text-sm text-brand">
+        ‹ 大会別一覧へ戻る
+      </Link>
+      <h1 className="font-display text-xl font-bold text-ink">シリーズ詳細</h1>
+      <Card>
+        <p className="py-10 text-center text-sm text-ink-meta">
+          シリーズ #{id} の詳細（回次一覧＋参加者数推移）は準備中です（PR-5
+          で実装）。
+        </p>
+      </Card>
+    </div>
+  )
+}

--- a/apps/web/src/app/(app)/tournaments/series/page.tsx
+++ b/apps/web/src/app/(app)/tournaments/series/page.tsx
@@ -1,0 +1,25 @@
+import { SectionTabs } from '@/components/stats/section-tabs'
+import { Card } from '@/components/ui'
+
+/**
+ * /tournaments/series — ② 大会結果の「大会別ビュー」（シリーズ一覧）。
+ * 年別（`/tournaments`）とトグルで切り替わる同一セクションのトップなので
+ * SectionTabs を出す（大会結果が active）。senseki-stats PR-5 で実装予定。
+ */
+export default function TournamentSeriesListPage() {
+  return (
+    <div>
+      <SectionTabs />
+      <div className="flex flex-col gap-4 p-4">
+        <h1 className="font-display text-xl font-bold text-ink">
+          大会結果（大会別）
+        </h1>
+        <Card>
+          <p className="py-10 text-center text-sm text-ink-meta">
+            シリーズ一覧は準備中です（PR-5 で実装）。
+          </p>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/(app)/tournaments/stats/[metric]/page.tsx
+++ b/apps/web/src/app/(app)/tournaments/stats/[metric]/page.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link'
+import { Card } from '@/components/ui'
+
+/**
+ * /tournaments/stats/[metric] — 大会統計の図詳細（級別比較スモールマルチプル）。
+ * metric = score / competitors / participations。プッシュ表示のため SectionTabs は
+ * 出さず戻る導線のみ。senseki-stats PR-4 で実装予定。
+ */
+export default async function StatsDetailPage({
+  params,
+}: {
+  params: Promise<{ metric: string }>
+}) {
+  const { metric } = await params
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <Link href="/tournaments/stats" className="text-sm text-brand">
+        ‹ 大会統計へ戻る
+      </Link>
+      <h1 className="font-display text-xl font-bold text-ink">
+        級別比較（{metric}）
+      </h1>
+      <Card>
+        <p className="py-10 text-center text-sm text-ink-meta">
+          「{metric}」の級別比較は準備中です（PR-4 で実装）。
+        </p>
+      </Card>
+    </div>
+  )
+}

--- a/apps/web/src/app/(app)/tournaments/stats/page.tsx
+++ b/apps/web/src/app/(app)/tournaments/stats/page.tsx
@@ -1,0 +1,22 @@
+import { SectionTabs } from '@/components/stats/section-tabs'
+import { Card } from '@/components/ui'
+
+/**
+ * /tournaments/stats — ④ 大会統計・全体サマリー（統計）。senseki-stats PR-4 で
+ * 実装予定。PR-2（ナビ）では 4 セクションシェル配下のプレースホルダ scaffold。
+ */
+export default function TournamentStatsPage() {
+  return (
+    <div>
+      <SectionTabs />
+      <div className="flex flex-col gap-4 p-4">
+        <h1 className="font-display text-xl font-bold text-ink">大会統計</h1>
+        <Card>
+          <p className="py-10 text-center text-sm text-ink-meta">
+            大会統計（全体サマリー）は準備中です（PR-4 で実装）。
+          </p>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/layout/bottom-nav.test.tsx
+++ b/apps/web/src/components/layout/bottom-nav.test.tsx
@@ -19,8 +19,8 @@ describe('BottomNav', () => {
     expect(screen.getByText('ホーム')).toBeTruthy()
     expect(screen.getByText('イベント')).toBeTruthy()
     expect(screen.getByText('予定')).toBeTruthy()
-    // tournament-results Task5: 戦績 は全ユーザー共有タブ。
-    expect(screen.getByText('戦績')).toBeTruthy()
+    // senseki-stats PR-2: 戦績 → 統計 に改称。全ユーザー共有タブ。
+    expect(screen.getByText('統計')).toBeTruthy()
     expect(screen.getByText('会員')).toBeTruthy()
     expect(screen.getByText('メール')).toBeTruthy()
     expect(screen.getByText('Bot')).toBeTruthy()
@@ -29,28 +29,44 @@ describe('BottomNav', () => {
   // Regression: non-admins previously saw 会員 tab and were bounced to /403
   // by the admin-only page guard — breaking their bottom-nav UX. メール
   // (mail-inbox) follows the same admin-only convention.
-  it('isAdmin=false のとき 共有タブ（戦績含む）のみ表示し 会員 / メール は出さない', () => {
+  it('isAdmin=false のとき 共有タブ（統計含む）のみ表示し 会員 / メール は出さない', () => {
     render(<BottomNav isAdmin={false} />)
     expect(screen.getByText('ホーム')).toBeTruthy()
     expect(screen.getByText('イベント')).toBeTruthy()
     expect(screen.getByText('予定')).toBeTruthy()
-    // tournament-results Task5: 戦績 は会員でも見える初の専用タブ。
-    expect(screen.getByText('戦績')).toBeTruthy()
+    // senseki-stats PR-2: 統計 は会員でも見える共有タブ。
+    expect(screen.getByText('統計')).toBeTruthy()
     expect(screen.queryByText('会員')).toBeNull()
     expect(screen.queryByText('メール')).toBeNull()
   })
 
-  it('pathname=/players で 戦績 タブが active になる', () => {
+  it('pathname=/players で 統計 タブが active になる', () => {
     mockUsePathname.mockReturnValue('/players')
     render(<BottomNav isAdmin={false} />)
-    const link = screen.getByText('戦績').closest('a')
+    const link = screen.getByText('統計').closest('a')
     expect(link?.className).toContain('border-brand')
   })
 
-  it('pathname=/players/42 のような詳細パスでも 戦績 タブが active', () => {
+  it('pathname=/players/42 のような詳細パスでも 統計 タブが active', () => {
     mockUsePathname.mockReturnValue('/players/42')
     render(<BottomNav isAdmin={false} />)
-    const link = screen.getByText('戦績').closest('a')
+    const link = screen.getByText('統計').closest('a')
+    expect(link?.className).toContain('border-brand')
+  })
+
+  // senseki-stats PR-2: 統計 タブは /tournaments 配下も active 判定に含む
+  // （大会結果・大会統計セクションは /tournaments 基底）。
+  it('pathname=/tournaments で 統計 タブが active になる', () => {
+    mockUsePathname.mockReturnValue('/tournaments')
+    render(<BottomNav isAdmin={false} />)
+    const link = screen.getByText('統計').closest('a')
+    expect(link?.className).toContain('border-brand')
+  })
+
+  it('pathname=/tournaments/5 のような大会詳細でも 統計 タブが active', () => {
+    mockUsePathname.mockReturnValue('/tournaments/5')
+    render(<BottomNav isAdmin={false} />)
+    const link = screen.getByText('統計').closest('a')
     expect(link?.className).toContain('border-brand')
   })
 

--- a/apps/web/src/components/layout/bottom-nav.tsx
+++ b/apps/web/src/components/layout/bottom-nav.tsx
@@ -22,9 +22,15 @@ const TABS: readonly Tab[] = [
   { id: 'home', label: 'ホーム', href: '/dashboard', matches: ['/dashboard'] },
   { id: 'events', label: 'イベント', href: '/events', matches: ['/events'] },
   { id: 'schedule', label: '予定', href: '/schedule', matches: ['/schedule'] },
-  // tournament-results (Task5): 選手戦績の検索・閲覧。全ログインユーザー向け
-  // （会員でも見える初の専用タブ）。/players 配下を active 判定。
-  { id: 'players', label: '戦績', href: '/players', matches: ['/players'] },
+  // senseki-stats (PR-2): 戦績 → 統計 に改称。href は /players 据え置き
+  // （着地点＝選手検索）だが、配下の 4 セクション（選手検索/大会結果/ランキング/
+  // 大会統計）は /players・/tournaments の 2 基底に分かれるため両方を active 判定。
+  {
+    id: 'players',
+    label: '統計',
+    href: '/players',
+    matches: ['/players', '/tournaments'],
+  },
   {
     id: 'members',
     label: '会員',

--- a/apps/web/src/components/stats/section-tabs.test.tsx
+++ b/apps/web/src/components/stats/section-tabs.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SectionTabs } from './section-tabs'
+
+const mockUsePathname = vi.fn<() => string | null>()
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockUsePathname(),
+}))
+
+/** Returns the <a> whose visible text matches, for active-state assertions. */
+function tab(label: string): HTMLAnchorElement {
+  const el = screen.getByText(label).closest('a')
+  if (!el) throw new Error(`tab not found: ${label}`)
+  return el as HTMLAnchorElement
+}
+
+describe('SectionTabs (ss-segA)', () => {
+  beforeEach(() => {
+    mockUsePathname.mockReset()
+    mockUsePathname.mockReturnValue('/players')
+  })
+
+  it('4 セクションのタブを設計仕様の順・href で描画する', () => {
+    render(<SectionTabs />)
+    expect(tab('選手検索').getAttribute('href')).toBe('/players')
+    expect(tab('大会結果').getAttribute('href')).toBe('/tournaments')
+    expect(tab('ランキング').getAttribute('href')).toBe('/players/ranking')
+    expect(tab('大会統計').getAttribute('href')).toBe('/tournaments/stats')
+  })
+
+  it('/players で 選手検索 が active', () => {
+    mockUsePathname.mockReturnValue('/players')
+    render(<SectionTabs />)
+    expect(tab('選手検索').getAttribute('aria-current')).toBe('page')
+    expect(tab('ランキング').getAttribute('aria-current')).toBeNull()
+  })
+
+  it('/players/42 のような詳細パスでも 選手検索 が active', () => {
+    mockUsePathname.mockReturnValue('/players/42')
+    render(<SectionTabs />)
+    expect(tab('選手検索').getAttribute('aria-current')).toBe('page')
+  })
+
+  // 最長プレフィックス一致: /players/ranking は /players と /players/ranking の
+  // 両方に前方一致するが、より長い方（ランキング）が勝たなければならない。
+  it('/players/ranking では ランキング が active（選手検索は非 active）', () => {
+    mockUsePathname.mockReturnValue('/players/ranking')
+    render(<SectionTabs />)
+    expect(tab('ランキング').getAttribute('aria-current')).toBe('page')
+    expect(tab('選手検索').getAttribute('aria-current')).toBeNull()
+  })
+
+  it('/tournaments で 大会結果 が active', () => {
+    mockUsePathname.mockReturnValue('/tournaments')
+    render(<SectionTabs />)
+    expect(tab('大会結果').getAttribute('aria-current')).toBe('page')
+  })
+
+  it('/tournaments/series（大会別トグル）でも 大会結果 が active', () => {
+    mockUsePathname.mockReturnValue('/tournaments/series')
+    render(<SectionTabs />)
+    expect(tab('大会結果').getAttribute('aria-current')).toBe('page')
+    expect(tab('大会統計').getAttribute('aria-current')).toBeNull()
+  })
+
+  it('/tournaments/123 のような大会詳細でも 大会結果 が active', () => {
+    mockUsePathname.mockReturnValue('/tournaments/123')
+    render(<SectionTabs />)
+    expect(tab('大会結果').getAttribute('aria-current')).toBe('page')
+  })
+
+  // 最長プレフィックス一致: /tournaments/stats は /tournaments より長い方が勝つ。
+  it('/tournaments/stats では 大会統計 が active（大会結果は非 active）', () => {
+    mockUsePathname.mockReturnValue('/tournaments/stats')
+    render(<SectionTabs />)
+    expect(tab('大会統計').getAttribute('aria-current')).toBe('page')
+    expect(tab('大会結果').getAttribute('aria-current')).toBeNull()
+  })
+
+  it('/tournaments/stats/score（図詳細）でも 大会統計 が active', () => {
+    mockUsePathname.mockReturnValue('/tournaments/stats/score')
+    render(<SectionTabs />)
+    expect(tab('大会統計').getAttribute('aria-current')).toBe('page')
+  })
+
+  // セグメント境界一致: /tournaments-archive のような別ルートで誤点灯しない。
+  it('/players-archive では 選手検索 が active にならない', () => {
+    mockUsePathname.mockReturnValue('/players-archive')
+    render(<SectionTabs />)
+    expect(tab('選手検索').getAttribute('aria-current')).toBeNull()
+  })
+})

--- a/apps/web/src/components/stats/section-tabs.tsx
+++ b/apps/web/src/components/stats/section-tabs.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { cn } from '@/lib/utils'
+
+interface Section {
+  id: string
+  label: string
+  href: string
+}
+
+/**
+ * 「統計」タブ配下の 4 セクション（design-spec §3.0 `ss-segA`）。
+ * 順序は仕様どおり 選手検索／大会結果／ランキング／大会統計。
+ *
+ * 選手検索(`/players`) と ランキング(`/players/ranking`)、大会結果(`/tournaments`)
+ * と 大会統計(`/tournaments/stats`) は親子プレフィックス関係にあるため、active は
+ * **最長プレフィックス一致**で解決する（`activeHref` 参照）。
+ */
+const SECTIONS: readonly Section[] = [
+  { id: 'players', label: '選手検索', href: '/players' },
+  { id: 'tournaments', label: '大会結果', href: '/tournaments' },
+  { id: 'ranking', label: 'ランキング', href: '/players/ranking' },
+  { id: 'stats', label: '大会統計', href: '/tournaments/stats' },
+]
+
+/** 前方一致をセグメント境界で判定（exact もしくは `${href}/...`）。 */
+function matchesPath(pathname: string, href: string): boolean {
+  return pathname === href || pathname.startsWith(href + '/')
+}
+
+/**
+ * 現在地に一致するセクションの href を返す。複数一致する場合は
+ * **最長プレフィックス**を採用する（`/players/ranking` は `/players` にも
+ * 一致するが、より具体的な `/players/ranking`=ランキングを勝たせる）。
+ * どれにも一致しない場合は空文字。
+ */
+function activeHref(pathname: string): string {
+  let best = ''
+  for (const s of SECTIONS) {
+    if (matchesPath(pathname, s.href) && s.href.length > best.length) {
+      best = s.href
+    }
+  }
+  return best
+}
+
+/**
+ * 「統計」タブ配下の 4 セクション横断ナビ（均等 4 分割の下線タブ）。
+ * 4 セクションの**トップ**（`/players`・`/tournaments`・`/players/ranking`・
+ * `/tournaments/stats`、および大会結果の大会別トグル `/tournaments/series`）に
+ * のみ配置し、戦績詳細・大会詳細・シリーズ詳細などのプッシュ画面には出さない
+ * （requirements §3.1）。
+ *
+ * Client component（アクティブ判定に `usePathname()` を読む）。
+ */
+export function SectionTabs() {
+  const pathname = usePathname() ?? ''
+  const current = activeHref(pathname)
+  return (
+    <nav
+      aria-label="統計セクション"
+      className="flex items-stretch border-b border-border bg-surface"
+    >
+      {SECTIONS.map((s) => {
+        const active = s.href === current
+        return (
+          <Link
+            key={s.id}
+            href={s.href}
+            aria-current={active ? 'page' : undefined}
+            className="flex flex-1 items-center justify-center py-2.5 text-[13px]"
+          >
+            <span
+              className={cn(
+                'inline-block rounded-[2px] border-b-[2.5px] pb-1 transition-colors',
+                active
+                  ? 'border-brand font-medium text-brand'
+                  : 'border-transparent text-ink-meta',
+              )}
+            >
+              {s.label}
+            </span>
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/docs/features/senseki-stats/implementation-plan.md
+++ b/docs/features/senseki-stats/implementation-plan.md
@@ -53,7 +53,7 @@ status: completed
   読み戻しで優勝/入賞数が妥当。**本番は投入待ち（worklog に残 DoD 明記）**。
 
 ### タスク4: タブ改称＋4セクションシェル＋ルート scaffold（PR-2 ナビ）
-- [ ] 完了
+- [x] 完了
 - **概要:** BottomNav「戦績」→「統計」（href=`/players`・active 判定に `/tournaments` 追加）。統計配下の
   **均等4分割の下線タブ**シェル（選手検索/大会結果/ランキング/大会統計）を共通コンポーネント化。新規ルートの
   空 scaffold（プレースホルダ）を作り、既存 `/players` 検索をシェル配下に収める。design-spec §3.0。


### PR DESCRIPTION
## Summary
senseki-stats **PR-2（ナビ再構成）**。BottomNav「戦績」を「統計」に改称し、配下を 4 セクション（選手検索／大会結果／ランキング／大会統計）へ再編する土台を作る。UI 中身は最小 scaffold（PR-3〜5 で実装）。親 Issue #208 / 子 #212。

- **BottomNav**: 「戦績」→「統計」に改称。href は `/players` 据え置き、active 判定に `/tournaments` を追加（大会結果・大会統計は `/tournaments` 基底のため）。
- **`SectionTabs`（新規・`components/stats/section-tabs.tsx`）**: design-spec §3.0 の `ss-segA` 相当。均等4分割の下線タブ。active は **最長プレフィックス一致**で解決し、`/players/ranking`→ランキング、`/tournaments/stats`→大会統計が親タブより優先して点灯する（単純 startsWith だと親タブが誤点灯するため）。
- **`/players` 収納**: 既存の選手検索を SectionTabs 配下に収める（**検索ロジックは不変**・冗長な見出しを削除）。
- **ルート scaffold（7本）**: セクショントップ（`players/ranking`・`tournaments`・`tournaments/series`・`tournaments/stats`）は SectionTabs＋プレースホルダ、詳細プッシュ（`tournaments/[id]`・`tournaments/series/[id]`・`tournaments/stats/[metric]`）は戻る導線＋プレースホルダ（横断ナビは出さない・requirements §3.1）。
- 静的セグメント（ranking/series/stats）は Next.js の優先順位で動的 `[id]` に勝つため衝突しない。

## 設計メモ
- SectionTabs はシェル layout ではなく **各セクショントップ page で個別 render**。「4 セクションのトップにのみ表示・詳細プッシュには出さない」（§3.1）を、server component の layout で pathname 判定するより per-page opt-in で表現する方が確実。
- `/tournaments/series`（大会別トグル）も大会結果セクションのトップなので SectionTabs を出す（大会結果が active）。

## Test plan
- section-tabs.test.tsx（10）: 4タブの href・順序、各パスの active（最長プレフィックス一致・セグメント境界）
- bottom-nav.test.tsx（14）: 統計改称・`/players`＋`/tournaments` の active
- e2e/senseki-stats-nav.spec.ts: 4セクション到達＋既存検索の非退行＋詳細プッシュで segA 非表示・戻る導線
- 型チェック green ・ vitest 24 tests green ・ lint clean
- [ ] 本番実機で 4 セクション導線を目視（ship 後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)