### PR TITLE
feat(stats): 選手ランキング（PR-3 senseki-stats）

### DIFF
--- a/apps/web/e2e/senseki-stats-nav.spec.ts
+++ b/apps/web/e2e/senseki-stats-nav.spec.ts
@@ -63,9 +63,8 @@ test.describe('統計タブ 4セクションナビ（SectionTabs）', () => {
     // → 選手ランキング（/players/ranking）
     await segA.getByRole('link', { name: 'ランキング' }).click()
     await expect(page).toHaveURL(/\/players\/ranking$/)
-    await expect(
-      page.getByRole('heading', { name: '選手ランキング' }),
-    ).toBeVisible()
+    // PR-3 で本実装：指標チップ（tablist）が出る（旧 scaffold の h1 は撤去）。
+    await expect(page.getByRole('tablist', { name: '指標' })).toBeVisible()
     await expect(
       segA.getByRole('link', { name: 'ランキング' }),
     ).toHaveAttribute('aria-current', 'page')

--- a/apps/web/src/app/(app)/players/ranking/RankingFilterBar.test.tsx
+++ b/apps/web/src/app/(app)/players/ranking/RankingFilterBar.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { RankingFilterBar } from './RankingFilterBar'
+
+const push = vi.fn()
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push }) }))
+
+const years = [2026, 2025, 2024, 2023, 2022, 2021, 2020, 2015]
+
+beforeEach(() => push.mockReset())
+
+describe('RankingFilterBar — サマリー表示', () => {
+  it('フィルタ無しは「全期間 / 全級」', () => {
+    render(<RankingFilterBar metric="participations" filter={{}} years={years} />)
+    expect(screen.getByText('全期間')).toBeTruthy()
+    expect(screen.getByText('全級')).toBeTruthy()
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('期間・級を反映したサマリー', () => {
+    render(
+      <RankingFilterBar
+        metric="wins"
+        filter={{ yearFrom: 2015, yearTo: 2020, grades: ['A', 'B'] }}
+        years={years}
+      />,
+    )
+    expect(screen.getByText('2015〜2020')).toBeTruthy()
+    expect(screen.getByText('A・B')).toBeTruthy()
+  })
+})
+
+describe('RankingFilterBar — シート操作', () => {
+  it('絞り込みでシートを開き、期間＋級を適用すると指標を保って遷移する', () => {
+    render(<RankingFilterBar metric="wins" filter={{}} years={years} />)
+    fireEvent.click(screen.getByRole('button', { name: '絞り込み' }))
+    expect(screen.getByRole('dialog', { name: '絞り込み' })).toBeTruthy()
+
+    fireEvent.change(screen.getByLabelText('開始年'), { target: { value: '2020' } })
+    fireEvent.change(screen.getByLabelText('終了年'), { target: { value: '2026' } })
+    fireEvent.click(screen.getByRole('button', { name: 'C' }))
+    fireEvent.click(screen.getByRole('button', { name: '適用' }))
+
+    expect(push).toHaveBeenCalledWith(
+      '/players/ranking?metric=wins&yearFrom=2020&yearTo=2026&grades=C',
+    )
+    // 適用でシートは閉じる
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('クリアはフィルタを外した URL へ遷移（指標は保持）', () => {
+    render(
+      <RankingFilterBar metric="nyusho" filter={{ yearFrom: 2015, grades: ['A'] }} years={years} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: '絞り込み' }))
+    fireEvent.click(screen.getByRole('button', { name: 'クリア' }))
+    expect(push).toHaveBeenCalledWith('/players/ranking?metric=nyusho')
+  })
+
+  it('× で閉じると遷移しない', () => {
+    render(<RankingFilterBar metric="wins" filter={{}} years={years} />)
+    fireEvent.click(screen.getByRole('button', { name: '絞り込み' }))
+    fireEvent.click(screen.getByRole('button', { name: '閉じる' }))
+    expect(screen.queryByRole('dialog')).toBeNull()
+    expect(push).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/app/(app)/players/ranking/RankingFilterBar.tsx
+++ b/apps/web/src/app/(app)/players/ranking/RankingFilterBar.tsx
@@ -1,0 +1,214 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import type { RankingMetric } from '@/lib/stats/ranking'
+import type { Grade, StatsFilter } from '@/lib/stats/types'
+import { cn } from '@/lib/utils'
+import { buildRankingHref } from './metrics'
+
+const GRADES: readonly Grade[] = ['A', 'B', 'C', 'D', 'E']
+
+function periodLabel(filter: StatsFilter): string {
+  const { yearFrom, yearTo } = filter
+  if (yearFrom != null && yearTo != null) {
+    return yearFrom === yearTo ? `${yearFrom}` : `${yearFrom}〜${yearTo}`
+  }
+  if (yearFrom != null) return `${yearFrom}〜`
+  if (yearTo != null) return `〜${yearTo}`
+  return '全期間'
+}
+
+function gradeLabel(filter: StatsFilter): string {
+  return filter.grades && filter.grades.length > 0 ? filter.grades.join('・') : '全級'
+}
+
+/**
+ * 1行フィルタ（design-spec §3.1.2）：現在の期間・級のサマリーを出し、右端の
+ * 「絞り込み」でボトムシートを開く。期間（年 from–to）と級（A–E 複数）を選んで
+ * 「適用」すると、指標を保ったまま `?yearFrom=...&grades=...` へ遷移する。
+ *
+ * シート開閉と下書き（draft）状態のみを持つクライアントコンポーネント。適用/クリアは
+ * URL 遷移（サーバー再集計）に委ねる＝アプリ状態の単一ソースは searchParams。
+ */
+export function RankingFilterBar({
+  metric,
+  filter,
+  years,
+}: {
+  metric: RankingMetric
+  filter: StatsFilter
+  /** 期間セレクトの候補（降順・収録開始〜当年）。 */
+  years: number[]
+}) {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [draftFrom, setDraftFrom] = useState<number | undefined>(filter.yearFrom)
+  const [draftTo, setDraftTo] = useState<number | undefined>(filter.yearTo)
+  const [draftGrades, setDraftGrades] = useState<Grade[]>(filter.grades ?? [])
+
+  // シートを開くたびに現在のフィルタで下書きを同期（前回のキャンセル分を破棄）。
+  useEffect(() => {
+    if (open) {
+      setDraftFrom(filter.yearFrom)
+      setDraftTo(filter.yearTo)
+      setDraftGrades(filter.grades ?? [])
+    }
+  }, [open, filter.yearFrom, filter.yearTo, filter.grades])
+
+  useEffect(() => {
+    if (!open) return
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [open])
+
+  const toggleGrade = (g: Grade) =>
+    setDraftGrades((prev) =>
+      prev.includes(g) ? prev.filter((x) => x !== g) : [...prev, g],
+    )
+
+  const apply = () => {
+    const next: StatsFilter = {}
+    if (draftFrom != null) next.yearFrom = draftFrom
+    if (draftTo != null) next.yearTo = draftTo
+    if (draftGrades.length > 0) next.grades = draftGrades
+    setOpen(false)
+    router.push(buildRankingHref(metric, next))
+  }
+
+  const clear = () => {
+    setOpen(false)
+    router.push(buildRankingHref(metric, {}))
+  }
+
+  return (
+    <>
+      <div className="flex items-center gap-3 text-[13px] text-ink-meta">
+        <span>
+          期間 <span className="text-ink">{periodLabel(filter)}</span>
+        </span>
+        <span>
+          級 <span className="text-ink">{gradeLabel(filter)}</span>
+        </span>
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          aria-haspopup="dialog"
+          aria-expanded={open}
+          className="ml-auto rounded-full border border-border px-3 py-1 font-medium text-brand hover:bg-brand-bg"
+        >
+          絞り込み
+        </button>
+      </div>
+
+      {open ? (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="絞り込み"
+          className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 sm:items-center"
+          onClick={() => setOpen(false)}
+        >
+          <div
+            className="flex w-full flex-col gap-4 rounded-t-2xl bg-surface p-4 pb-[calc(1rem_+_env(safe-area-inset-bottom))] sm:max-w-md sm:rounded-2xl sm:pb-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <header className="flex items-center justify-between">
+              <h2 className="text-base font-semibold text-ink">絞り込み</h2>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                aria-label="閉じる"
+                className="text-xl leading-none text-ink-meta hover:text-ink"
+              >
+                ×
+              </button>
+            </header>
+
+            <section className="flex flex-col gap-2">
+              <h3 className="text-xs font-medium text-ink-meta">期間（年）</h3>
+              <div className="flex items-center gap-2">
+                <select
+                  aria-label="開始年"
+                  value={draftFrom ?? ''}
+                  onChange={(e) =>
+                    setDraftFrom(e.target.value ? Number(e.target.value) : undefined)
+                  }
+                  className="min-w-0 flex-1 rounded border border-border bg-surface p-2 text-sm text-ink"
+                >
+                  <option value="">指定なし</option>
+                  {years.map((y) => (
+                    <option key={y} value={y}>
+                      {y}
+                    </option>
+                  ))}
+                </select>
+                <span className="text-ink-meta">〜</span>
+                <select
+                  aria-label="終了年"
+                  value={draftTo ?? ''}
+                  onChange={(e) =>
+                    setDraftTo(e.target.value ? Number(e.target.value) : undefined)
+                  }
+                  className="min-w-0 flex-1 rounded border border-border bg-surface p-2 text-sm text-ink"
+                >
+                  <option value="">指定なし</option>
+                  {years.map((y) => (
+                    <option key={y} value={y}>
+                      {y}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </section>
+
+            <section className="flex flex-col gap-2">
+              <h3 className="text-xs font-medium text-ink-meta">級</h3>
+              <div className="flex gap-2">
+                {GRADES.map((g) => {
+                  const on = draftGrades.includes(g)
+                  return (
+                    <button
+                      key={g}
+                      type="button"
+                      onClick={() => toggleGrade(g)}
+                      aria-pressed={on}
+                      className={cn(
+                        'flex-1 rounded-lg border py-2 text-sm font-medium transition-colors',
+                        on
+                          ? 'border-brand bg-brand text-white'
+                          : 'border-border bg-surface text-ink-meta hover:bg-surface-alt',
+                      )}
+                    >
+                      {g}
+                    </button>
+                  )
+                })}
+              </div>
+            </section>
+
+            <div className="mt-1 flex items-center gap-2">
+              <button
+                type="button"
+                onClick={clear}
+                className="rounded-lg px-4 py-2 text-sm font-medium text-ink-meta hover:bg-surface-alt"
+              >
+                クリア
+              </button>
+              <button
+                type="button"
+                onClick={apply}
+                className="ml-auto rounded-lg bg-brand px-5 py-2 text-sm font-semibold text-white hover:bg-brand-hover"
+              >
+                適用
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/apps/web/src/app/(app)/players/ranking/RankingList.test.tsx
+++ b/apps/web/src/app/(app)/players/ranking/RankingList.test.tsx
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import type { RankingRow } from '@/lib/stats/ranking'
+import { RankingList } from './RankingList'
+import { loadMoreRanking } from './actions'
+
+vi.mock('./actions', () => ({ loadMoreRanking: vi.fn() }))
+const loadMoreMock = vi.mocked(loadMoreRanking)
+
+beforeEach(() => loadMoreMock.mockReset())
+
+const row = (over: Partial<RankingRow> & { rank: number; playerId: number }): RankingRow => ({
+  displayName: `選手${over.playerId}`,
+  affiliation: null,
+  value: 1,
+  sub: null,
+  ...over,
+})
+
+describe('RankingList — 行描画', () => {
+  it('順位・氏名・所属・指標値＋単位を出す（行タップ→戦績詳細）', () => {
+    render(
+      <RankingList
+        initialRows={[
+          row({ rank: 1, playerId: 10, displayName: '一位太郎', affiliation: '札幌', value: 12 }),
+          row({ rank: 2, playerId: 20, displayName: '二位花子', value: 8 }),
+        ]}
+        total={2}
+        metric="wins"
+        filter={{}}
+      />,
+    )
+    expect(screen.getByText('一位太郎')).toBeTruthy()
+    expect(screen.getByText('札幌')).toBeTruthy()
+    // 所属 null は「所属不明」
+    expect(screen.getByText('所属不明')).toBeTruthy()
+    // 値＋単位（勝利＝勝）
+    expect(screen.getByText('12')).toBeTruthy()
+    expect(screen.getAllByText('勝').length).toBeGreaterThan(0)
+    // 行は /players/{id} へのリンク
+    const link = screen.getByText('一位太郎').closest('a')
+    expect(link?.getAttribute('href')).toBe('/players/10')
+  })
+
+  it('勝率は小数第1位＋副次（N戦）を出す', () => {
+    render(
+      <RankingList
+        initialRows={[row({ rank: 1, playerId: 1, value: 66.7, sub: 30 })]}
+        total={1}
+        metric="winRate"
+        filter={{}}
+      />,
+    )
+    expect(screen.getByText('66.7')).toBeTruthy()
+    expect(screen.getByText('%')).toBeTruthy()
+    expect(screen.getByText('30戦')).toBeTruthy()
+  })
+
+  it('長名は truncate（省略）クラスを持つ', () => {
+    render(
+      <RankingList
+        initialRows={[row({ rank: 1, playerId: 1, displayName: 'とても長い選手名'.repeat(4) })]}
+        total={1}
+        metric="wins"
+        filter={{}}
+      />,
+    )
+    const nameEl = screen.getByText('とても長い選手名'.repeat(4))
+    expect(nameEl.className).toContain('truncate')
+  })
+})
+
+describe('RankingList — 空 / もっと見る', () => {
+  it('該当0件は空状態文言（もっと見る無し）', () => {
+    render(<RankingList initialRows={[]} total={0} metric="championships" filter={{}} />)
+    expect(screen.getByText('該当する選手がいません。')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /もっと見る/ })).toBeNull()
+  })
+
+  it('total>表示数 なら もっと見る、押すと offset=表示数 で追記', async () => {
+    loadMoreMock.mockResolvedValue([row({ rank: 3, playerId: 30, displayName: '三位次郎', value: 5 })])
+    render(
+      <RankingList
+        initialRows={[
+          row({ rank: 1, playerId: 10, value: 12 }),
+          row({ rank: 2, playerId: 20, value: 8 }),
+        ]}
+        total={3}
+        metric="wins"
+        filter={{ grades: ['A'] }}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'もっと見る' }))
+    // offset=既存行数(2)・metric/filter を引き継いで呼ぶ
+    expect(loadMoreMock).toHaveBeenCalledWith('wins', { grades: ['A'] }, 2)
+
+    await waitFor(() => expect(screen.getByText('三位次郎')).toBeTruthy())
+    // 全件（3）表示に達したら もっと見る は消える
+    expect(screen.queryByRole('button', { name: /もっと見る/ })).toBeNull()
+  })
+
+  it('表示数が total 未満のままなら もっと見る が残る', async () => {
+    loadMoreMock.mockResolvedValue([row({ rank: 3, playerId: 30, value: 5 })])
+    render(
+      <RankingList
+        initialRows={[row({ rank: 1, playerId: 10, value: 12 }), row({ rank: 2, playerId: 20, value: 8 })]}
+        total={10}
+        metric="wins"
+        filter={{}}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'もっと見る' }))
+    await waitFor(() => expect(screen.getByText('選手30')).toBeTruthy())
+    expect(screen.getByRole('button', { name: 'もっと見る' })).toBeTruthy()
+  })
+})

--- a/apps/web/src/app/(app)/players/ranking/RankingList.test.tsx
+++ b/apps/web/src/app/(app)/players/ranking/RankingList.test.tsx
@@ -113,4 +113,22 @@ describe('RankingList — 空 / もっと見る', () => {
     await waitFor(() => expect(screen.getByText('選手30')).toBeTruthy())
     expect(screen.getByRole('button', { name: 'もっと見る' })).toBeTruthy()
   })
+
+  it('追加取得が空配列なら（total 未達でも）もっと見る を終端して消す', async () => {
+    // total=10 だが次ページが 0 件（データ変化/offset 超過）→ 以後ボタンを出さない。
+    loadMoreMock.mockResolvedValue([])
+    render(
+      <RankingList
+        initialRows={[row({ rank: 1, playerId: 10, value: 12 }), row({ rank: 2, playerId: 20, value: 8 })]}
+        total={10}
+        metric="wins"
+        filter={{}}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'もっと見る' }))
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /もっと見る/ })).toBeNull(),
+    )
+    expect(loadMoreMock).toHaveBeenCalledTimes(1)
+  })
 })

--- a/apps/web/src/app/(app)/players/ranking/RankingList.test.tsx
+++ b/apps/web/src/app/(app)/players/ranking/RankingList.test.tsx
@@ -114,6 +114,29 @@ describe('RankingList — 空 / もっと見る', () => {
     expect(screen.getByRole('button', { name: 'もっと見る' })).toBeTruthy()
   })
 
+  it('追加取得が失敗したらエラー表示・ボタンは残り再試行できる', async () => {
+    loadMoreMock.mockRejectedValueOnce(new Error('boom'))
+    render(
+      <RankingList
+        initialRows={[row({ rank: 1, playerId: 10, value: 12 }), row({ rank: 2, playerId: 20, value: 8 })]}
+        total={10}
+        metric="wins"
+        filter={{}}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'もっと見る' }))
+    await waitFor(() =>
+      expect(screen.getByText('読み込みに失敗しました。もう一度お試しください。')).toBeTruthy(),
+    )
+    // ボタンは残り（再試行可能）。再試行が成功すれば行が増えエラーは消える。
+    loadMoreMock.mockResolvedValueOnce([row({ rank: 3, playerId: 30, displayName: '三位', value: 5 })])
+    fireEvent.click(screen.getByRole('button', { name: 'もっと見る' }))
+    await waitFor(() => expect(screen.getByText('三位')).toBeTruthy())
+    expect(
+      screen.queryByText('読み込みに失敗しました。もう一度お試しください。'),
+    ).toBeNull()
+  })
+
   it('追加取得が空配列なら（total 未達でも）もっと見る を終端して消す', async () => {
     // total=10 だが次ページが 0 件（データ変化/offset 超過）→ 以後ボタンを出さない。
     loadMoreMock.mockResolvedValue([])

--- a/apps/web/src/app/(app)/players/ranking/RankingList.tsx
+++ b/apps/web/src/app/(app)/players/ranking/RankingList.tsx
@@ -29,6 +29,10 @@ export function RankingList({
 }) {
   const [rows, setRows] = useState<RankingRow[]>(initialRows)
   const [loading, setLoading] = useState(false)
+  // 追加取得が空配列を返したら終端扱いにする。total は初期表示時点のスナップショットで、
+  // データ変化や offset 超過で `rows.length < total` のままでも次ページが 0 件になり得るため、
+  // それだけでボタンを出し続けると同じ offset のリクエストを繰り返せてしまう。
+  const [exhausted, setExhausted] = useState(false)
   const unit = metricDef(metric).unit
 
   if (rows.length === 0) {
@@ -39,13 +43,14 @@ export function RankingList({
     )
   }
 
-  const hasMore = rows.length < total
+  const hasMore = !exhausted && rows.length < total
 
   const loadMore = async () => {
     setLoading(true)
     try {
       const more = await loadMoreRanking(metric, filter, rows.length)
-      setRows((prev) => [...prev, ...more])
+      if (more.length === 0) setExhausted(true)
+      else setRows((prev) => [...prev, ...more])
     } finally {
       setLoading(false)
     }

--- a/apps/web/src/app/(app)/players/ranking/RankingList.tsx
+++ b/apps/web/src/app/(app)/players/ranking/RankingList.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import type { RankingMetric, RankingRow } from '@/lib/stats/ranking'
+import type { StatsFilter } from '@/lib/stats/types'
+import { formatMetricSub, formatMetricValue, metricDef } from './metrics'
+import { loadMoreRanking } from './actions'
+
+/**
+ * 順位リスト（design-spec §3.1.4）。
+ * `[順位 | 氏名＋所属 | 指標値＋単位＋副次 | ›]` の行を並べ、行タップで戦績詳細へ。
+ * TOP 100（サーバー初期表示）＋「もっと見る」で `loadMoreRanking` を呼んで追記する。
+ * 同値は同順位（rank はサーバー算出＝タイの次は飛ばす）。長名は省略記号。
+ *
+ * 初期行はサーバーから props で受け取り、追加分だけクライアントで持つ。metric/filter が
+ * 変わると page 側の `key` で再マウントされ、初期行が入れ替わる。
+ */
+export function RankingList({
+  initialRows,
+  total,
+  metric,
+  filter,
+}: {
+  initialRows: RankingRow[]
+  total: number
+  metric: RankingMetric
+  filter: StatsFilter
+}) {
+  const [rows, setRows] = useState<RankingRow[]>(initialRows)
+  const [loading, setLoading] = useState(false)
+  const unit = metricDef(metric).unit
+
+  if (rows.length === 0) {
+    return (
+      <p className="py-10 text-center text-sm text-ink-meta">
+        該当する選手がいません。
+      </p>
+    )
+  }
+
+  const hasMore = rows.length < total
+
+  const loadMore = async () => {
+    setLoading(true)
+    try {
+      const more = await loadMoreRanking(metric, filter, rows.length)
+      setRows((prev) => [...prev, ...more])
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col">
+      <ul className="flex flex-col divide-y divide-border-soft">
+        {rows.map((r) => {
+          const sub = formatMetricSub(metric, r.sub)
+          return (
+            <li key={r.playerId}>
+              <Link
+                href={`/players/${r.playerId}`}
+                className="flex items-center gap-3 py-2.5 hover:bg-surface-alt"
+              >
+                <span className="w-8 shrink-0 text-right font-display text-lg font-bold text-ink tabular-nums">
+                  {r.rank}
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate font-display text-[15px] text-ink">
+                    {r.displayName}
+                  </span>
+                  <span className="block truncate text-xs text-ink-meta">
+                    {r.affiliation ?? '所属不明'}
+                  </span>
+                </span>
+                <span className="shrink-0 text-right">
+                  <span className="font-display text-lg font-bold text-brand tabular-nums">
+                    {formatMetricValue(metric, r.value)}
+                    <span className="ml-0.5 text-xs font-normal text-ink-meta">
+                      {unit}
+                    </span>
+                  </span>
+                  {sub ? (
+                    <span className="block text-[11px] text-ink-muted tabular-nums">
+                      {sub}
+                    </span>
+                  ) : null}
+                </span>
+                <span aria-hidden className="shrink-0 text-ink-muted">
+                  ›
+                </span>
+              </Link>
+            </li>
+          )
+        })}
+      </ul>
+
+      {hasMore ? (
+        <button
+          type="button"
+          onClick={loadMore}
+          disabled={loading}
+          className="mt-3 self-center rounded-full border border-border bg-surface px-6 py-2 text-sm font-medium text-brand hover:bg-brand-bg disabled:opacity-50"
+        >
+          {loading ? '読み込み中…' : 'もっと見る'}
+        </button>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/src/app/(app)/players/ranking/RankingList.tsx
+++ b/apps/web/src/app/(app)/players/ranking/RankingList.tsx
@@ -33,6 +33,9 @@ export function RankingList({
   // データ変化や offset 超過で `rows.length < total` のままでも次ページが 0 件になり得るため、
   // それだけでボタンを出し続けると同じ offset のリクエストを繰り返せてしまう。
   const [exhausted, setExhausted] = useState(false)
+  // 追加取得の失敗（ネットワーク/一時的な Server Action 失敗/DB エラー）を捕捉して表示する。
+  // 捕捉しないとイベントハンドラ内の非同期例外が未処理になる。捕捉後もボタンは残し再試行可能。
+  const [error, setError] = useState<string | null>(null)
   const unit = metricDef(metric).unit
 
   if (rows.length === 0) {
@@ -46,11 +49,15 @@ export function RankingList({
   const hasMore = !exhausted && rows.length < total
 
   const loadMore = async () => {
+    if (loading) return // 多重実行ガード（同じ offset の連打を防ぐ）
     setLoading(true)
+    setError(null)
     try {
       const more = await loadMoreRanking(metric, filter, rows.length)
       if (more.length === 0) setExhausted(true)
       else setRows((prev) => [...prev, ...more])
+    } catch {
+      setError('読み込みに失敗しました。もう一度お試しください。')
     } finally {
       setLoading(false)
     }
@@ -99,6 +106,12 @@ export function RankingList({
           )
         })}
       </ul>
+
+      {error ? (
+        <p role="alert" className="mt-2 self-center text-xs text-accent-fg">
+          {error}
+        </p>
+      ) : null}
 
       {hasMore ? (
         <button

--- a/apps/web/src/app/(app)/players/ranking/RankingMetricChips.test.tsx
+++ b/apps/web/src/app/(app)/players/ranking/RankingMetricChips.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { RankingMetricChips } from './RankingMetricChips'
+
+describe('RankingMetricChips', () => {
+  it('6 指標チップを描画し、現在の指標だけ選択状態', () => {
+    render(<RankingMetricChips metric="wins" filter={{}} />)
+    const tabs = screen.getAllByRole('tab')
+    expect(tabs).toHaveLength(6)
+    const selected = tabs.filter((t) => t.getAttribute('aria-selected') === 'true')
+    expect(selected).toHaveLength(1)
+    expect(selected[0]!.textContent).toBe('勝利')
+  })
+
+  it('各チップは現在のフィルタを保ったまま metric を差し替える href', () => {
+    render(<RankingMetricChips metric="participations" filter={{ grades: ['A'] }} />)
+    // 出場（既定）はフィルタのみ、勝利は metric を付ける。いずれも grades=A を保持。
+    expect(screen.getByRole('tab', { name: '出場' }).getAttribute('href')).toBe(
+      '/players/ranking?grades=A',
+    )
+    expect(screen.getByRole('tab', { name: '勝利' }).getAttribute('href')).toBe(
+      '/players/ranking?metric=wins&grades=A',
+    )
+    expect(screen.getByRole('tab', { name: '優勝' }).getAttribute('href')).toBe(
+      '/players/ranking?metric=championships&grades=A',
+    )
+  })
+})

--- a/apps/web/src/app/(app)/players/ranking/RankingMetricChips.tsx
+++ b/apps/web/src/app/(app)/players/ranking/RankingMetricChips.tsx
@@ -1,0 +1,46 @@
+import Link from 'next/link'
+import type { RankingMetric } from '@/lib/stats/ranking'
+import type { StatsFilter } from '@/lib/stats/types'
+import { cn } from '@/lib/utils'
+import { RANKING_METRICS, buildRankingHref } from './metrics'
+
+/**
+ * 指標切替チップ（design-spec §3.1.1）。横スクロールの 6 チップ、選択中＝藍 bg。
+ * 各チップは現在のフィルタを保ったまま `?metric=` を差し替える Link なので、
+ * クライアント JS 無しで動く（サーバーコンポーネントから描画可）。
+ */
+export function RankingMetricChips({
+  metric,
+  filter,
+}: {
+  metric: RankingMetric
+  filter: StatsFilter
+}) {
+  return (
+    <div
+      className="-mx-4 flex gap-2 overflow-x-auto px-4 pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      role="tablist"
+      aria-label="指標"
+    >
+      {RANKING_METRICS.map((m) => {
+        const active = m.key === metric
+        return (
+          <Link
+            key={m.key}
+            href={buildRankingHref(m.key, filter)}
+            role="tab"
+            aria-selected={active}
+            className={cn(
+              'shrink-0 rounded-full border px-3 py-1 text-[13px] font-medium whitespace-nowrap transition-colors',
+              active
+                ? 'border-brand bg-brand text-white'
+                : 'border-border bg-surface text-ink-meta hover:bg-surface-alt',
+            )}
+          >
+            {m.chip}
+          </Link>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/web/src/app/(app)/players/ranking/actions.ts
+++ b/apps/web/src/app/(app)/players/ranking/actions.ts
@@ -1,13 +1,15 @@
 'use server'
 
+import { redirect } from 'next/navigation'
 import { auth } from '@/auth'
 import { getPlayerRanking, type RankingMetric, type RankingRow } from '@/lib/stats/ranking'
 import type { StatsFilter } from '@/lib/stats/types'
 
 /**
  * 「もっと見る」用：次ページ（offset 以降の TOP 100）を返す Server Action。
- * 全ログインユーザー向け（統計タブの audience）なので auth 済みのみ許可、
- * 未認証は空配列を返す（クライアントはそのまま打ち止めになる）。
+ * 全ログインユーザー向け（統計タブの audience）なので auth 済みのみ許可。未認証（例：セッション
+ * 期限切れ後にボタンを押す）は**ページ本体と同じく** `/auth/signin` へ redirect する。空配列を
+ * 返すと RankingList の「もっと見る」（rows.length < total 判定）が消えず失敗を繰り返せるため。
  *
  * この引数（metric/filter/offset）はクライアントが改変できる信頼できない入力だが、
  * `getPlayerRanking` がデータアクセス境界で許可リスト/範囲に丸める（不正 metric は既定へ、
@@ -20,7 +22,7 @@ export async function loadMoreRanking(
   offset: number,
 ): Promise<RankingRow[]> {
   const session = await auth()
-  if (!session) return []
+  if (!session) redirect('/auth/signin')
   const { rows } = await getPlayerRanking(metric, filter, 100, offset)
   return rows
 }

--- a/apps/web/src/app/(app)/players/ranking/actions.ts
+++ b/apps/web/src/app/(app)/players/ranking/actions.ts
@@ -1,0 +1,21 @@
+'use server'
+
+import { auth } from '@/auth'
+import { getPlayerRanking, type RankingMetric, type RankingRow } from '@/lib/stats/ranking'
+import type { StatsFilter } from '@/lib/stats/types'
+
+/**
+ * 「もっと見る」用：次ページ（offset 以降の TOP 100）を返す Server Action。
+ * 全ログインユーザー向け（統計タブの audience）なので auth 済みのみ許可、
+ * 未認証は空配列を返す（クライアントはそのまま打ち止めになる）。
+ */
+export async function loadMoreRanking(
+  metric: RankingMetric,
+  filter: StatsFilter,
+  offset: number,
+): Promise<RankingRow[]> {
+  const session = await auth()
+  if (!session) return []
+  const { rows } = await getPlayerRanking(metric, filter, 100, offset)
+  return rows
+}

--- a/apps/web/src/app/(app)/players/ranking/actions.ts
+++ b/apps/web/src/app/(app)/players/ranking/actions.ts
@@ -8,6 +8,11 @@ import type { StatsFilter } from '@/lib/stats/types'
  * 「もっと見る」用：次ページ（offset 以降の TOP 100）を返す Server Action。
  * 全ログインユーザー向け（統計タブの audience）なので auth 済みのみ許可、
  * 未認証は空配列を返す（クライアントはそのまま打ち止めになる）。
+ *
+ * この引数（metric/filter/offset）はクライアントが改変できる信頼できない入力だが、
+ * `getPlayerRanking` がデータアクセス境界で許可リスト/範囲に丸める（不正 metric は既定へ、
+ * enum 外 grade・NaN 年・負 offset は除外/クランプ）。ここで別途検証は重ねない＝単一 choke
+ * point に集約する。
  */
 export async function loadMoreRanking(
   metric: RankingMetric,

--- a/apps/web/src/app/(app)/players/ranking/metrics.test.ts
+++ b/apps/web/src/app/(app)/players/ranking/metrics.test.ts
@@ -64,6 +64,18 @@ describe('parseRankingParams', () => {
   it('grades は正規順（A→E）に並べ替える', () => {
     expect(parseRankingParams({ grades: 'E,B,A' }).filter.grades).toEqual(['A', 'B', 'E'])
   })
+
+  it('配列 searchParams（?grades=A&grades=B）でもクラッシュせず丸める', () => {
+    // 繰り返し query
+    expect(parseRankingParams({ grades: ['A', 'B'] }).filter.grades).toEqual(['A', 'B'])
+    // 繰り返し＋カンマ混在
+    expect(parseRankingParams({ grades: ['A,C', 'B'] }).filter.grades).toEqual(['A', 'B', 'C'])
+    // metric/year が配列なら先頭を採用
+    expect(parseRankingParams({ metric: ['winRate', 'wins'], yearFrom: ['2015'] })).toEqual({
+      metric: 'winRate',
+      filter: { yearFrom: 2015 },
+    })
+  })
 })
 
 describe('formatMetricValue / formatMetricSub', () => {

--- a/apps/web/src/app/(app)/players/ranking/metrics.test.ts
+++ b/apps/web/src/app/(app)/players/ranking/metrics.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import {
+  RANKING_METRICS,
+  buildRankingHref,
+  formatMetricSub,
+  formatMetricValue,
+  metricDef,
+  parseRankingParams,
+} from './metrics'
+
+describe('RANKING_METRICS', () => {
+  it('design-spec §3.1 の並び（出場/勝利/勝率/対戦/優勝/入賞）', () => {
+    expect(RANKING_METRICS.map((m) => m.key)).toEqual([
+      'participations',
+      'wins',
+      'winRate',
+      'matches',
+      'championships',
+      'nyusho',
+    ])
+  })
+})
+
+describe('buildRankingHref', () => {
+  it('既定指標（出場）＋フィルタ無しは素の URL', () => {
+    expect(buildRankingHref('participations', {})).toBe('/players/ranking')
+  })
+
+  it('非既定指標とフィルタを載せる（級は A→E 正規順で安定化）', () => {
+    expect(
+      buildRankingHref('wins', { yearFrom: 2015, yearTo: 2020, grades: ['C', 'A'] }),
+    ).toBe('/players/ranking?metric=wins&yearFrom=2015&yearTo=2020&grades=A%2CC')
+  })
+
+  it('空の grades は載せない', () => {
+    expect(buildRankingHref('winRate', { grades: [] })).toBe('/players/ranking?metric=winRate')
+  })
+})
+
+describe('parseRankingParams', () => {
+  it('未指定は既定（出場・フィルタ無し）', () => {
+    expect(parseRankingParams({})).toEqual({ metric: 'participations', filter: {} })
+  })
+
+  it('妥当な指標・年・級を採用', () => {
+    expect(
+      parseRankingParams({ metric: 'nyusho', yearFrom: '2015', yearTo: '2020', grades: 'A,B' }),
+    ).toEqual({ metric: 'nyusho', filter: { yearFrom: 2015, yearTo: 2020, grades: ['A', 'B'] } })
+  })
+
+  it('不正な指標・年・級は捨てる', () => {
+    expect(
+      parseRankingParams({ metric: 'bogus', yearFrom: 'x', grades: 'Z,foo' }),
+    ).toEqual({ metric: 'participations', filter: {} })
+  })
+
+  it('yearFrom>yearTo は入れ替える', () => {
+    expect(parseRankingParams({ yearFrom: '2020', yearTo: '2015' }).filter).toEqual({
+      yearFrom: 2015,
+      yearTo: 2020,
+    })
+  })
+
+  it('grades は正規順（A→E）に並べ替える', () => {
+    expect(parseRankingParams({ grades: 'E,B,A' }).filter.grades).toEqual(['A', 'B', 'E'])
+  })
+})
+
+describe('formatMetricValue / formatMetricSub', () => {
+  it('勝率は小数第1位固定・他は整数', () => {
+    expect(formatMetricValue('winRate', 60)).toBe('60.0')
+    expect(formatMetricValue('winRate', 66.7)).toBe('66.7')
+    expect(formatMetricValue('wins', 12)).toBe('12')
+  })
+
+  it('副次は勝率のみ母数（N戦）を返す', () => {
+    expect(formatMetricSub('winRate', 25)).toBe('25戦')
+    expect(formatMetricSub('winRate', null)).toBeNull()
+    expect(formatMetricSub('wins', 12)).toBeNull()
+  })
+
+  it('metricDef は unit/heading を引く', () => {
+    expect(metricDef('winRate').unit).toBe('%')
+    expect(metricDef('championships').heading).toBe('優勝回数')
+  })
+})

--- a/apps/web/src/app/(app)/players/ranking/metrics.ts
+++ b/apps/web/src/app/(app)/players/ranking/metrics.ts
@@ -1,0 +1,104 @@
+import type { RankingMetric } from '@/lib/stats/ranking'
+import type { Grade, StatsFilter } from '@/lib/stats/types'
+
+/**
+ * ③選手ランキングの指標カタログ（design-spec §3.1 の並び：出場／勝利／勝率／対戦／優勝／入賞）。
+ * `chip`＝指標チップの短ラベル・`heading`＝見出しの正式名・`unit`＝値の単位。
+ *
+ * 型のみ `@/lib/stats/ranking` から借りる（`import type` はビルド時に消えるので、
+ * db を含むサーバーモジュールがクライアントバンドルに混ざらない）。このモジュール自体は
+ * 純粋な定数/関数だけなのでクライアントからも安全に import できる。
+ */
+export interface MetricDef {
+  key: RankingMetric
+  chip: string
+  heading: string
+  unit: string
+}
+
+export const RANKING_METRICS: readonly MetricDef[] = [
+  { key: 'participations', chip: '出場', heading: '出場回数', unit: '大会' },
+  { key: 'wins', chip: '勝利', heading: '勝利数', unit: '勝' },
+  { key: 'winRate', chip: '勝率', heading: '勝率', unit: '%' },
+  { key: 'matches', chip: '対戦', heading: '対戦数', unit: '戦' },
+  { key: 'championships', chip: '優勝', heading: '優勝回数', unit: '回' },
+  { key: 'nyusho', chip: '入賞', heading: '入賞回数', unit: '回' },
+]
+
+const METRIC_KEYS = RANKING_METRICS.map((m) => m.key)
+const DEFAULT_METRIC: RankingMetric = 'participations'
+const ALL_GRADES: readonly Grade[] = ['A', 'B', 'C', 'D', 'E']
+
+export function metricDef(metric: RankingMetric): MetricDef {
+  return RANKING_METRICS.find((m) => m.key === metric) ?? RANKING_METRICS[0]!
+}
+
+/** 指標値＋単位の表示文字列（勝率のみ小数第1位固定）。 */
+export function formatMetricValue(metric: RankingMetric, value: number): string {
+  return metric === 'winRate' ? value.toFixed(1) : String(value)
+}
+
+/** 副次（muted）表示。勝率のみ母数（対戦数）を「N戦」で返し、他は null。 */
+export function formatMetricSub(metric: RankingMetric, sub: number | null): string | null {
+  if (metric === 'winRate' && sub != null) return `${sub}戦`
+  return null
+}
+
+/** filter を反映した /players/ranking の href（既定値は省略してURLを短く保つ）。 */
+export function buildRankingHref(metric: RankingMetric, filter: StatsFilter): string {
+  const params = new URLSearchParams()
+  if (metric !== DEFAULT_METRIC) params.set('metric', metric)
+  if (filter.yearFrom != null) params.set('yearFrom', String(filter.yearFrom))
+  if (filter.yearTo != null) params.set('yearTo', String(filter.yearTo))
+  if (filter.grades && filter.grades.length > 0) {
+    // 級は正規順（A→E）で安定化。
+    params.set('grades', ALL_GRADES.filter((g) => filter.grades!.includes(g)).join(','))
+  }
+  const qs = params.toString()
+  return qs ? `/players/ranking?${qs}` : '/players/ranking'
+}
+
+/** 年の searchParam を検証（数値・妥当な範囲のみ採用、他は undefined）。 */
+function parseYear(raw: string | undefined): number | undefined {
+  if (raw == null) return undefined
+  const n = Number(raw)
+  if (!Number.isInteger(n) || n < 1900 || n > 3000) return undefined
+  return n
+}
+
+/** grades の searchParam（"A,B"）を検証して正規順の配列に。無効値は捨てる。 */
+function parseGrades(raw: string | undefined): Grade[] | undefined {
+  if (!raw) return undefined
+  const set = new Set(raw.split(','))
+  const grades = ALL_GRADES.filter((g) => set.has(g))
+  return grades.length > 0 ? grades : undefined
+}
+
+/**
+ * /players/ranking の searchParams を検証済みの `{ metric, filter }` に。
+ * 不正な指標/年/級は既定（出場・フィルタ無し）に落とす。yearFrom>yearTo は入替。
+ */
+export function parseRankingParams(sp: {
+  metric?: string
+  yearFrom?: string
+  yearTo?: string
+  grades?: string
+}): { metric: RankingMetric; filter: StatsFilter } {
+  const metric = (METRIC_KEYS as string[]).includes(sp.metric ?? '')
+    ? (sp.metric as RankingMetric)
+    : DEFAULT_METRIC
+
+  let yearFrom = parseYear(sp.yearFrom)
+  let yearTo = parseYear(sp.yearTo)
+  if (yearFrom != null && yearTo != null && yearFrom > yearTo) {
+    ;[yearFrom, yearTo] = [yearTo, yearFrom]
+  }
+
+  const filter: StatsFilter = {}
+  if (yearFrom != null) filter.yearFrom = yearFrom
+  if (yearTo != null) filter.yearTo = yearTo
+  const grades = parseGrades(sp.grades)
+  if (grades) filter.grades = grades
+
+  return { metric, filter }
+}

--- a/apps/web/src/app/(app)/players/ranking/metrics.ts
+++ b/apps/web/src/app/(app)/players/ranking/metrics.ts
@@ -61,24 +61,43 @@ export function buildRankingHref(metric: RankingMetric, filter: StatsFilter): st
   return qs ? `/players/ranking?${qs}` : '/players/ranking'
 }
 
+/** searchParams の値は Next.js App Router では string だけでなく配列にもなり得る。 */
+type RawParam = string | string[] | undefined
+
+/** 配列 searchParam（?k=a&k=b）は先頭を採用。単値/未指定はそのまま。 */
+function firstParam(v: RawParam): string | undefined {
+  return Array.isArray(v) ? v[0] : v
+}
+
 /**
  * /players/ranking の searchParams を検証済みの `{ metric, filter }` に。
  * 指標は許可リストへ丸め、年/級は `sanitizeStatsFilter` で妥当な値のみ採用（不正は捨てる・
  * yearFrom>yearTo は入替）。文字列 → 型付き候補にしてから共通検証へ委譲する。
+ *
+ * `searchParams` はユーザーが直接改変できる入力で、Next.js は同名 query 複数指定
+ * （`?grades=A&grades=B`）を **配列**で渡す。metric/year は先頭を採用、grades は配列・
+ * カンマ区切りの両方を平坦化してから検証する（`.split` を配列に対して呼んでページが 500 化
+ * するのを防ぐ）。
  */
 export function parseRankingParams(sp: {
-  metric?: string
-  yearFrom?: string
-  yearTo?: string
-  grades?: string
+  metric?: RawParam
+  yearFrom?: RawParam
+  yearTo?: RawParam
+  grades?: RawParam
 }): { metric: RankingMetric; filter: StatsFilter } {
   const candidate: StatsFilter = {}
-  if (sp.yearFrom != null) candidate.yearFrom = Number(sp.yearFrom)
-  if (sp.yearTo != null) candidate.yearTo = Number(sp.yearTo)
-  if (sp.grades) candidate.grades = sp.grades.split(',') as Grade[]
+  const yearFrom = firstParam(sp.yearFrom)
+  const yearTo = firstParam(sp.yearTo)
+  if (yearFrom != null) candidate.yearFrom = Number(yearFrom)
+  if (yearTo != null) candidate.yearTo = Number(yearTo)
+
+  const rawGrades = Array.isArray(sp.grades)
+    ? sp.grades.flatMap((v) => v.split(','))
+    : (sp.grades?.split(',') ?? [])
+  if (rawGrades.length > 0) candidate.grades = rawGrades as Grade[]
 
   return {
-    metric: coerceRankingMetric(sp.metric),
+    metric: coerceRankingMetric(firstParam(sp.metric)),
     filter: sanitizeStatsFilter(candidate),
   }
 }

--- a/apps/web/src/app/(app)/players/ranking/metrics.ts
+++ b/apps/web/src/app/(app)/players/ranking/metrics.ts
@@ -1,13 +1,20 @@
-import type { RankingMetric } from '@/lib/stats/ranking'
-import type { Grade, StatsFilter } from '@/lib/stats/types'
+import {
+  ALL_GRADES,
+  DEFAULT_RANKING_METRIC,
+  coerceRankingMetric,
+  sanitizeStatsFilter,
+  type Grade,
+  type RankingMetric,
+  type StatsFilter,
+} from '@/lib/stats/types'
 
 /**
  * ③選手ランキングの指標カタログ（design-spec §3.1 の並び：出場／勝利／勝率／対戦／優勝／入賞）。
  * `chip`＝指標チップの短ラベル・`heading`＝見出しの正式名・`unit`＝値の単位。
  *
- * 型のみ `@/lib/stats/ranking` から借りる（`import type` はビルド時に消えるので、
- * db を含むサーバーモジュールがクライアントバンドルに混ざらない）。このモジュール自体は
- * 純粋な定数/関数だけなのでクライアントからも安全に import できる。
+ * 指標の許可リスト/検証・フィルタ検証は `@/lib/stats/types`（db 非依存）に集約し、ここは
+ * 表示ラベルと URL 組み立てだけを持つ。すべて純粋な定数/関数なのでクライアントから安全に
+ * import できる（サーバー依存を持ち込まない）。
  */
 export interface MetricDef {
   key: RankingMetric
@@ -24,10 +31,6 @@ export const RANKING_METRICS: readonly MetricDef[] = [
   { key: 'championships', chip: '優勝', heading: '優勝回数', unit: '回' },
   { key: 'nyusho', chip: '入賞', heading: '入賞回数', unit: '回' },
 ]
-
-const METRIC_KEYS = RANKING_METRICS.map((m) => m.key)
-const DEFAULT_METRIC: RankingMetric = 'participations'
-const ALL_GRADES: readonly Grade[] = ['A', 'B', 'C', 'D', 'E']
 
 export function metricDef(metric: RankingMetric): MetricDef {
   return RANKING_METRICS.find((m) => m.key === metric) ?? RANKING_METRICS[0]!
@@ -47,7 +50,7 @@ export function formatMetricSub(metric: RankingMetric, sub: number | null): stri
 /** filter を反映した /players/ranking の href（既定値は省略してURLを短く保つ）。 */
 export function buildRankingHref(metric: RankingMetric, filter: StatsFilter): string {
   const params = new URLSearchParams()
-  if (metric !== DEFAULT_METRIC) params.set('metric', metric)
+  if (metric !== DEFAULT_RANKING_METRIC) params.set('metric', metric)
   if (filter.yearFrom != null) params.set('yearFrom', String(filter.yearFrom))
   if (filter.yearTo != null) params.set('yearTo', String(filter.yearTo))
   if (filter.grades && filter.grades.length > 0) {
@@ -58,25 +61,10 @@ export function buildRankingHref(metric: RankingMetric, filter: StatsFilter): st
   return qs ? `/players/ranking?${qs}` : '/players/ranking'
 }
 
-/** 年の searchParam を検証（数値・妥当な範囲のみ採用、他は undefined）。 */
-function parseYear(raw: string | undefined): number | undefined {
-  if (raw == null) return undefined
-  const n = Number(raw)
-  if (!Number.isInteger(n) || n < 1900 || n > 3000) return undefined
-  return n
-}
-
-/** grades の searchParam（"A,B"）を検証して正規順の配列に。無効値は捨てる。 */
-function parseGrades(raw: string | undefined): Grade[] | undefined {
-  if (!raw) return undefined
-  const set = new Set(raw.split(','))
-  const grades = ALL_GRADES.filter((g) => set.has(g))
-  return grades.length > 0 ? grades : undefined
-}
-
 /**
  * /players/ranking の searchParams を検証済みの `{ metric, filter }` に。
- * 不正な指標/年/級は既定（出場・フィルタ無し）に落とす。yearFrom>yearTo は入替。
+ * 指標は許可リストへ丸め、年/級は `sanitizeStatsFilter` で妥当な値のみ採用（不正は捨てる・
+ * yearFrom>yearTo は入替）。文字列 → 型付き候補にしてから共通検証へ委譲する。
  */
 export function parseRankingParams(sp: {
   metric?: string
@@ -84,21 +72,13 @@ export function parseRankingParams(sp: {
   yearTo?: string
   grades?: string
 }): { metric: RankingMetric; filter: StatsFilter } {
-  const metric = (METRIC_KEYS as string[]).includes(sp.metric ?? '')
-    ? (sp.metric as RankingMetric)
-    : DEFAULT_METRIC
+  const candidate: StatsFilter = {}
+  if (sp.yearFrom != null) candidate.yearFrom = Number(sp.yearFrom)
+  if (sp.yearTo != null) candidate.yearTo = Number(sp.yearTo)
+  if (sp.grades) candidate.grades = sp.grades.split(',') as Grade[]
 
-  let yearFrom = parseYear(sp.yearFrom)
-  let yearTo = parseYear(sp.yearTo)
-  if (yearFrom != null && yearTo != null && yearFrom > yearTo) {
-    ;[yearFrom, yearTo] = [yearTo, yearFrom]
+  return {
+    metric: coerceRankingMetric(sp.metric),
+    filter: sanitizeStatsFilter(candidate),
   }
-
-  const filter: StatsFilter = {}
-  if (yearFrom != null) filter.yearFrom = yearFrom
-  if (yearTo != null) filter.yearTo = yearTo
-  const grades = parseGrades(sp.grades)
-  if (grades) filter.grades = grades
-
-  return { metric, filter }
 }

--- a/apps/web/src/app/(app)/players/ranking/page.tsx
+++ b/apps/web/src/app/(app)/players/ranking/page.tsx
@@ -23,12 +23,9 @@ const MIN_YEAR = 2010
 export default async function PlayerRankingPage({
   searchParams,
 }: {
-  searchParams: Promise<{
-    metric?: string
-    yearFrom?: string
-    yearTo?: string
-    grades?: string
-  }>
+  // Next.js App Router は同名 query 複数指定を配列で渡す（`?grades=A&grades=B`）。
+  // parseRankingParams が配列/単値の両方を安全に丸める。
+  searchParams: Promise<Record<string, string | string[] | undefined>>
 }) {
   const session = await auth()
   if (!session) redirect('/auth/signin')

--- a/apps/web/src/app/(app)/players/ranking/page.tsx
+++ b/apps/web/src/app/(app)/players/ranking/page.tsx
@@ -1,24 +1,67 @@
+import { redirect } from 'next/navigation'
+import { auth } from '@/auth'
 import { SectionTabs } from '@/components/stats/section-tabs'
-import { Card } from '@/components/ui'
+import { getPlayerRanking } from '@/lib/stats/ranking'
+import { buildRankingHref, metricDef, parseRankingParams } from './metrics'
+import { RankingMetricChips } from './RankingMetricChips'
+import { RankingFilterBar } from './RankingFilterBar'
+import { RankingList } from './RankingList'
+
+export const dynamic = 'force-dynamic'
+
+/** 収録開始年（design-spec §3.2「収録開始2010」）。期間セレクトの下限。 */
+const MIN_YEAR = 2010
 
 /**
- * /players/ranking — ③ 選手ランキング（統計）。senseki-stats PR-3 で実装予定。
- * PR-2（ナビ）では 4 セクションシェル（SectionTabs）配下のプレースホルダ scaffold。
- * 静的セグメント `ranking` は動的 `/players/[id]` より優先されるため衝突しない。
+ * /players/ranking — ③ 選手ランキング（統計）。design-spec §3.1。
+ *
+ * 指標チップ（横スクロール）＋1行フィルタ（期間/級・シート）＋順位リスト
+ * （TOP100＋もっと見る、行タップ→戦績詳細）。指標・フィルタは searchParams が単一
+ * ソースで、変更のたびにサーバー再集計（`getPlayerRanking`）する。優勝/入賞は PR-1 の
+ * 事前計算列 derived_bracket を数える。
  */
-export default function PlayerRankingPage() {
+export default async function PlayerRankingPage({
+  searchParams,
+}: {
+  searchParams: Promise<{
+    metric?: string
+    yearFrom?: string
+    yearTo?: string
+    grades?: string
+  }>
+}) {
+  const session = await auth()
+  if (!session) redirect('/auth/signin')
+
+  const { metric, filter } = parseRankingParams(await searchParams)
+  const { rows, total } = await getPlayerRanking(metric, filter, 100, 0)
+
+  // 期間セレクトの候補：収録開始〜当年（降順）。
+  const currentYear = new Date().getFullYear()
+  const years: number[] = []
+  for (let y = Math.max(currentYear, MIN_YEAR); y >= MIN_YEAR; y--) years.push(y)
+
   return (
     <div>
       <SectionTabs />
-      <div className="flex flex-col gap-4 p-4">
-        <h1 className="font-display text-xl font-bold text-ink">
-          選手ランキング
-        </h1>
-        <Card>
-          <p className="py-10 text-center text-sm text-ink-meta">
-            選手ランキングは準備中です（PR-3 で実装）。
-          </p>
-        </Card>
+      <div className="flex flex-col gap-3 p-4">
+        <RankingMetricChips metric={metric} filter={filter} />
+        <RankingFilterBar metric={metric} filter={filter} years={years} />
+
+        <p className="text-xs text-ink-meta">
+          <span className="text-ink">{metricDef(metric).heading}</span>
+          {' ・ 全国 ・ 該当 '}
+          <span className="text-ink tabular-nums">{total}</span>
+          {' 人'}
+        </p>
+
+        <RankingList
+          key={buildRankingHref(metric, filter)}
+          initialRows={rows}
+          total={total}
+          metric={metric}
+          filter={filter}
+        />
       </div>
     </div>
   )

--- a/apps/web/src/lib/stats/ranking.test.ts
+++ b/apps/web/src/lib/stats/ranking.test.ts
@@ -289,6 +289,16 @@ describe('getPlayerRanking — ページング / total', () => {
     expect(rows).toEqual([])
     expect(total).toBe(0)
   })
+
+  it('offset が末尾を超えても total は offset 非依存の全体件数（rows は空）', async () => {
+    await seed('大会1', '2026-01-01', [
+      classWith('D級', 'D', [p('甲', []), p('乙', []), p('丙', [])]),
+    ])
+    // 3 人しかいないが offset=10 → このページは空。total は 3 のまま（契約）。
+    const { rows, total } = await getPlayerRanking('participations', {}, 100, 10)
+    expect(rows).toEqual([])
+    expect(total).toBe(3)
+  })
 })
 
 describe('getPlayerRanking — 不正入力の防御（Server Action 境界）', () => {

--- a/apps/web/src/lib/stats/ranking.test.ts
+++ b/apps/web/src/lib/stats/ranking.test.ts
@@ -290,3 +290,22 @@ describe('getPlayerRanking — ページング / total', () => {
     expect(total).toBe(0)
   })
 })
+
+describe('getPlayerRanking — 不正入力の防御（Server Action 境界）', () => {
+  it('改変された metric/grade/年/offset でも例外を投げず既定で集計する', async () => {
+    await seed('大会1', '2026-01-01', [classWith('D級', 'D', [p('防御太郎', [])])])
+
+    // 不正 metric→既定(participations)・enum外grade/NaN年→除外・負offset→0 に丸められる。
+    // 型を欺いて（as）改変クライアントのペイロードを模す。
+    const res = await getPlayerRanking(
+      'bogus' as unknown as 'participations',
+      { grades: ['Z'] as unknown as Array<'A'>, yearFrom: Number.NaN, yearTo: -1 },
+      100,
+      -5,
+    )
+    // 例外にならず、フィルタが実質無効化されて「防御太郎」が出場ランキングに出る。
+    expect(res.total).toBe(1)
+    expect(res.rows[0]!.displayName).toBe('防御太郎')
+    expect(res.rows[0]!.value).toBe(1)
+  })
+})

--- a/apps/web/src/lib/stats/ranking.test.ts
+++ b/apps/web/src/lib/stats/ranking.test.ts
@@ -1,0 +1,292 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import type { ParsedResultPayload } from '@kagetra/mail-worker/result-import/schema'
+import { closeTestDb, testDb, truncateAll } from '@/test-utils/db'
+import { materializeResultDraft } from '@/lib/result-import/materialize'
+import { searchPlayers } from '@/lib/players/queries'
+import { getPlayerRanking } from './ranking'
+
+beforeEach(async () => {
+  await truncateAll()
+})
+
+afterAll(async () => {
+  await closeTestDb()
+})
+
+type Part = ParsedResultPayload['classes'][number]['participants'][number]
+type Mt = Part['matches'][number]
+
+const mt = (
+  round: number,
+  roundLabel: string | null,
+  opponentName: string | null,
+  scoreDiff: number | null,
+  result: 'win' | 'lose',
+  status: 'normal' | 'walkover' | 'forfeit' = 'normal',
+): Mt => ({ round, roundLabel, opponentName, scoreDiff, result, status })
+
+const p = (
+  name: string,
+  matches: Mt[],
+  opts: { affiliation?: string | null; finalRank?: string | null } = {},
+): Part => ({
+  seqNo: 1,
+  name,
+  nameKana: null,
+  affiliation: opts.affiliation ?? null,
+  prefecture: null,
+  dan: null,
+  memberNo: null,
+  finalRank: opts.finalRank ?? null,
+  matches,
+})
+
+function classWith(
+  className: string,
+  grade: 'A' | 'B' | 'C' | 'D' | 'E' | null,
+  participants: Part[],
+): ParsedResultPayload['classes'][number] {
+  return { className, grade, sheetName: null, participants }
+}
+
+async function seed(
+  name: string,
+  eventDate: string | null,
+  classes: ParsedResultPayload['classes'],
+) {
+  return testDb.transaction(async (tx) =>
+    materializeResultDraft(
+      tx,
+      { parserVersion: '1.0.0', classes },
+      { tournamentName: name, eventDate, venue: null, sourceResultDraftId: 1 },
+    ),
+  )
+}
+
+/** 4人シングルイリミ（準決勝→決勝）。champ=優勝(1)/runner=準優勝(2)/semiX,semiY=ベスト4(4)。 */
+function bracketClass(
+  className: string,
+  grade: 'A' | 'B' | 'C' | 'D' | 'E' | null,
+  champ: string,
+  runner: string,
+  semiX: string,
+  semiY: string,
+): ParsedResultPayload['classes'][number] {
+  return classWith(className, grade, [
+    p(champ, [mt(1, '準決勝', semiX, 5, 'win'), mt(2, '決勝', runner, 3, 'win')]),
+    p(semiX, [mt(1, '準決勝', champ, 5, 'lose')]),
+    p(runner, [mt(1, '準決勝', semiY, 7, 'win'), mt(2, '決勝', champ, 3, 'lose')]),
+    p(semiY, [mt(1, '準決勝', runner, 7, 'lose')]),
+  ])
+}
+
+/** win/lose を並べた normal 試合の列（1 参加者だけの級＝ブラケット非導出）。 */
+function manyMatches(wins: number, losses: number): Mt[] {
+  const arr: Mt[] = []
+  let r = 1
+  for (let i = 0; i < wins; i++) arr.push(mt(r++, null, `勝相手${i}`, 5, 'win'))
+  for (let i = 0; i < losses; i++) arr.push(mt(r++, null, `負相手${i}`, 3, 'lose'))
+  return arr
+}
+
+async function idOf(name: string): Promise<number> {
+  const res = await searchPlayers(name)
+  return res[0]!.id
+}
+
+describe('getPlayerRanking — 出場回数', () => {
+  it('参加数の降順・同値同順位・total を返す', async () => {
+    // X=3大会 / Y=2大会 / Z=1大会
+    await seed('大会1', '2026-01-01', [classWith('D級', 'D', [p('X太郎', []), p('Z太郎', [])])])
+    await seed('大会2', '2026-02-01', [classWith('D級', 'D', [p('X太郎', []), p('Y太郎', [])])])
+    await seed('大会3', '2026-03-01', [classWith('D級', 'D', [p('X太郎', []), p('Y太郎', [])])])
+
+    const { rows, total } = await getPlayerRanking('participations')
+    expect(total).toBe(3)
+    expect(rows.map((r) => [r.displayName, r.value, r.rank])).toEqual([
+      ['X太郎', 3, 1],
+      ['Y太郎', 2, 2],
+      ['Z太郎', 1, 3],
+    ])
+  })
+
+  it('直近大会の所属会を返す（searchPlayers と同一の相関サブクエリ）', async () => {
+    await seed('古い大会', '2024-01-01', [classWith('D級', 'D', [p('所属太郎', [], { affiliation: '札幌' })])])
+    await seed('新しい大会', '2026-05-01', [classWith('D級', 'D', [p('所属太郎', [], { affiliation: '東京' })])])
+
+    const { rows } = await getPlayerRanking('participations')
+    expect(rows[0]!.displayName).toBe('所属太郎')
+    expect(rows[0]!.affiliation).toBe('東京')
+  })
+})
+
+describe('getPlayerRanking — 勝利数 / 対戦数（normal のみ）', () => {
+  it('勝利数は normal の win のみ・対戦数は normal のみ（不戦勝/棄権は除外）', async () => {
+    await seed('大会1', '2026-01-01', [
+      classWith('D級', 'D', [
+        // P1: normal win×2, normal lose×1, walkover win×1 → wins=2, matches=3
+        p('P1太郎', [
+          mt(1, null, '相手a', 5, 'win'),
+          mt(2, null, '相手b', 4, 'win'),
+          mt(3, null, '相手c', 2, 'lose'),
+          mt(4, null, null, null, 'win', 'walkover'),
+        ]),
+        // P2: normal win×1 → wins=1, matches=1
+        p('P2太郎', [mt(1, null, '相手d', 6, 'win')]),
+      ]),
+    ])
+
+    const wins = await getPlayerRanking('wins')
+    expect(wins.total).toBe(2)
+    expect(wins.rows.map((r) => [r.displayName, r.value, r.rank])).toEqual([
+      ['P1太郎', 2, 1],
+      ['P2太郎', 1, 2],
+    ])
+
+    const games = await getPlayerRanking('matches')
+    expect(games.rows.map((r) => [r.displayName, r.value])).toEqual([
+      ['P1太郎', 3],
+      ['P2太郎', 1],
+    ])
+  })
+})
+
+describe('getPlayerRanking — 勝率（最低20試合で足切り）', () => {
+  it('20試合未満は除外・勝率降順・sub に母数（対戦数）を返す', async () => {
+    await seed('大会1', '2026-01-01', [
+      classWith('D級', 'D', [p('高勝率', manyMatches(15, 10))]), // 25試合 60.0%
+    ])
+    await seed('大会2', '2026-01-02', [
+      classWith('D級', 'D', [p('五分', manyMatches(11, 11))]), // 22試合 50.0%
+    ])
+    await seed('大会3', '2026-01-03', [
+      classWith('D級', 'D', [p('少数精鋭', manyMatches(10, 0))]), // 10試合 100%（足切りで除外）
+    ])
+
+    const { rows, total } = await getPlayerRanking('winRate')
+    expect(total).toBe(2) // 少数精鋭は 20試合未満で除外
+    expect(rows.map((r) => [r.displayName, r.value, r.sub, r.rank])).toEqual([
+      ['高勝率', 60, 25, 1],
+      ['五分', 50, 22, 2],
+    ])
+    expect(rows.some((r) => r.displayName === '少数精鋭')).toBe(false)
+  })
+})
+
+describe('getPlayerRanking — 優勝回数（bracket=1）', () => {
+  it('優勝者のみ・回数をカウント・非優勝は除外', async () => {
+    await seed('選手権1', '2026-01-01', [bracketClass('A級', 'A', 'A太郎', 'C太郎', 'B太郎', 'D太郎')])
+    await seed('選手権2', '2026-02-01', [bracketClass('A級', 'A', 'A太郎', 'F太郎', 'G太郎', 'H太郎')])
+    await seed('選手権3', '2026-03-01', [bracketClass('A級', 'A', 'K太郎', 'L太郎', 'M太郎', 'N太郎')])
+
+    const { rows, total } = await getPlayerRanking('championships')
+    expect(total).toBe(2) // A太郎 と K太郎 のみ
+    expect(rows.map((r) => [r.displayName, r.value, r.rank])).toEqual([
+      ['A太郎', 2, 1],
+      ['K太郎', 1, 2],
+    ])
+    // 準優勝・ベスト4 は優勝ランキングに現れない
+    expect(rows.some((r) => r.displayName === 'C太郎')).toBe(false)
+  })
+})
+
+describe('getPlayerRanking — 入賞回数（bracket≤8）', () => {
+  it('導出できた bracket≤8 のみを数える・導出不能級（null）は除外', async () => {
+    // 4人ブラケット：A(1)/C(2)/B(4)/D(4) 全員が入賞（bracket≤8）
+    await seed('選手権', '2026-01-01', [bracketClass('A級', 'A', 'A太郎', 'C太郎', 'B太郎', 'D太郎')])
+    // 総当たり（非導出）：L太郎 は bracket=null → 入賞に数えない
+    await seed('総当たり', '2026-02-01', [
+      classWith('B級', 'B', [
+        p('L太郎', [mt(1, '1回戦', 'M太郎', 2, 'win'), mt(3, '3回戦', 'N太郎', 1, 'lose')], { finalRank: '優勝' }),
+        p('M太郎', [mt(1, '1回戦', 'L太郎', 2, 'lose'), mt(2, '2回戦', 'N太郎', 3, 'win')], { finalRank: '2位' }),
+        p('N太郎', [mt(2, '2回戦', 'M太郎', 3, 'lose'), mt(3, '3回戦', 'L太郎', 1, 'win')], { finalRank: '3位' }),
+      ]),
+    ])
+
+    const { rows, total } = await getPlayerRanking('nyusho')
+    expect(total).toBe(4) // A/C/B/D のみ
+    const names = rows.map((r) => r.displayName).sort()
+    expect(names).toEqual(['A太郎', 'B太郎', 'C太郎', 'D太郎'])
+    expect(rows.every((r) => r.value === 1)).toBe(true)
+    // 非導出級の L太郎（final_rank=優勝）は入賞に入らない
+    expect(rows.some((r) => r.displayName === 'L太郎')).toBe(false)
+  })
+})
+
+describe('getPlayerRanking — 期間フィルタ', () => {
+  it('year 範囲で絞り・event_date 無し大会は範囲指定時に除外', async () => {
+    await seed('2018大会', '2018-05-01', [classWith('D級', 'D', [p('期間太郎', [])])])
+    await seed('2020大会', '2020-05-01', [classWith('D級', 'D', [p('期間太郎', [])])])
+    await seed('日付不明大会', null, [classWith('D級', 'D', [p('期間太郎', [])])])
+
+    // フィルタ無し：3大会すべて
+    const all = await getPlayerRanking('participations')
+    expect(all.rows[0]!.value).toBe(3)
+
+    // 2019〜2020：2020大会のみ（2018 は範囲外・null は除外）
+    const ranged = await getPlayerRanking('participations', { yearFrom: 2019, yearTo: 2020 })
+    expect(ranged.rows[0]!.value).toBe(1)
+  })
+})
+
+describe('getPlayerRanking — 級フィルタ', () => {
+  it('grades で絞る', async () => {
+    await seed('A大会', '2026-01-01', [classWith('A級', 'A', [p('級太郎', [])])])
+    await seed('C大会', '2026-02-01', [classWith('C級', 'C', [p('級太郎', [])])])
+
+    expect((await getPlayerRanking('participations', { grades: ['A'] })).rows[0]!.value).toBe(1)
+    expect((await getPlayerRanking('participations', { grades: ['A', 'C'] })).rows[0]!.value).toBe(2)
+  })
+})
+
+describe('getPlayerRanking — 同順位（競技ランキング=タイの次は順位を飛ばす）', () => {
+  it('3人が同値で1位タイ→次は4位', async () => {
+    // X/Y/W=2大会（1位タイ）、Z=1大会（次順位＝4位）
+    await seed('大会1', '2026-01-01', [
+      classWith('D級', 'D', [p('X太郎', []), p('Y太郎', []), p('W太郎', []), p('Z太郎', [])]),
+    ])
+    await seed('大会2', '2026-02-01', [
+      classWith('D級', 'D', [p('X太郎', []), p('Y太郎', []), p('W太郎', [])]),
+    ])
+
+    const { rows } = await getPlayerRanking('participations')
+    const byName = new Map(rows.map((r) => [r.displayName, r]))
+    expect(byName.get('X太郎')!.rank).toBe(1)
+    expect(byName.get('Y太郎')!.rank).toBe(1)
+    expect(byName.get('W太郎')!.rank).toBe(1)
+    // 3人が1位タイ → 次は4位（2,3 を飛ばす）
+    expect(byName.get('Z太郎')!.rank).toBe(4)
+    // 同値内は表示名昇順
+    const top3 = rows.slice(0, 3).map((r) => r.displayName)
+    expect(top3).toEqual([...top3].sort())
+  })
+})
+
+describe('getPlayerRanking — ページング / total', () => {
+  it('limit/offset でページングしても rank と total は全体基準', async () => {
+    // 5人を distinct な参加数に（A=5,B=4,C=3,D=2,E=1）
+    for (let n = 5; n >= 1; n--) {
+      for (let k = 0; k < n; k++) {
+        await seed(`t${n}-${k}`, `2026-0${(k % 9) + 1}-01`, [
+          classWith('D級', 'D', [p(`Rank${6 - n}`, [])]),
+        ])
+      }
+    }
+
+    const page1 = await getPlayerRanking('participations', {}, 2, 0)
+    expect(page1.total).toBe(5)
+    expect(page1.rows.map((r) => r.rank)).toEqual([1, 2])
+    expect(page1.rows[0]!.value).toBe(5)
+
+    const page2 = await getPlayerRanking('participations', {}, 2, 2)
+    expect(page2.total).toBe(5) // total は offset に関係なく全体
+    expect(page2.rows.map((r) => r.rank)).toEqual([3, 4])
+    expect(page2.rows[0]!.value).toBe(3)
+  })
+
+  it('該当0人なら空配列・total=0', async () => {
+    const { rows, total } = await getPlayerRanking('championships')
+    expect(rows).toEqual([])
+    expect(total).toBe(0)
+  })
+})

--- a/apps/web/src/lib/stats/ranking.ts
+++ b/apps/web/src/lib/stats/ranking.ts
@@ -7,21 +7,16 @@ import {
   tournamentParticipants,
   tournaments,
 } from '@kagetra/shared/schema'
-import type { StatsFilter } from './types'
+import {
+  coerceRankingMetric,
+  sanitizeStatsFilter,
+  type RankingMetric,
+  type StatsFilter,
+} from './types'
 
-/**
- * ③選手ランキングの指標。requirements §3.5。
- * - `participations` 出場回数 ／ `wins` 勝利数（normal の win）／
- *   `winRate` 勝率（最低20試合で足切り）／ `matches` 対戦数（normal の試合数）／
- *   `championships` 優勝回数（derived_bracket=1）／ `nyusho` 入賞回数（derived_bracket≤8）。
- */
-export type RankingMetric =
-  | 'participations'
-  | 'wins'
-  | 'winRate'
-  | 'matches'
-  | 'championships'
-  | 'nyusho'
+// RankingMetric は共有型（types.ts）で定義。従来 `@/lib/stats/ranking` から import して
+// いた箇所を壊さないよう、取り込んだ型をそのまま再エクスポートする。
+export type { RankingMetric }
 
 export interface RankingRow {
   /** 競技ランキング順位（同値=同順位・タイの次は順位を飛ばす。3人が1位タイ→次は4位）。 */
@@ -183,7 +178,16 @@ export async function getPlayerRanking(
   limit = DEFAULT_LIMIT,
   offset = 0,
 ): Promise<PlayerRankingResult> {
-  const agg = aggFor(metric, filter)
+  // データアクセスの choke point で入力を丸める（全呼び出し元＝ページ/Server Action が
+  // ここを通る防御）。信頼できない Server Action ペイロード（改変された metric/filter/offset）
+  // でも aggFor が undefined を返したり DB エラー（enum 外 grade・負 offset・NaN 年）で 500 に
+  // ならないよう、許可リスト/範囲へ丸めてから集計する。
+  const safeMetric = coerceRankingMetric(metric)
+  const safeFilter = sanitizeStatsFilter(filter)
+  const safeOffset = Number.isInteger(offset) && offset >= 0 ? offset : 0
+  const safeLimit =
+    Number.isInteger(limit) && limit > 0 ? Math.min(limit, DEFAULT_LIMIT) : DEFAULT_LIMIT
+  const agg = aggFor(safeMetric, safeFilter)
 
   const rows = await db
     .select({
@@ -199,8 +203,8 @@ export async function getPlayerRanking(
     // 値降順→表示名昇順→player_id 昇順。最後の player_id は同値同名でも並びを一意に
     // 固定し、offset ページング（「もっと見る」）で境界の重複/欠落が起きないようにする。
     .orderBy(desc(agg.value), asc(agg.displayName), asc(agg.playerId))
-    .limit(limit)
-    .offset(offset)
+    .limit(safeLimit)
+    .offset(safeOffset)
 
   return {
     rows: rows.map((r) => ({

--- a/apps/web/src/lib/stats/ranking.ts
+++ b/apps/web/src/lib/stats/ranking.ts
@@ -1,0 +1,214 @@
+import { and, asc, desc, eq, inArray, sql, type SQL, type SQLWrapper } from 'drizzle-orm'
+import { db } from '@/lib/db'
+import {
+  matches,
+  players,
+  tournamentClasses,
+  tournamentParticipants,
+  tournaments,
+} from '@kagetra/shared/schema'
+import type { StatsFilter } from './types'
+
+/**
+ * ③選手ランキングの指標。requirements §3.5。
+ * - `participations` 出場回数 ／ `wins` 勝利数（normal の win）／
+ *   `winRate` 勝率（最低20試合で足切り）／ `matches` 対戦数（normal の試合数）／
+ *   `championships` 優勝回数（derived_bracket=1）／ `nyusho` 入賞回数（derived_bracket≤8）。
+ */
+export type RankingMetric =
+  | 'participations'
+  | 'wins'
+  | 'winRate'
+  | 'matches'
+  | 'championships'
+  | 'nyusho'
+
+export interface RankingRow {
+  /** 競技ランキング順位（同値=同順位・タイの次は順位を飛ばす。3人が1位タイ→次は4位）。 */
+  rank: number
+  playerId: number
+  displayName: string
+  /** 直近大会（event_date 降順 NULLS LAST・同日 id 降順）の participant 所属。未参加は null。 */
+  affiliation: string | null
+  /** 指標値（勝率は 0–100 の小数第1位、他は整数）。 */
+  value: number
+  /** 副次表示用の補助数値。勝率のみ母数（対戦数）を返し、他の指標は null。 */
+  sub: number | null
+}
+
+export interface PlayerRankingResult {
+  rows: RankingRow[]
+  /** フィルタ該当選手の総数（＝見出し「該当N人」・ページングの母数。offset に依存しない全体値）。 */
+  total: number
+}
+
+/** 勝率の足切り（最低対戦数）。requirements §3.5。 */
+const WIN_RATE_MIN_MATCHES = 20
+const DEFAULT_LIMIT = 100
+
+/**
+ * 期間・級フィルタの WHERE 断片。tournaments / tournament_classes を join 済みの
+ * クエリで使う。year 指定時は event_date の日付比較になり、event_date 無し大会は
+ * 自然に除外される（NULL 比較が偽）。grades は enum 列への IN（未指定なら無条件）。
+ */
+function filterConds(filter: StatsFilter): SQL[] {
+  const conds: SQL[] = []
+  if (filter.yearFrom != null) {
+    conds.push(sql`${tournaments.eventDate} >= ${`${filter.yearFrom}-01-01`}::date`)
+  }
+  if (filter.yearTo != null) {
+    conds.push(sql`${tournaments.eventDate} <= ${`${filter.yearTo}-12-31`}::date`)
+  }
+  if (filter.grades && filter.grades.length > 0) {
+    conds.push(inArray(tournamentClasses.grade, filter.grades))
+  }
+  return conds
+}
+
+/**
+ * 直近大会（event_date 降順 NULLS LAST・同日は tournament id 降順）の participant 所属。
+ * searchPlayers（[[impl_player_search_recent_affiliation]]）と同一ロジック＝戦績詳細
+ * ヘッダ・検索結果・ランキングで所属表示が一致する。
+ */
+function recentAffiliation(playerIdCol: SQLWrapper): SQL<string | null> {
+  return sql<string | null>`(
+    select tp.affiliation
+    from ${tournamentParticipants} tp
+    join ${tournamentClasses} tc on tc.id = tp.class_id
+    join ${tournaments} t on t.id = tc.tournament_id
+    where tp.player_id = ${playerIdCol}
+    order by t.event_date desc nulls last, t.id desc
+    limit 1
+  )`
+}
+
+/** 参加グレイン（tournament_participants 起点）の集計サブクエリ。優勝/入賞/出場で使う。 */
+function participantAgg(
+  filter: StatsFilter,
+  valueSql: SQL<number>,
+  subSql: SQL<number | null>,
+  havingSql: SQL,
+) {
+  return db
+    .select({
+      playerId: sql<number>`${players.id}`.as('player_id'),
+      displayName: sql<string>`${players.displayName}`.as('display_name'),
+      value: valueSql.as('value'),
+      sub: subSql.as('sub'),
+    })
+    .from(tournamentParticipants)
+    .innerJoin(players, eq(players.id, tournamentParticipants.playerId))
+    .innerJoin(tournamentClasses, eq(tournamentClasses.id, tournamentParticipants.classId))
+    .innerJoin(tournaments, eq(tournaments.id, tournamentClasses.tournamentId))
+    .where(and(...filterConds(filter)))
+    .groupBy(players.id)
+    .having(havingSql)
+    .as('agg')
+}
+
+/** 対戦グレイン（matches 起点）の集計サブクエリ。勝利/対戦/勝率で使う。 */
+function matchAgg(
+  filter: StatsFilter,
+  valueSql: SQL<number>,
+  subSql: SQL<number | null>,
+  havingSql: SQL,
+) {
+  return db
+    .select({
+      playerId: sql<number>`${players.id}`.as('player_id'),
+      displayName: sql<string>`${players.displayName}`.as('display_name'),
+      value: valueSql.as('value'),
+      sub: subSql.as('sub'),
+    })
+    .from(matches)
+    .innerJoin(
+      tournamentParticipants,
+      and(
+        eq(tournamentParticipants.id, matches.participantId),
+        eq(tournamentParticipants.classId, matches.classId),
+      ),
+    )
+    .innerJoin(players, eq(players.id, tournamentParticipants.playerId))
+    .innerJoin(tournamentClasses, eq(tournamentClasses.id, matches.classId))
+    .innerJoin(tournaments, eq(tournaments.id, tournamentClasses.tournamentId))
+    .where(and(...filterConds(filter)))
+    .groupBy(players.id)
+    .having(havingSql)
+    .as('agg')
+}
+
+// 集計式の断片（SELECT と HAVING で同一式を使い回すため定数化＝alias は HAVING で参照不可）。
+const NORMAL_WINS = sql`count(*) filter (where ${matches.result} = 'win' and ${matches.status} = 'normal')`
+const NORMAL_GAMES = sql`count(*) filter (where ${matches.status} = 'normal')`
+const CHAMPIONS = sql`count(*) filter (where ${tournamentParticipants.derivedBracket} = 1)`
+const NYUSHO = sql`count(*) filter (where ${tournamentParticipants.derivedBracket} <= 8)`
+const NO_SUB = sql<number | null>`null`
+
+/** 指標に応じた集計サブクエリ（value / sub / HAVING を切り替える）。 */
+function aggFor(metric: RankingMetric, filter: StatsFilter) {
+  switch (metric) {
+    case 'participations':
+      return participantAgg(filter, sql<number>`count(*)::int`, NO_SUB, sql`count(*) > 0`)
+    case 'championships':
+      return participantAgg(filter, sql<number>`${CHAMPIONS}::int`, NO_SUB, sql`${CHAMPIONS} > 0`)
+    case 'nyusho':
+      return participantAgg(filter, sql<number>`${NYUSHO}::int`, NO_SUB, sql`${NYUSHO} > 0`)
+    case 'wins':
+      return matchAgg(filter, sql<number>`${NORMAL_WINS}::int`, NO_SUB, sql`${NORMAL_WINS} > 0`)
+    case 'matches':
+      return matchAgg(filter, sql<number>`${NORMAL_GAMES}::int`, NO_SUB, sql`${NORMAL_GAMES} > 0`)
+    case 'winRate':
+      // 勝率＝normal の勝ち/対戦（小数第1位）。母数は最低20試合で足切り（HAVING）。
+      // 母数0はHAVINGで弾かれるが、念のため nullif でゼロ除算を防ぐ。
+      return matchAgg(
+        filter,
+        sql<number>`round(100.0 * ${NORMAL_WINS} / nullif(${NORMAL_GAMES}, 0), 1)::float8`,
+        sql<number>`${NORMAL_GAMES}::int`,
+        sql`${NORMAL_GAMES} >= ${WIN_RATE_MIN_MATCHES}`,
+      )
+  }
+}
+
+/**
+ * 指標別の選手ランキング（読み取り専用・サーバー集計）。requirements §3.5 / §4.2。
+ *
+ * 集計サブクエリ（フィルタ・HAVING 済み）を FROM に、`rank() over (order by value desc)`
+ * で競技ランキング順位（タイの次は飛ばす）を、`count(*) over ()` で該当総数を、相関
+ * サブクエリで直近所属を1回のクエリで取る。並びは値降順→表示名昇順。TOP `limit` を offset で
+ * ページング（「もっと見る」）。優勝/入賞は事前計算列 derived_bracket を数える（§4.1）。
+ */
+export async function getPlayerRanking(
+  metric: RankingMetric,
+  filter: StatsFilter = {},
+  limit = DEFAULT_LIMIT,
+  offset = 0,
+): Promise<PlayerRankingResult> {
+  const agg = aggFor(metric, filter)
+
+  const rows = await db
+    .select({
+      playerId: agg.playerId,
+      displayName: agg.displayName,
+      value: agg.value,
+      sub: agg.sub,
+      rank: sql<number>`cast(rank() over (order by ${agg.value} desc) as int)`,
+      total: sql<number>`cast(count(*) over () as int)`,
+      affiliation: recentAffiliation(agg.playerId),
+    })
+    .from(agg)
+    .orderBy(desc(agg.value), asc(agg.displayName))
+    .limit(limit)
+    .offset(offset)
+
+  return {
+    rows: rows.map((r) => ({
+      rank: r.rank,
+      playerId: r.playerId,
+      displayName: r.displayName,
+      affiliation: r.affiliation,
+      value: r.value,
+      sub: r.sub,
+    })),
+    total: rows[0]?.total ?? 0,
+  }
+}

--- a/apps/web/src/lib/stats/ranking.ts
+++ b/apps/web/src/lib/stats/ranking.ts
@@ -206,6 +206,19 @@ export async function getPlayerRanking(
     .limit(safeLimit)
     .offset(safeOffset)
 
+  // total は `count(*) over ()`＝offset 非依存の全体件数だが、offset が末尾を超える等で
+  // このページに 1 行も返らないと窓の値が取れない。契約（offset 非依存）を守るため、その
+  // ときだけ agg を数え直す（GROUP BY の行数＝該当選手数）。通常（offset=0 等 rows あり）は
+  // 追加クエリ無しで rows[0].total を使う。
+  let total = rows[0]?.total ?? 0
+  if (rows.length === 0) {
+    const countAgg = aggFor(safeMetric, safeFilter)
+    const [c] = await db
+      .select({ n: sql<number>`cast(count(*) as int)` })
+      .from(countAgg)
+    total = c?.n ?? 0
+  }
+
   return {
     rows: rows.map((r) => ({
       rank: r.rank,
@@ -215,6 +228,6 @@ export async function getPlayerRanking(
       value: r.value,
       sub: r.sub,
     })),
-    total: rows[0]?.total ?? 0,
+    total,
   }
 }

--- a/apps/web/src/lib/stats/ranking.ts
+++ b/apps/web/src/lib/stats/ranking.ts
@@ -196,7 +196,9 @@ export async function getPlayerRanking(
       affiliation: recentAffiliation(agg.playerId),
     })
     .from(agg)
-    .orderBy(desc(agg.value), asc(agg.displayName))
+    // 値降順→表示名昇順→player_id 昇順。最後の player_id は同値同名でも並びを一意に
+    // 固定し、offset ページング（「もっと見る」）で境界の重複/欠落が起きないようにする。
+    .orderBy(desc(agg.value), asc(agg.displayName), asc(agg.playerId))
     .limit(limit)
     .offset(offset)
 

--- a/apps/web/src/lib/stats/types.test.ts
+++ b/apps/web/src/lib/stats/types.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { coerceRankingMetric, sanitizeStatsFilter } from './types'
+
+describe('coerceRankingMetric', () => {
+  it('妥当な指標はそのまま通す', () => {
+    expect(coerceRankingMetric('winRate')).toBe('winRate')
+    expect(coerceRankingMetric('championships')).toBe('championships')
+  })
+
+  it('未知/非文字列は既定（participations）へ丸める', () => {
+    expect(coerceRankingMetric('bogus')).toBe('participations')
+    expect(coerceRankingMetric('')).toBe('participations')
+    expect(coerceRankingMetric(undefined)).toBe('participations')
+    expect(coerceRankingMetric(null)).toBe('participations')
+    expect(coerceRankingMetric(42)).toBe('participations')
+    expect(coerceRankingMetric({ metric: 'wins' })).toBe('participations')
+  })
+})
+
+describe('sanitizeStatsFilter', () => {
+  it('妥当な年・級はそのまま', () => {
+    expect(sanitizeStatsFilter({ yearFrom: 2015, yearTo: 2020, grades: ['A', 'C'] })).toEqual({
+      yearFrom: 2015,
+      yearTo: 2020,
+      grades: ['A', 'C'],
+    })
+  })
+
+  it('null / undefined / 空は {}', () => {
+    expect(sanitizeStatsFilter(undefined)).toEqual({})
+    expect(sanitizeStatsFilter(null)).toEqual({})
+    expect(sanitizeStatsFilter({})).toEqual({})
+  })
+
+  it('yearFrom>yearTo は入替', () => {
+    expect(sanitizeStatsFilter({ yearFrom: 2020, yearTo: 2015 })).toEqual({
+      yearFrom: 2015,
+      yearTo: 2020,
+    })
+  })
+
+  it('NaN・非整数・範囲外の年は捨てる', () => {
+    expect(sanitizeStatsFilter({ yearFrom: Number.NaN })).toEqual({})
+    expect(sanitizeStatsFilter({ yearFrom: 2015.5 })).toEqual({})
+    expect(sanitizeStatsFilter({ yearFrom: 1800, yearTo: 5000 })).toEqual({})
+    // 片方だけ妥当なら妥当な方は残る
+    expect(sanitizeStatsFilter({ yearFrom: 2015, yearTo: Number.NaN })).toEqual({ yearFrom: 2015 })
+  })
+
+  it('enum 外 grade は捨て A–E 正規順に整える', () => {
+    expect(
+      sanitizeStatsFilter({ grades: ['Z', 'B', 'A', 'foo'] as unknown as Array<'A'> }),
+    ).toEqual({ grades: ['A', 'B'] })
+  })
+
+  it('grades が配列でない/空なら落とす', () => {
+    expect(sanitizeStatsFilter({ grades: 'A' as unknown as Array<'A'> })).toEqual({})
+    expect(sanitizeStatsFilter({ grades: [] })).toEqual({})
+  })
+})

--- a/apps/web/src/lib/stats/types.ts
+++ b/apps/web/src/lib/stats/types.ts
@@ -1,10 +1,15 @@
 /**
- * 統計セクション（③選手ランキング・④大会統計）横断の共通フィルタ型。
+ * 統計セクション（③選手ランキング・④大会統計）横断の共通型と、
+ * 信頼できない入力（Server Action・searchParams）を安全な値に丸める検証関数。
+ * db を持たない純粋モジュールなのでサーバー/クライアント両方から安全に import できる。
  * requirements §3.2 / §4.2。
  */
 
 /** 級（A–E）。tournament_classes.grade（正規化値）に対応。 */
 export type Grade = 'A' | 'B' | 'C' | 'D' | 'E'
+
+/** 級の正規順（A→E）。表示・URL の安定化に使う。 */
+export const ALL_GRADES: readonly Grade[] = ['A', 'B', 'C', 'D', 'E']
 
 /**
  * 期間・級の横断フィルタ。
@@ -16,4 +21,73 @@ export interface StatsFilter {
   yearFrom?: number
   yearTo?: number
   grades?: Grade[]
+}
+
+/**
+ * ③選手ランキングの指標。requirements §3.5。
+ * - `participations` 出場回数 ／ `wins` 勝利数（normal の win）／
+ *   `winRate` 勝率（最低20試合で足切り）／ `matches` 対戦数（normal の試合数）／
+ *   `championships` 優勝回数（derived_bracket=1）／ `nyusho` 入賞回数（derived_bracket≤8）。
+ */
+export type RankingMetric =
+  | 'participations'
+  | 'wins'
+  | 'winRate'
+  | 'matches'
+  | 'championships'
+  | 'nyusho'
+
+export const RANKING_METRIC_KEYS: readonly RankingMetric[] = [
+  'participations',
+  'wins',
+  'winRate',
+  'matches',
+  'championships',
+  'nyusho',
+]
+
+/** 既定指標（不正入力のフォールバック・URL 既定）。 */
+export const DEFAULT_RANKING_METRIC: RankingMetric = 'participations'
+
+/**
+ * 未知の値を安全な RankingMetric に丸める。Server Action / searchParams のように
+ * クライアントが改変できる入力に対して、許可リスト外を既定（出場）へ落とす。
+ * これで `aggFor` が undefined を返して集計が例外化することを防ぐ。
+ */
+export function coerceRankingMetric(value: unknown): RankingMetric {
+  return typeof value === 'string' &&
+    (RANKING_METRIC_KEYS as readonly string[]).includes(value)
+    ? (value as RankingMetric)
+    : DEFAULT_RANKING_METRIC
+}
+
+/** 年として妥当（整数・現実的な範囲）な値のみ通す。他は undefined。 */
+function validYear(n: unknown): number | undefined {
+  return typeof n === 'number' && Number.isInteger(n) && n >= 1900 && n <= 3000
+    ? n
+    : undefined
+}
+
+/**
+ * StatsFilter を検証済みの安全な形に丸める：年は整数・現実範囲のみ、from>to は入替、
+ * grades は A–E の正規順のみ（enum 外・非配列は捨てる）。信頼できない入力（Server Action・
+ * searchParams 由来）を集計クエリに渡す前に必ず通す。これにより enum 外 grade や NaN 年で
+ * DB エラー（500）が出るのを防ぐ。
+ */
+export function sanitizeStatsFilter(filter: StatsFilter | null | undefined): StatsFilter {
+  const f = filter ?? {}
+  let yearFrom = validYear(f.yearFrom)
+  let yearTo = validYear(f.yearTo)
+  if (yearFrom != null && yearTo != null && yearFrom > yearTo) {
+    ;[yearFrom, yearTo] = [yearTo, yearFrom]
+  }
+  const grades = Array.isArray(f.grades)
+    ? ALL_GRADES.filter((g) => f.grades!.includes(g))
+    : []
+
+  const out: StatsFilter = {}
+  if (yearFrom != null) out.yearFrom = yearFrom
+  if (yearTo != null) out.yearTo = yearTo
+  if (grades.length > 0) out.grades = grades
+  return out
 }

--- a/apps/web/src/lib/stats/types.ts
+++ b/apps/web/src/lib/stats/types.ts
@@ -1,0 +1,19 @@
+/**
+ * 統計セクション（③選手ランキング・④大会統計）横断の共通フィルタ型。
+ * requirements §3.2 / §4.2。
+ */
+
+/** 級（A–E）。tournament_classes.grade（正規化値）に対応。 */
+export type Grade = 'A' | 'B' | 'C' | 'D' | 'E'
+
+/**
+ * 期間・級の横断フィルタ。
+ * - `yearFrom` / `yearTo`: `tournaments.event_date` の**年**で絞る（含む・両端任意）。
+ *   いずれかを指定すると event_date 無し大会は集計から除外される（日付比較が偽になるため）。
+ * - `grades`: 級（複数選択可）。**③選手ランキングのみ**で使用。④大会統計は級で絞らない。
+ */
+export interface StatsFilter {
+  yearFrom?: number
+  yearTo?: number
+  grades?: Grade[]
+}

--- a/docs/features/senseki-stats/implementation-plan.md
+++ b/docs/features/senseki-stats/implementation-plan.md
@@ -81,7 +81,7 @@ status: completed
   `ANY(ARRAY[...]::int[])`（[[feedback_drizzle_sql_int_array_binding]]）。
 
 ### タスク6: 選手ランキング 画面（PR-3）
-- [ ] 完了
+- [x] 完了
 - **概要:** `/players/ranking`。横スクロール指標チップ＋1行フィルタ（期間/級/絞り込みシート）＋順位リスト
   （TOP100＋もっと見る、行タップ→戦績詳細）。design-spec §3.1。
 - **変更対象ファイル:**

--- a/docs/features/senseki-stats/implementation-plan.md
+++ b/docs/features/senseki-stats/implementation-plan.md
@@ -70,7 +70,7 @@ status: completed
   既存 `/players`/`/players/[id]` 非退行・E2E で4セクション到達。
 
 ### タスク5: 選手ランキング クエリ（PR-3）
-- [ ] 完了
+- [x] 完了
 - **概要:** `getPlayerRanking(metric, filter, limit, offset)`。指標＝出場/勝利/勝率(最低20試合)/対戦/
   **優勝(bracket=1)**/**入賞(bracket≤8)**。期間・級フィルタ連動。同値=同順位・値降順→表示名。requirements §3.5/§4.2。
 - **変更対象ファイル:**


### PR DESCRIPTION
## Summary
senseki-stats「統計」タブ再編の **PR-3 選手ランキング**（親 #208 / 子 #213・#214）。design-spec §3.1 / requirements §3.5・§4.2。

### タスク5: `getPlayerRanking` クエリ（#213）
- 読み取り専用サーバー集計 `getPlayerRanking(metric, filter, limit, offset)` を新設（`apps/web/src/lib/stats/ranking.ts`）。
- 6指標: **出場回数 / 勝利数**(normal win) **/ 勝率**(最低20試合で足切り) **/ 対戦数**(normal) **/ 優勝回数**(derived_bracket=1) **/ 入賞回数**(derived_bracket≤8)。
- 期間(年 from–to)・級(A–E複数)フィルタ連動。year 指定時は `event_date` 無し大会を除外。優勝/入賞は PR-1 の事前計算列 `derived_bracket` を数える（§4.1）。
- 集計サブクエリ + `rank() over` で競技ランキング順位（同値=同順位・タイの次は順位を飛ばす）、`count(*) over` で該当総数、相関サブクエリで直近所属を1クエリで取得。並びは値降順→表示名→player_id（offset ページング安定化）。
- 共通フィルタ型 `StatsFilter` を `lib/stats/types.ts` に切り出し。

### タスク6: `/players/ranking` 画面（#214）
- 横スクロール指標チップ（選択中=藍bg・現在フィルタを保つ Link）。
- 1行フィルタ（期間/級サマリー＋「絞り込み」ボトムシート）→ 適用で指標を保ったまま `searchParams` 遷移。アプリ状態の単一ソースは URL。
- 見出し「指標名 ・ 全国 ・ 該当N人」。
- 順位リスト `[順位 | 氏名＋所属 | 値＋単位＋副次 | ›]`・行タップ→戦績詳細・長名省略・TOP100＋「もっと見る」（Server Action `loadMoreRanking` で追記）。
- `metrics.ts` に指標カタログ / URL 組立 / searchParams 検証（型のみ import でクライアントバンドルに db を持ち込まない）。

## Test plan
- [x] `getPlayerRanking` テスト 11 件（各指標・勝率足切り・期間/級フィルタ・同順位スキップ・ページング/total・空・所属）green
- [x] フロントテスト 25 件（metrics 12 / チップ 2 / フィルタ 5 / リスト 6）green
- [x] tsc / next lint clean
- [x] 全 web テスト 862 pass（1 skip）・リグレッションなし
- [ ] 本番反映後の実機目視（375px 縦積み・横スクロールは指標チップのみ・もっと見る・絞り込みシート）

🤖 Generated with [Claude Code](https://claude.com/claude-code)