### PR TITLE
feat(stats): 大会統計（getStatsOverview/Detail＋メイン/図詳細画面）senseki-stats PR-4

### DIFF
--- a/apps/web/e2e/senseki-stats-nav.spec.ts
+++ b/apps/web/e2e/senseki-stats-nav.spec.ts
@@ -69,12 +69,15 @@ test.describe('統計タブ 4セクションナビ（SectionTabs）', () => {
       segA.getByRole('link', { name: 'ランキング' }),
     ).toHaveAttribute('aria-current', 'page')
 
-    // → 大会統計（/tournaments/stats）
+    // → 大会統計（/tournaments/stats）：PR-4 本実装。全体サマリーの図見出しが出る
+    // （旧 scaffold の h1「大会統計」は撤去）。
     await segA.getByRole('link', { name: '大会統計' }).click()
     await expect(page).toHaveURL(/\/tournaments\/stats$/)
-    await expect(
-      page.getByRole('heading', { name: '大会統計', exact: true }),
-    ).toBeVisible()
+    await expect(page.getByRole('heading', { name: '級別構成の推移' })).toBeVisible()
+    await expect(segA.getByRole('link', { name: '大会統計' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    )
 
     // → 選手検索へ戻れる（既存検索の非退行を再確認）
     await segA.getByRole('link', { name: '選手検索' }).click()

--- a/apps/web/src/app/(app)/tournaments/stats/[metric]/page.tsx
+++ b/apps/web/src/app/(app)/tournaments/stats/[metric]/page.tsx
@@ -1,30 +1,167 @@
 import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { auth } from '@/auth'
 import { Card } from '@/components/ui'
+import { StatsPeriodFilter } from '@/components/stats/StatsPeriodFilter'
+import { BarChart } from '@/components/stats/charts/BarChart'
+import { Histogram } from '@/components/stats/charts/Histogram'
+import { denseYears, formatDecimal1, formatInt } from '@/components/stats/charts/chart-utils'
+import { getStatsDetail, type ScoreSeries, type YearSeries } from '@/lib/stats/detail'
+import { gradeTone, seriesLabel } from '@/lib/stats/grade-tones'
+import {
+  buildStatsHref,
+  coerceDetailMetric,
+  detailMetricTitle,
+  parsePeriodParams,
+} from '../params'
+
+export const dynamic = 'force-dynamic'
+
+const MIN_YEAR = 2010
 
 /**
- * /tournaments/stats/[metric] — 大会統計の図詳細（級別比較スモールマルチプル）。
- * metric = score / competitors / participations。プッシュ表示のため SectionTabs は
- * 出さず戻る導線のみ。senseki-stats PR-4 で実装予定。
+ * /tournaments/stats/[metric] — ④ 大会統計・図詳細（級別比較）。requirements §3.6・design-spec §3.3。
+ *
+ * 全級（参照）＋各級（A〜E）を**縦スモールマルチプル**で並べる。縦軸は形状比較のため図ごと
+ * 個別正規化（各ミニ図が自分の最大でスケール）。metric = score / competitors / participations。
+ * プッシュ表示のため SectionTabs は出さず戻る導線のみ。期間フィルタは有効（級では絞らない）。
  */
 export default async function StatsDetailPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ metric: string }>
+  searchParams: Promise<Record<string, string | string[] | undefined>>
 }) {
-  const { metric } = await params
+  const session = await auth()
+  if (!session) redirect('/auth/signin')
+
+  const { metric: rawMetric } = await params
+  const metric = coerceDetailMetric(rawMetric)
+  const filter = parsePeriodParams(await searchParams)
+  const detail = await getStatsDetail(metric, filter)
+  const title = detailMetricTitle(metric)
+
+  const currentYear = new Date().getFullYear()
+  const years: number[] = []
+  for (let y = Math.max(currentYear, MIN_YEAR); y >= MIN_YEAR; y--) years.push(y)
+
   return (
     <div className="flex flex-col gap-4 p-4">
-      <Link href="/tournaments/stats" className="text-sm text-brand">
+      <Link href={buildStatsHref('/tournaments/stats', filter)} className="text-sm text-brand">
         ‹ 大会統計へ戻る
       </Link>
-      <h1 className="font-display text-xl font-bold text-ink">
-        級別比較（{metric}）
-      </h1>
-      <Card>
-        <p className="py-10 text-center text-sm text-ink-meta">
-          「{metric}」の級別比較は準備中です（PR-4 で実装）。
-        </p>
-      </Card>
+      <h1 className="font-display text-xl font-bold text-ink">{title}｜級別比較</h1>
+
+      <StatsPeriodFilter basePath={`/tournaments/stats/${metric}`} filter={filter} years={years} />
+
+      <p className="text-xs text-ink-meta">
+        全級（参照）と各級（A〜E）を並べて比較します。縦軸は形状比較のため図ごとに個別正規化しています。
+      </p>
+
+      <div className="flex flex-col gap-3">
+        {detail.metric === 'score'
+          ? detail.series.map((s) => <ScorePanel key={s.key} series={s} />)
+          : renderYearPanels(detail.series, detail.metric)}
+      </div>
     </div>
+  )
+}
+
+/** competitors / participations：全系列の x（年）を揃えるため 'all' から年域を取り 0 埋め。 */
+function renderYearPanels(series: YearSeries[], unit: 'competitors' | 'participations') {
+  const allPoints = series.find((s) => s.key === 'all')?.points ?? []
+  const lo = allPoints.length ? Math.min(...allPoints.map((p) => p.year)) : undefined
+  const hi = allPoints.length ? Math.max(...allPoints.map((p) => p.year)) : undefined
+  return series.map((s) => <YearPanel key={s.key} series={s} lo={lo} hi={hi} unit={unit} />)
+}
+
+/** 系列スウォッチ＋ラベル＋見出し数値（serif藍）の共通ヘッダ。 */
+function PanelHeader({
+  tone,
+  label,
+  headline,
+  sub,
+}: {
+  tone: string
+  label: string
+  headline: string
+  sub?: string
+}) {
+  return (
+    <div className="flex items-baseline gap-2">
+      <span
+        aria-hidden
+        className="inline-block h-3 w-3 shrink-0 translate-y-0.5 rounded-[2px]"
+        style={{ backgroundColor: tone }}
+      />
+      <span className="text-sm font-medium text-ink">{label}</span>
+      <span className="ml-auto font-display text-base font-bold text-brand tabular-nums">
+        {headline}
+      </span>
+      {sub ? <span className="text-[11px] text-ink-meta">{sub}</span> : null}
+    </div>
+  )
+}
+
+/** score 詳細の 1 パネル（枚数差ヒスト・個別正規化・平均線）。 */
+function ScorePanel({ series }: { series: ScoreSeries }) {
+  const total = series.bins.reduce((s, v) => s + v, 0)
+  const tone = gradeTone(series.key)
+  return (
+    <Card className="flex flex-col gap-1.5">
+      <PanelHeader
+        tone={tone}
+        label={seriesLabel(series.key)}
+        headline={`平均 ${formatDecimal1(series.average)} 枚`}
+        sub={`${formatInt(total)}試合`}
+      />
+      <Histogram
+        bins={series.bins}
+        average={series.average}
+        color={tone}
+        height={120}
+        showAverageLabel={false}
+        ariaLabel={`${seriesLabel(series.key)}の枚数差ヒストグラム`}
+      />
+    </Card>
+  )
+}
+
+/** competitors / participations 詳細の 1 パネル（年推移・個別正規化）。 */
+function YearPanel({
+  series,
+  lo,
+  hi,
+  unit,
+}: {
+  series: YearSeries
+  lo?: number
+  hi?: number
+  unit: 'competitors' | 'participations'
+}) {
+  const data = denseYears(series.points, lo, hi)
+  const dataYears = series.points.filter((p) => p.count > 0)
+  const mean =
+    dataYears.length > 0
+      ? dataYears.reduce((s, p) => s + p.count, 0) / dataYears.length
+      : 0
+  const tone = gradeTone(series.key)
+  const unitLabel = unit === 'competitors' ? '人/年' : '/年'
+  return (
+    <Card className="flex flex-col gap-1.5">
+      <PanelHeader
+        tone={tone}
+        label={seriesLabel(series.key)}
+        headline={`平均 ${formatInt(mean)}`}
+        sub={unitLabel}
+      />
+      <BarChart
+        data={data}
+        color={tone}
+        height={120}
+        ariaLabel={`${seriesLabel(series.key)}の年推移`}
+      />
+    </Card>
   )
 }

--- a/apps/web/src/app/(app)/tournaments/stats/[metric]/page.tsx
+++ b/apps/web/src/app/(app)/tournaments/stats/[metric]/page.tsx
@@ -39,6 +39,12 @@ export default async function StatsDetailPage({
   const { metric: rawMetric } = await params
   const metric = coerceDetailMetric(rawMetric)
   const filter = parsePeriodParams(await searchParams)
+  // 不正な metric セグメント（例 /tournaments/stats/bogus）は canonical URL へ正規化
+  // リダイレクトする。丸めた metric（score）で表示だけ差し替えると URL が /bogus のまま残り、
+  // 戻る導線・期間フィルタ（basePath=canonical）と現在パスが食い違うため（Codex R1 blocker）。
+  if (rawMetric !== metric) {
+    redirect(buildStatsHref(`/tournaments/stats/${metric}`, filter))
+  }
   const detail = await getStatsDetail(metric, filter)
   const title = detailMetricTitle(metric)
 

--- a/apps/web/src/app/(app)/tournaments/stats/page.tsx
+++ b/apps/web/src/app/(app)/tournaments/stats/page.tsx
@@ -1,22 +1,157 @@
+import type { ReactNode } from 'react'
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { auth } from '@/auth'
 import { SectionTabs } from '@/components/stats/section-tabs'
 import { Card } from '@/components/ui'
+import { StatsPeriodFilter } from '@/components/stats/StatsPeriodFilter'
+import { BarChart } from '@/components/stats/charts/BarChart'
+import { Histogram } from '@/components/stats/charts/Histogram'
+import { GradeLegend, StackedComposition } from '@/components/stats/charts/StackedComposition'
+import { denseYears, formatDecimal1, formatInt } from '@/components/stats/charts/chart-utils'
+import { getStatsOverview } from '@/lib/stats/overview'
+import { GRADE_TONES } from '@/lib/stats/grade-tones'
+import { detailHref, parsePeriodParams } from './params'
+
+export const dynamic = 'force-dynamic'
+
+/** 収録開始年（design-spec §3.2「収録開始2010」）。期間セレクトの下限。 */
+const MIN_YEAR = 2010
 
 /**
- * /tournaments/stats — ④ 大会統計・全体サマリー（統計）。senseki-stats PR-4 で
- * 実装予定。PR-2（ナビ）では 4 セクションシェル配下のプレースホルダ scaffold。
+ * /tournaments/stats — ④ 大会統計・全体サマリー（統計）。requirements §3.6・design-spec §3.2。
+ *
+ * 4 カード＋6 図。全級固定・**期間フィルタのみ**（級は絞り込みでなく比較軸）。図 1〜3 はこの
+ * 画面で完結（詳細なし）、図 4〜6 は右上「級別比較 ›」で `/tournaments/stats/<metric>` へドリル。
+ * 朱はデータ装飾に使わない（正の強調＝藍・平均線＝中立インク）。
  */
-export default function TournamentStatsPage() {
+export default async function TournamentStatsPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}) {
+  const session = await auth()
+  if (!session) redirect('/auth/signin')
+
+  const filter = parsePeriodParams(await searchParams)
+  const ov = await getStatsOverview(filter)
+
+  const currentYear = new Date().getFullYear()
+  const years: number[] = []
+  for (let y = Math.max(currentYear, MIN_YEAR); y >= MIN_YEAR; y--) years.push(y)
+
+  // 図データ：年推移は連続年で 0 埋め・級別は級トーンで着色。
+  const newcomers = denseYears(ov.newcomers)
+  const competitors = denseYears(ov.competitorsByYear)
+  const participations = denseYears(ov.participationsByYear)
+  const perPlayerAvg = ov.perPlayerAvg.map((g) => ({
+    label: `${g.grade}級`,
+    value: g.avg,
+    color: GRADE_TONES[g.grade],
+  }))
+
   return (
     <div>
       <SectionTabs />
       <div className="flex flex-col gap-4 p-4">
-        <h1 className="font-display text-xl font-bold text-ink">大会統計</h1>
-        <Card>
-          <p className="py-10 text-center text-sm text-ink-meta">
-            大会統計（全体サマリー）は準備中です（PR-4 で実装）。
-          </p>
-        </Card>
+        <StatsPeriodFilter basePath="/tournaments/stats" filter={filter} years={years} />
+
+        {/* 絶対数カード（大会数／対戦数／競技人口／延べ参加） */}
+        <div className="grid grid-cols-2 gap-3">
+          <StatCard label="大会数" value={ov.totals.tournaments} />
+          <StatCard label="対戦数" value={ov.totals.matches} />
+          <StatCard label="競技人口" value={ov.totals.competitors} unit="人" />
+          <StatCard label="延べ参加" value={ov.totals.participations} unit="人" />
+        </div>
+
+        {/* 図1：級別構成の推移（完結） */}
+        <ChartCard title="級別構成の推移" note="各年を100%に正規化（A〜E）">
+          <StackedComposition data={ov.gradeComposition} ariaLabel="級別構成の推移（100%積み上げ）" />
+          <GradeLegend className="mt-2 flex flex-wrap gap-x-3 gap-y-1" />
+        </ChartCard>
+
+        {/* 図2：新規参入者（完結） */}
+        <ChartCard
+          title="新規参入者の推移"
+          note="初出場年別・2011〜（収録開始2010は既存選手を含むため除外）"
+        >
+          <BarChart data={newcomers} ariaLabel="新規参入者の推移（初出場年別）" />
+        </ChartCard>
+
+        {/* 図3：一人当たり 平均年参加数（x=級・完結） */}
+        <ChartCard title="一人当たり 平均年参加数" note="級別・大会/年">
+          <BarChart
+            data={perPlayerAvg}
+            ariaLabel="一人当たり 平均年参加数（級別）"
+            valueFormat={formatDecimal1}
+          />
+        </ChartCard>
+
+        {/* 図4：スコア統計（ドリル） */}
+        <ChartCard title="スコア統計" note="枚数差の分布（1〜25枚・平均線）" drill={detailHref('score', filter)}>
+          <Histogram
+            bins={ov.scoreHistogram.bins}
+            average={ov.scoreHistogram.average}
+            ariaLabel="スコア統計（枚数差ヒストグラム）"
+          />
+        </ChartCard>
+
+        {/* 図5：年別 競技人口（ドリル） */}
+        <ChartCard title="年別 競技人口" note="各年のユニーク選手数" drill={detailHref('competitors', filter)}>
+          <BarChart data={competitors} ariaLabel="年別 競技人口の推移" />
+        </ChartCard>
+
+        {/* 図6：年別 大会参加人数（ドリル） */}
+        <ChartCard
+          title="年別 大会参加人数"
+          note="各年の延べ参加"
+          drill={detailHref('participations', filter)}
+        >
+          <BarChart data={participations} ariaLabel="年別 大会参加人数の推移" />
+        </ChartCard>
       </div>
     </div>
+  )
+}
+
+/** 絶対数カード。数値は serif（design-spec §8：大きい数字は Noto Serif JP）。 */
+function StatCard({ label, value, unit }: { label: string; value: number; unit?: string }) {
+  return (
+    <Card className="flex flex-col gap-1">
+      <span className="text-xs text-ink-meta">{label}</span>
+      <span className="font-display text-2xl font-bold text-ink tabular-nums">
+        {formatInt(value)}
+        {unit ? <span className="ml-0.5 text-sm font-normal text-ink-meta">{unit}</span> : null}
+      </span>
+    </Card>
+  )
+}
+
+/** 図カード（見出し＋任意の注記／ドリルリンク＋本体）。 */
+function ChartCard({
+  title,
+  note,
+  drill,
+  children,
+}: {
+  title: string
+  note?: string
+  /** 「級別比較 ›」ドリル先（図 4〜6 のみ）。 */
+  drill?: string
+  children: ReactNode
+}) {
+  return (
+    <Card className="flex flex-col gap-2">
+      <div className="flex items-baseline justify-between gap-2">
+        <h2 className="font-display text-base font-bold text-ink">{title}</h2>
+        {drill ? (
+          <Link href={drill} className="shrink-0 text-xs font-medium text-brand">
+            級別比較 ›
+          </Link>
+        ) : null}
+      </div>
+      {note ? <p className="text-[11px] text-ink-meta">{note}</p> : null}
+      {children}
+    </Card>
   )
 }

--- a/apps/web/src/app/(app)/tournaments/stats/params.test.ts
+++ b/apps/web/src/app/(app)/tournaments/stats/params.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildStatsHref,
+  coerceDetailMetric,
+  detailHref,
+  detailMetricTitle,
+  parsePeriodParams,
+} from './params'
+
+describe('parsePeriodParams', () => {
+  it('yearFrom/yearTo を数値化（配列は先頭）', () => {
+    expect(parsePeriodParams({ yearFrom: '2015', yearTo: '2020' })).toEqual({
+      yearFrom: 2015,
+      yearTo: 2020,
+    })
+    expect(parsePeriodParams({ yearFrom: ['2018', '2019'] })).toEqual({ yearFrom: 2018 })
+  })
+
+  it('不正年は捨て・from>to は入替', () => {
+    expect(parsePeriodParams({ yearFrom: 'x', yearTo: '2020' })).toEqual({ yearTo: 2020 })
+    expect(parsePeriodParams({ yearFrom: '2020', yearTo: '2015' })).toEqual({
+      yearFrom: 2015,
+      yearTo: 2020,
+    })
+    expect(parsePeriodParams({})).toEqual({})
+  })
+})
+
+describe('buildStatsHref / detailHref', () => {
+  it('期間を付ける（無指定は base のまま）', () => {
+    expect(buildStatsHref('/tournaments/stats', {})).toBe('/tournaments/stats')
+    expect(buildStatsHref('/tournaments/stats', { yearFrom: 2015 })).toBe(
+      '/tournaments/stats?yearFrom=2015',
+    )
+    expect(buildStatsHref('/tournaments/stats', { yearFrom: 2015, yearTo: 2020 })).toBe(
+      '/tournaments/stats?yearFrom=2015&yearTo=2020',
+    )
+  })
+
+  it('detailHref は metric セグメント＋期間', () => {
+    expect(detailHref('score', {})).toBe('/tournaments/stats/score')
+    expect(detailHref('competitors', { yearFrom: 2015 })).toBe(
+      '/tournaments/stats/competitors?yearFrom=2015',
+    )
+  })
+})
+
+describe('detailMetricTitle / coerceDetailMetric', () => {
+  it('指標のタイトル', () => {
+    expect(detailMetricTitle('score')).toBe('スコア統計')
+    expect(detailMetricTitle('competitors')).toBe('年別 競技人口')
+    expect(detailMetricTitle('participations')).toBe('年別 大会参加人数')
+  })
+
+  it('coerceDetailMetric を再エクスポートしている', () => {
+    expect(coerceDetailMetric('participations')).toBe('participations')
+    expect(coerceDetailMetric('bogus')).toBe('score')
+  })
+})

--- a/apps/web/src/app/(app)/tournaments/stats/params.ts
+++ b/apps/web/src/app/(app)/tournaments/stats/params.ts
@@ -1,0 +1,67 @@
+import {
+  coerceDetailMetric,
+  sanitizeStatsFilter,
+  type DetailMetric,
+  type StatsFilter,
+} from '@/lib/stats/types'
+
+/**
+ * ④大会統計（`/tournaments/stats` とその図詳細）の searchParams ⇔ フィルタ変換とリンク
+ * 組み立て。大会統計は**期間フィルタのみ**（級では絞らない）なので year だけを扱う。純関数の
+ * ため client/server 双方から import 可。`coerceDetailMetric` も再エクスポートして
+ * ページ側の import を 1 箇所に集約する。
+ */
+export { coerceDetailMetric }
+
+type RawParam = string | string[] | undefined
+
+function firstParam(v: RawParam): string | undefined {
+  return Array.isArray(v) ? v[0] : v
+}
+
+/**
+ * 期間 searchParams（yearFrom/yearTo）を検証済み StatsFilter に。配列/単値の両方を安全に
+ * 丸め、`sanitizeStatsFilter` で妥当な年のみ採用（不正は捨てる・from>to は入替）。級は扱わない。
+ */
+export function parsePeriodParams(sp: {
+  yearFrom?: RawParam
+  yearTo?: RawParam
+}): StatsFilter {
+  const candidate: StatsFilter = {}
+  const yf = firstParam(sp.yearFrom)
+  const yt = firstParam(sp.yearTo)
+  if (yf != null) candidate.yearFrom = Number(yf)
+  if (yt != null) candidate.yearTo = Number(yt)
+  return sanitizeStatsFilter(candidate)
+}
+
+/** base（`/tournaments/stats` 等）に期間フィルタを付けた href（既定値は省略）。 */
+export function buildStatsHref(base: string, filter: StatsFilter): string {
+  const params = new URLSearchParams()
+  if (filter.yearFrom != null) params.set('yearFrom', String(filter.yearFrom))
+  if (filter.yearTo != null) params.set('yearTo', String(filter.yearTo))
+  const qs = params.toString()
+  return qs ? `${base}?${qs}` : base
+}
+
+/** 図詳細の指標カタログ（タイトル・ドリル対象）。 */
+export interface DetailMetricDef {
+  key: DetailMetric
+  /** メイン画面のカード見出し＝詳細画面のタイトル。 */
+  title: string
+}
+
+export const DETAIL_METRICS: readonly DetailMetricDef[] = [
+  { key: 'score', title: 'スコア統計' },
+  { key: 'competitors', title: '年別 競技人口' },
+  { key: 'participations', title: '年別 大会参加人数' },
+]
+
+export function detailMetricTitle(metric: DetailMetric): string {
+  return DETAIL_METRICS.find((m) => m.key === metric)?.title ?? DETAIL_METRICS[0]!.title
+}
+
+/** 詳細ドリルの href（メインの図 4〜6 の「級別比較 ›」）。 */
+export function detailHref(metric: DetailMetric, filter: StatsFilter): string {
+  return buildStatsHref(`/tournaments/stats/${metric}`, filter)
+}

--- a/apps/web/src/components/stats/StatsPeriodFilter.test.tsx
+++ b/apps/web/src/components/stats/StatsPeriodFilter.test.tsx
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { StatsPeriodFilter } from './StatsPeriodFilter'
+
+const push = vi.fn()
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push }) }))
+
+const years = [2026, 2025, 2024, 2023, 2022, 2021, 2020, 2015]
+
+beforeEach(() => push.mockReset())
+
+describe('StatsPeriodFilter', () => {
+  it('フィルタ無しは「全期間」・シートは閉じている', () => {
+    render(<StatsPeriodFilter basePath="/tournaments/stats" filter={{}} years={years} />)
+    expect(screen.getByText('全期間')).toBeTruthy()
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('期間サマリーを反映', () => {
+    render(
+      <StatsPeriodFilter
+        basePath="/tournaments/stats"
+        filter={{ yearFrom: 2015, yearTo: 2020 }}
+        years={years}
+      />,
+    )
+    expect(screen.getByText('2015〜2020')).toBeTruthy()
+  })
+
+  it('絞り込み→適用で basePath へ期間付き遷移（級は付かない）', () => {
+    render(<StatsPeriodFilter basePath="/tournaments/stats/score" filter={{}} years={years} />)
+    fireEvent.click(screen.getByRole('button', { name: '絞り込み' }))
+    expect(screen.getByRole('dialog', { name: '期間で絞り込み' })).toBeTruthy()
+
+    fireEvent.change(screen.getByLabelText('開始年'), { target: { value: '2020' } })
+    fireEvent.change(screen.getByLabelText('終了年'), { target: { value: '2026' } })
+    fireEvent.click(screen.getByRole('button', { name: '適用' }))
+
+    expect(push).toHaveBeenCalledWith('/tournaments/stats/score?yearFrom=2020&yearTo=2026')
+  })
+
+  it('クリアで basePath へ（期間なし）', () => {
+    render(
+      <StatsPeriodFilter
+        basePath="/tournaments/stats"
+        filter={{ yearFrom: 2015 }}
+        years={years}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: '絞り込み' }))
+    fireEvent.click(screen.getByRole('button', { name: 'クリア' }))
+    expect(push).toHaveBeenCalledWith('/tournaments/stats')
+  })
+})

--- a/apps/web/src/components/stats/StatsPeriodFilter.tsx
+++ b/apps/web/src/components/stats/StatsPeriodFilter.tsx
@@ -1,0 +1,168 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import type { StatsFilter } from '@/lib/stats/types'
+import { buildStatsHref } from '@/app/(app)/tournaments/stats/params'
+
+function periodLabel(filter: StatsFilter): string {
+  const { yearFrom, yearTo } = filter
+  if (yearFrom != null && yearTo != null) {
+    return yearFrom === yearTo ? `${yearFrom}` : `${yearFrom}〜${yearTo}`
+  }
+  if (yearFrom != null) return `${yearFrom}〜`
+  if (yearTo != null) return `〜${yearTo}`
+  return '全期間'
+}
+
+/**
+ * ④大会統計の 1 行期間フィルタ（design-spec §3.2 / §3.3）。大会統計は**級では絞らない**ので
+ * 期間（年 from–to）だけを持つ（ランキングの `RankingFilterBar` の period 専用版）。適用/クリアは
+ * `basePath` への URL 遷移＝サーバー再集計に委ね、状態の単一ソースは searchParams。
+ * `basePath` を受けるのでメイン（`/tournaments/stats`）と各図詳細
+ * （`/tournaments/stats/<metric>`）の両方で同じ部品を使える。
+ */
+export function StatsPeriodFilter({
+  basePath,
+  filter,
+  years,
+}: {
+  basePath: string
+  filter: StatsFilter
+  /** 期間セレクトの候補（降順・収録開始〜当年）。 */
+  years: number[]
+}) {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [draftFrom, setDraftFrom] = useState<number | undefined>(filter.yearFrom)
+  const [draftTo, setDraftTo] = useState<number | undefined>(filter.yearTo)
+
+  useEffect(() => {
+    if (open) {
+      setDraftFrom(filter.yearFrom)
+      setDraftTo(filter.yearTo)
+    }
+  }, [open, filter.yearFrom, filter.yearTo])
+
+  useEffect(() => {
+    if (!open) return
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [open])
+
+  const apply = () => {
+    const next: StatsFilter = {}
+    if (draftFrom != null) next.yearFrom = draftFrom
+    if (draftTo != null) next.yearTo = draftTo
+    setOpen(false)
+    router.push(buildStatsHref(basePath, next))
+  }
+
+  const clear = () => {
+    setOpen(false)
+    router.push(buildStatsHref(basePath, {}))
+  }
+
+  return (
+    <>
+      <div className="flex items-center gap-3 text-[13px] text-ink-meta">
+        <span>
+          期間 <span className="text-ink">{periodLabel(filter)}</span>
+        </span>
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          aria-haspopup="dialog"
+          aria-expanded={open}
+          className="ml-auto rounded-full border border-border px-3 py-1 font-medium text-brand hover:bg-brand-bg"
+        >
+          絞り込み
+        </button>
+      </div>
+
+      {open ? (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="期間で絞り込み"
+          className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 sm:items-center"
+          onClick={() => setOpen(false)}
+        >
+          <div
+            className="flex w-full flex-col gap-4 rounded-t-2xl bg-surface p-4 pb-[calc(1rem_+_env(safe-area-inset-bottom))] sm:max-w-md sm:rounded-2xl sm:pb-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <header className="flex items-center justify-between">
+              <h2 className="text-base font-semibold text-ink">期間で絞り込み</h2>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                aria-label="閉じる"
+                className="text-xl leading-none text-ink-meta hover:text-ink"
+              >
+                ×
+              </button>
+            </header>
+
+            <section className="flex flex-col gap-2">
+              <h3 className="text-xs font-medium text-ink-meta">期間（年）</h3>
+              <div className="flex items-center gap-2">
+                <select
+                  aria-label="開始年"
+                  value={draftFrom ?? ''}
+                  onChange={(e) =>
+                    setDraftFrom(e.target.value ? Number(e.target.value) : undefined)
+                  }
+                  className="min-w-0 flex-1 rounded border border-border bg-surface p-2 text-sm text-ink"
+                >
+                  <option value="">指定なし</option>
+                  {years.map((y) => (
+                    <option key={y} value={y}>
+                      {y}
+                    </option>
+                  ))}
+                </select>
+                <span className="text-ink-meta">〜</span>
+                <select
+                  aria-label="終了年"
+                  value={draftTo ?? ''}
+                  onChange={(e) =>
+                    setDraftTo(e.target.value ? Number(e.target.value) : undefined)
+                  }
+                  className="min-w-0 flex-1 rounded border border-border bg-surface p-2 text-sm text-ink"
+                >
+                  <option value="">指定なし</option>
+                  {years.map((y) => (
+                    <option key={y} value={y}>
+                      {y}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </section>
+
+            <div className="mt-1 flex items-center gap-2">
+              <button
+                type="button"
+                onClick={clear}
+                className="rounded-lg px-4 py-2 text-sm font-medium text-ink-meta hover:bg-surface-alt"
+              >
+                クリア
+              </button>
+              <button
+                type="button"
+                onClick={apply}
+                className="ml-auto rounded-lg bg-brand px-5 py-2 text-sm font-semibold text-white hover:bg-brand-hover"
+              >
+                適用
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/apps/web/src/components/stats/charts/BarChart.test.tsx
+++ b/apps/web/src/components/stats/charts/BarChart.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { BarChart } from './BarChart'
+
+describe('BarChart', () => {
+  const data = [
+    { label: '2018', value: 3 },
+    { label: '2019', value: 5 },
+    { label: '2020', value: 1 },
+  ]
+
+  it('データ数だけ棒を描き aria-label を持つ', () => {
+    const { container } = render(<BarChart data={data} ariaLabel="年推移" />)
+    expect(screen.getByRole('img', { name: '年推移' })).toBeTruthy()
+    expect(container.querySelectorAll('rect')).toHaveLength(3)
+  })
+
+  it('本数が少なければ値ラベル（font-display）を各棒に出す', () => {
+    const { container } = render(<BarChart data={data} ariaLabel="年推移" />)
+    // 値ラベルは font-display の text（y 目盛は fill-ink-muted で別）。
+    const valueLabels = [...container.querySelectorAll('text.font-display')].map(
+      (t) => t.textContent,
+    )
+    expect(valueLabels).toEqual(['3', '5', '1'])
+  })
+
+  it('指定色で棒を塗る（既定は藍・朱はデータ装飾に使わない）', () => {
+    const { container } = render(
+      <BarChart data={data} color="#123456" ariaLabel="年推移" />,
+    )
+    const rects = [...container.querySelectorAll('rect')]
+    expect(rects.every((r) => r.getAttribute('fill') === '#123456')).toBe(true)
+    // 朱（accent）を含まない
+    expect(container.innerHTML).not.toContain('#b33c2d')
+    expect(container.innerHTML).not.toContain('accent')
+  })
+
+  it('valueFormat を値ラベルと y 目盛に適用（小数）', () => {
+    render(
+      <BarChart
+        data={[{ label: 'A級', value: 1.5 }]}
+        ariaLabel="平均"
+        valueFormat={(n) => n.toFixed(1)}
+      />,
+    )
+    expect(screen.getByText('1.5')).toBeTruthy()
+  })
+})

--- a/apps/web/src/components/stats/charts/BarChart.tsx
+++ b/apps/web/src/components/stats/charts/BarChart.tsx
@@ -1,0 +1,127 @@
+import { axisTicks, formatCompact, niceMax, type LabeledValue } from './chart-utils'
+
+export interface BarDatum extends LabeledValue {
+  /** 棒ごとの色（級別トーン等）。無指定なら chart の color。 */
+  color?: string
+}
+
+export interface BarChartProps {
+  data: BarDatum[]
+  /** 既定の棒色（design-spec §8：正の強調＝藍。朱はデータ装飾に使わない）。 */
+  color?: string
+  /** viewBox 高さ（既定 160）。幅は 320 固定で親幅にスケール。 */
+  height?: number
+  /** スクリーンリーダー用の説明（必須）。 */
+  ariaLabel: string
+  /** 値ラベルの整形（既定 formatCompact）。 */
+  valueFormat?: (n: number) => string
+  className?: string
+}
+
+const VW = 320
+const PL = 32 // y 目盛ラベル幅
+const PR = 6
+const PT = 14 // 値ラベル余白
+const PB = 22 // x ラベル余白
+
+/**
+ * 縦棒グラフ（y 軸目盛線＋値ラベル）。design-spec §3.2「全棒グラフに y軸目盛線＋値ラベル」。
+ * 純粋な SVG コンポーネント（フックなし＝サーバー描画・jsdom テスト可）。棒色は既定で藍
+ * （朱はデータ装飾に使わない）。x が密なとき（>12 本）は x ラベルを間引き、棒スロットが
+ * 狭いとき（<16u）は値ラベルを省いて重なりを避ける（y 目盛で桁は読める）。
+ */
+export function BarChart({
+  data,
+  color = 'var(--color-brand)',
+  height = 160,
+  ariaLabel,
+  valueFormat = formatCompact,
+  className,
+}: BarChartProps) {
+  const plotW = VW - PL - PR
+  const plotH = height - PT - PB
+  const maxVal = data.reduce((m, d) => Math.max(m, d.value), 0)
+  const top = niceMax(maxVal)
+  const ticks = axisTicks(maxVal)
+
+  const yOf = (v: number) => PT + (1 - v / top) * plotH
+  const baseY = yOf(0)
+
+  const n = data.length
+  const slot = n > 0 ? plotW / n : plotW
+  const barW = Math.min(slot * 0.62, 22)
+  const showValueLabels = slot >= 16
+  const xEvery = n > 12 ? 2 : 1
+
+  return (
+    <svg
+      viewBox={`0 0 ${VW} ${height}`}
+      role="img"
+      aria-label={ariaLabel}
+      className={className}
+      style={{ width: '100%', height: 'auto' }}
+    >
+      {/* y 目盛線＋ラベル */}
+      {ticks.map((t, i) => {
+        const y = yOf(t)
+        return (
+          <g key={`t${i}`}>
+            <line
+              x1={PL}
+              y1={y}
+              x2={VW - PR}
+              y2={y}
+              className="stroke-border"
+              strokeWidth={0.5}
+            />
+            <text
+              x={PL - 3}
+              y={y + 3}
+              textAnchor="end"
+              className="fill-ink-muted"
+              fontSize={8}
+            >
+              {valueFormat(t)}
+            </text>
+          </g>
+        )
+      })}
+
+      {/* 棒＋値ラベル＋x ラベル */}
+      {data.map((d, i) => {
+        const x = PL + slot * i + (slot - barW) / 2
+        const y = yOf(d.value)
+        const h = Math.max(0, baseY - y)
+        const cx = PL + slot * i + slot / 2
+        const showX = i % xEvery === 0 || i === n - 1
+        return (
+          <g key={`b${i}`}>
+            <rect x={x} y={y} width={barW} height={h} rx={1} fill={d.color ?? color} />
+            {showValueLabels && d.value > 0 ? (
+              <text
+                x={cx}
+                y={y - 2}
+                textAnchor="middle"
+                className="fill-ink-meta font-display"
+                fontSize={7.5}
+              >
+                {valueFormat(d.value)}
+              </text>
+            ) : null}
+            {showX ? (
+              <text
+                x={cx}
+                y={height - 7}
+                textAnchor="middle"
+                className="fill-ink-muted"
+                fontSize={8}
+              >
+                {d.label}
+              </text>
+            ) : null}
+          </g>
+        )
+      })}
+    </svg>
+  )
+}

--- a/apps/web/src/components/stats/charts/Histogram.test.tsx
+++ b/apps/web/src/components/stats/charts/Histogram.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Histogram } from './Histogram'
+
+function bins25(): number[] {
+  const b = new Array<number>(25).fill(0)
+  b[4] = 10 // 5 枚差
+  b[7] = 4 // 8 枚差
+  return b
+}
+
+describe('Histogram', () => {
+  it('25 本の棒と x 目盛（1・5・…・25）を描く', () => {
+    const { container } = render(
+      <Histogram bins={bins25()} average={6} ariaLabel="枚数差ヒスト" />,
+    )
+    expect(screen.getByRole('img', { name: '枚数差ヒスト' })).toBeTruthy()
+    expect(container.querySelectorAll('rect')).toHaveLength(25)
+    // y 目盛（0,2,4,6,8,10）と衝突しない x 目盛だけを検証する。
+    const texts = [...container.querySelectorAll('text')].map((t) => t.textContent)
+    for (const t of ['1', '5', '15', '20', '25']) {
+      expect(texts).toContain(t)
+    }
+  })
+
+  it('平均線は中立インクの破線（朱不使用）', () => {
+    const { container } = render(
+      <Histogram bins={bins25()} average={6} ariaLabel="枚数差ヒスト" />,
+    )
+    const dashed = container.querySelector('line[stroke-dasharray]')
+    expect(dashed).not.toBeNull()
+    expect(dashed!.getAttribute('class') ?? '').toContain('neutral')
+    expect(container.innerHTML).not.toContain('#b33c2d')
+    expect(container.innerHTML).not.toContain('accent')
+  })
+
+  it('showAverageLabel=true で平均ラベル（単一 text）を出す', () => {
+    const { container } = render(<Histogram bins={bins25()} average={6.3} ariaLabel="h" />)
+    const texts = [...container.querySelectorAll('text')].map((t) => t.textContent)
+    expect(texts).toContain('平均 6.3')
+  })
+
+  it('showAverageLabel=false で平均ラベルを出さない', () => {
+    const { container } = render(
+      <Histogram bins={bins25()} average={6.3} ariaLabel="h2" showAverageLabel={false} />,
+    )
+    const hasAvg = [...container.querySelectorAll('text')].some((t) =>
+      t.textContent?.includes('平均'),
+    )
+    expect(hasAvg).toBe(false)
+  })
+
+  it('average=0 なら平均線を出さない', () => {
+    const { container } = render(
+      <Histogram bins={new Array(25).fill(0)} average={0} ariaLabel="空" />,
+    )
+    expect(container.querySelector('line[stroke-dasharray]')).toBeNull()
+  })
+})

--- a/apps/web/src/components/stats/charts/Histogram.tsx
+++ b/apps/web/src/components/stats/charts/Histogram.tsx
@@ -1,0 +1,145 @@
+import { axisTicks, formatCompact, formatDecimal1, niceMax } from './chart-utils'
+
+export interface HistogramProps {
+  /** 枚数差ヒスト（length 25：index i＝枚数差 i+1 の試合数）。 */
+  bins: number[]
+  /** 平均枚数差（破線マーカー）。 */
+  average: number
+  /** 棒色（既定 藍）。 */
+  color?: string
+  height?: number
+  ariaLabel: string
+  className?: string
+  /** 平均ラベル「平均 N.N」を線の上に出す（既定 true）。 */
+  showAverageLabel?: boolean
+}
+
+const VW = 320
+const PL = 32
+const PR = 6
+const PT = 14
+const PB = 20
+/** x 軸ラベルを出す枚数差（1・5・10・15・20・25）。 */
+const X_TICKS = [1, 5, 10, 15, 20, 25]
+
+/**
+ * 枚数差ヒストグラム（25 本）＋平均線。design-spec §3.2 / §3.3。
+ * 平均マーカーは **中立インクの破線**（朱不使用・design-spec §8 / R2）、平均の数値ラベルは藍。
+ * 純粋 SVG（フックなし）。棒が密（25 本）なので値ラベルは出さず y 目盛で桁を読む。
+ */
+export function Histogram({
+  bins,
+  average,
+  color = 'var(--color-brand)',
+  height = 150,
+  ariaLabel,
+  className,
+  showAverageLabel = true,
+}: HistogramProps) {
+  const plotW = VW - PL - PR
+  const plotH = height - PT - PB
+  const maxVal = bins.reduce((m, v) => Math.max(m, v), 0)
+  const top = niceMax(maxVal)
+  const ticks = axisTicks(maxVal)
+
+  const yOf = (v: number) => PT + (1 - v / top) * plotH
+  const baseY = yOf(0)
+  const n = bins.length // 25
+  const slot = plotW / n
+  const barW = slot * 0.72
+
+  // 枚数差 d(=1..25) の棒中心 x。連続平均も同じ写像で位置付ける。
+  const cxOfDiff = (d: number) => PL + slot * (d - 1) + slot / 2
+  const avgClamped = Math.min(Math.max(average, 1), n)
+  const avgX = cxOfDiff(avgClamped)
+
+  return (
+    <svg
+      viewBox={`0 0 ${VW} ${height}`}
+      role="img"
+      aria-label={ariaLabel}
+      className={className}
+      style={{ width: '100%', height: 'auto' }}
+    >
+      {ticks.map((t, i) => {
+        const y = yOf(t)
+        return (
+          <g key={`t${i}`}>
+            <line
+              x1={PL}
+              y1={y}
+              x2={VW - PR}
+              y2={y}
+              className="stroke-border"
+              strokeWidth={0.5}
+            />
+            <text
+              x={PL - 3}
+              y={y + 3}
+              textAnchor="end"
+              className="fill-ink-muted"
+              fontSize={8}
+            >
+              {formatCompact(t)}
+            </text>
+          </g>
+        )
+      })}
+
+      {bins.map((v, i) => {
+        const x = PL + slot * i + (slot - barW) / 2
+        const y = yOf(v)
+        return (
+          <rect
+            key={`h${i}`}
+            x={x}
+            y={y}
+            width={barW}
+            height={Math.max(0, baseY - y)}
+            fill={color}
+          />
+        )
+      })}
+
+      {/* x 軸ラベル（1・5・…・25） */}
+      {X_TICKS.map((d) => (
+        <text
+          key={`x${d}`}
+          x={cxOfDiff(d)}
+          y={height - 6}
+          textAnchor="middle"
+          className="fill-ink-muted"
+          fontSize={8}
+        >
+          {d}
+        </text>
+      ))}
+
+      {/* 平均線＝中立インク破線（朱不使用）＋藍の数値ラベル */}
+      {average > 0 ? (
+        <>
+          <line
+            x1={avgX}
+            y1={PT - 2}
+            x2={avgX}
+            y2={baseY}
+            className="stroke-neutral-fg"
+            strokeWidth={1}
+            strokeDasharray="3 2"
+          />
+          {showAverageLabel ? (
+            <text
+              x={Math.min(avgX + 3, VW - PR)}
+              y={PT + 6}
+              textAnchor={avgX > VW - 60 ? 'end' : 'start'}
+              className="fill-brand font-display"
+              fontSize={8.5}
+            >
+              {`平均 ${formatDecimal1(average)}`}
+            </text>
+          ) : null}
+        </>
+      ) : null}
+    </svg>
+  )
+}

--- a/apps/web/src/components/stats/charts/StackedComposition.test.tsx
+++ b/apps/web/src/components/stats/charts/StackedComposition.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { GradeLegend, StackedComposition } from './StackedComposition'
+import type { GradeCompositionPoint } from '@/lib/stats/overview'
+
+const data: GradeCompositionPoint[] = [
+  { year: 2025, counts: { A: 2, B: 1, C: 0, D: 0, E: 0 } }, // 2 セグメント
+  { year: 2026, counts: { A: 1, B: 0, C: 0, D: 0, E: 0 } }, // 1 セグメント
+]
+
+describe('StackedComposition', () => {
+  it('総和>0 の級だけセグメントを描く（0 の級は省く）', () => {
+    const { container } = render(
+      <StackedComposition data={data} ariaLabel="級別構成" />,
+    )
+    expect(screen.getByRole('img', { name: '級別構成' })).toBeTruthy()
+    // 2025: A,B の 2 本 ＋ 2026: A の 1 本 = 3 本
+    expect(container.querySelectorAll('rect')).toHaveLength(3)
+    // 朱をデータ装飾に使わない
+    expect(container.innerHTML).not.toContain('#b33c2d')
+  })
+
+  it('0/50/100% の目盛ラベルを持つ', () => {
+    render(<StackedComposition data={data} ariaLabel="級別構成" />)
+    for (const t of ['0', '50', '100']) {
+      expect(screen.getByText(t)).toBeTruthy()
+    }
+  })
+})
+
+describe('GradeLegend', () => {
+  it('A〜E の 5 凡例', () => {
+    render(<GradeLegend />)
+    for (const g of ['A級', 'B級', 'C級', 'D級', 'E級']) {
+      expect(screen.getByText(g)).toBeTruthy()
+    }
+  })
+})

--- a/apps/web/src/components/stats/charts/StackedComposition.tsx
+++ b/apps/web/src/components/stats/charts/StackedComposition.tsx
@@ -1,0 +1,138 @@
+import { ALL_GRADES } from '@/lib/stats/types'
+import { GRADE_TONE_ENTRIES, GRADE_TONES } from '@/lib/stats/grade-tones'
+import type { GradeCompositionPoint } from '@/lib/stats/overview'
+
+export interface StackedCompositionProps {
+  /** 年昇順の級別構成（各年 A〜E の延べ参加）。 */
+  data: GradeCompositionPoint[]
+  height?: number
+  ariaLabel: string
+  className?: string
+}
+
+const VW = 320
+const PL = 28
+const PR = 6
+const PT = 8
+const PB = 20
+const PCT_TICKS = [0, 50, 100]
+
+/**
+ * 級別構成の推移（100% 積み上げ棒）。design-spec §3.2 図1。各年を 100% に正規化して
+ * A（藍）→E（砂）を下から積む（トーンランプ＝虹色でない）。細い区切り線＝surface ストローク。
+ * 図内で級別比較が完成するため詳細ドリルは持たない。純粋 SVG。
+ */
+export function StackedComposition({
+  data,
+  height = 160,
+  ariaLabel,
+  className,
+}: StackedCompositionProps) {
+  const plotW = VW - PL - PR
+  const plotH = height - PT - PB
+  const baseY = height - PB
+  const n = data.length
+  const slot = n > 0 ? plotW / n : plotW
+  const barW = Math.min(slot * 0.62, 24)
+  const xEvery = n > 12 ? 2 : 1
+
+  return (
+    <svg
+      viewBox={`0 0 ${VW} ${height}`}
+      role="img"
+      aria-label={ariaLabel}
+      className={className}
+      style={{ width: '100%', height: 'auto' }}
+    >
+      {/* 0/50/100% 目盛 */}
+      {PCT_TICKS.map((pct) => {
+        const y = baseY - (pct / 100) * plotH
+        return (
+          <g key={`p${pct}`}>
+            <line
+              x1={PL}
+              y1={y}
+              x2={VW - PR}
+              y2={y}
+              className="stroke-border"
+              strokeWidth={0.5}
+            />
+            <text
+              x={PL - 3}
+              y={y + 3}
+              textAnchor="end"
+              className="fill-ink-muted"
+              fontSize={8}
+            >
+              {pct}
+            </text>
+          </g>
+        )
+      })}
+
+      {data.map((point, i) => {
+        const total = ALL_GRADES.reduce((s, g) => s + point.counts[g], 0)
+        const x = PL + slot * i + (slot - barW) / 2
+        const cx = PL + slot * i + slot / 2
+        const showX = i % xEvery === 0 || i === n - 1
+        let cum = 0
+        const segs = total > 0
+          ? ALL_GRADES.map((g) => {
+              const frac = point.counts[g] / total
+              const segBottom = baseY - (cum / total) * plotH
+              cum += point.counts[g]
+              const segTop = baseY - (cum / total) * plotH
+              return { g, y: segTop, h: segBottom - segTop, frac }
+            })
+          : []
+        return (
+          <g key={`c${point.year}`}>
+            {segs.map((s) =>
+              s.h > 0 ? (
+                <rect
+                  key={s.g}
+                  x={x}
+                  y={s.y}
+                  width={barW}
+                  height={s.h}
+                  fill={GRADE_TONES[s.g]}
+                  className="stroke-surface"
+                  strokeWidth={0.4}
+                />
+              ) : null,
+            )}
+            {showX ? (
+              <text
+                x={cx}
+                y={height - 6}
+                textAnchor="middle"
+                className="fill-ink-muted"
+                fontSize={8}
+              >
+                {point.year}
+              </text>
+            ) : null}
+          </g>
+        )
+      })}
+    </svg>
+  )
+}
+
+/** A〜E のトーン凡例（級別構成の下などに置く）。 */
+export function GradeLegend({ className }: { className?: string }) {
+  return (
+    <ul className={className ?? 'flex flex-wrap gap-x-3 gap-y-1'}>
+      {GRADE_TONE_ENTRIES.map(([g, tone]) => (
+        <li key={g} className="flex items-center gap-1 text-[11px] text-ink-meta">
+          <span
+            aria-hidden
+            className="inline-block h-2.5 w-2.5 rounded-[2px]"
+            style={{ backgroundColor: tone }}
+          />
+          {g}級
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/apps/web/src/components/stats/charts/chart-utils.test.ts
+++ b/apps/web/src/components/stats/charts/chart-utils.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import {
+  axisTicks,
+  denseYears,
+  formatCompact,
+  formatDecimal1,
+  formatInt,
+  niceMax,
+} from './chart-utils'
+
+describe('formatInt / formatCompact / formatDecimal1', () => {
+  it('formatInt は桁区切り整数', () => {
+    expect(formatInt(0)).toBe('0')
+    expect(formatInt(1234)).toBe('1,234')
+    expect(formatInt(1234567)).toBe('1,234,567')
+    expect(formatInt(12.6)).toBe('13') // 四捨五入
+  })
+
+  it('formatCompact は 1 万以上を「万」表記', () => {
+    expect(formatCompact(999)).toBe('999')
+    expect(formatCompact(9999)).toBe('9,999')
+    expect(formatCompact(12000)).toBe('1.2万')
+    expect(formatCompact(120000)).toBe('12万') // 10 万以上は整数万
+  })
+
+  it('formatDecimal1 は小数第1位', () => {
+    expect(formatDecimal1(1.5)).toBe('1.5')
+    expect(formatDecimal1(4)).toBe('4.0')
+  })
+})
+
+describe('niceMax', () => {
+  it('0/負は 1・きりの良い上端へ丸める', () => {
+    expect(niceMax(0)).toBe(1)
+    expect(niceMax(-5)).toBe(1)
+    expect(niceMax(3)).toBe(5)
+    expect(niceMax(7)).toBe(10)
+    expect(niceMax(23)).toBe(25)
+    expect(niceMax(120)).toBe(200)
+  })
+})
+
+describe('axisTicks', () => {
+  it('整数上端は割り切れる本数で整数目盛', () => {
+    expect(axisTicks(5)).toEqual([0, 1, 2, 3, 4, 5]) // top=5 → 5等分
+    expect(axisTicks(9)).toEqual([0, 2, 4, 6, 8, 10]) // top=10 → 5等分
+    expect(axisTicks(2)).toEqual([0, 1, 2]) // top=2 → 2等分
+  })
+
+  it('最小値は 0、最大値は niceMax(top)', () => {
+    const t = axisTicks(23)
+    expect(t[0]).toBe(0)
+    expect(t[t.length - 1]).toBe(25)
+  })
+})
+
+describe('denseYears', () => {
+  it('min〜max を連続年で 0 埋め', () => {
+    expect(
+      denseYears([
+        { year: 2018, count: 3 },
+        { year: 2020, count: 5 },
+      ]),
+    ).toEqual([
+      { label: '2018', value: 3 },
+      { label: '2019', value: 0 },
+      { label: '2020', value: 5 },
+    ])
+  })
+
+  it('from/to を明示すると端まで 0 埋め（系列間の x 揃え）', () => {
+    expect(denseYears([{ year: 2020, count: 4 }], 2019, 2021)).toEqual([
+      { label: '2019', value: 0 },
+      { label: '2020', value: 4 },
+      { label: '2021', value: 0 },
+    ])
+  })
+
+  it('空は空配列', () => {
+    expect(denseYears([])).toEqual([])
+  })
+})

--- a/apps/web/src/components/stats/charts/chart-utils.ts
+++ b/apps/web/src/components/stats/charts/chart-utils.ts
@@ -1,0 +1,95 @@
+import type { YearCountPoint } from '@/lib/stats/overview'
+
+/**
+ * 大会統計チャート（棒/ヒスト/100%積み上げ）共通の純粋ユーティリティ。SVG 描画に使う
+ * 目盛計算・数値整形・年域の 0 埋めなど、db 非依存で単体テストできるものを集約する。
+ */
+
+/** 棒の値ラベル/カード用の桁区切り整数。 */
+export function formatInt(n: number): string {
+  return Math.round(n).toLocaleString('en-US')
+}
+
+/**
+ * 密な棒グラフの値ラベル用の短縮表記。1 万以上は「N.N万」（10 万以上は整数万）、
+ * それ未満は桁区切り整数。y 軸目盛にも使う。
+ */
+export function formatCompact(n: number): string {
+  if (n >= 10000) {
+    const man = n / 10000
+    // 10 万以上（man>=10）は整数万、1〜10 万未満は小数第1位（例：1.2万）。
+    return `${man >= 10 ? Math.round(man) : man.toFixed(1)}万`
+  }
+  return formatInt(n)
+}
+
+/** 小数第1位（一人当たり平均・平均枚数差）。 */
+export function formatDecimal1(n: number): string {
+  return n.toFixed(1)
+}
+
+/**
+ * 軸の上端を「きりの良い」値へ丸める（0 は 1 に）。1/2/2.5/5/10 × 10^k のいずれか。
+ * y 軸目盛線と棒高さの正規化に使う。
+ */
+export function niceMax(max: number): number {
+  if (!Number.isFinite(max) || max <= 0) return 1
+  const pow = 10 ** Math.floor(Math.log10(max))
+  const n = max / pow
+  let nice: number
+  if (n <= 1) nice = 1
+  else if (n <= 2) nice = 2
+  else if (n <= 2.5) nice = 2.5
+  else if (n <= 5) nice = 5
+  else nice = 10
+  return nice * pow
+}
+
+/**
+ * 0〜niceMax(max) を等分した目盛値（昇順）。top が整数なら割り切れる本数を優先し、目盛が
+ * きれいな整数になるようにする（例：top=5→6本[0..5]、top=10→6本[0,2,..,10]）。
+ */
+export function axisTicks(max: number, preferred = 4): number[] {
+  const top = niceMax(max)
+  let count = preferred
+  if (Number.isInteger(top)) {
+    for (const c of [preferred, 5, 3, 2]) {
+      if (top % c === 0) {
+        count = c
+        break
+      }
+    }
+  }
+  const ticks: number[] = []
+  for (let i = 0; i <= count; i++) ticks.push((top / count) * i)
+  return ticks
+}
+
+export interface LabeledValue {
+  label: string
+  value: number
+}
+
+/**
+ * 年推移点を **連続した年域で 0 埋め** して {label=年, value} 配列に。棒グラフの x 軸を
+ * 年で連続させ、欠けた年（大会が無い/中止のみ）も 0 の棒として見せるため。範囲は
+ * `from`/`to` 明示（詳細のスモールマルチプルで全系列を揃える）か、無指定ならデータの min〜max。
+ * データが空なら空配列。
+ */
+export function denseYears(
+  points: readonly YearCountPoint[],
+  from?: number,
+  to?: number,
+): LabeledValue[] {
+  const byYear = new Map<number, number>()
+  for (const p of points) byYear.set(p.year, p.count)
+  const years = points.map((p) => p.year)
+  const lo = from ?? (years.length ? Math.min(...years) : undefined)
+  const hi = to ?? (years.length ? Math.max(...years) : undefined)
+  if (lo == null || hi == null || lo > hi) return []
+  const out: LabeledValue[] = []
+  for (let y = lo; y <= hi; y++) {
+    out.push({ label: String(y), value: byYear.get(y) ?? 0 })
+  }
+  return out
+}

--- a/apps/web/src/lib/stats/detail.test.ts
+++ b/apps/web/src/lib/stats/detail.test.ts
@@ -1,0 +1,152 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import type { ParsedResultPayload } from '@kagetra/mail-worker/result-import/schema'
+import { closeTestDb, testDb, truncateAll } from '@/test-utils/db'
+import { materializeResultDraft } from '@/lib/result-import/materialize'
+import { getStatsDetail, type ScoreSeries, type YearSeries } from './detail'
+
+beforeEach(async () => {
+  await truncateAll()
+})
+
+afterAll(async () => {
+  await closeTestDb()
+})
+
+type Part = ParsedResultPayload['classes'][number]['participants'][number]
+type Mt = Part['matches'][number]
+
+const mt = (
+  round: number,
+  opponentName: string | null,
+  scoreDiff: number | null,
+  result: 'win' | 'lose',
+  status: 'normal' | 'walkover' | 'forfeit' = 'normal',
+): Mt => ({ round, roundLabel: null, opponentName, scoreDiff, result, status })
+
+const p = (name: string, matches: Mt[] = []): Part => ({
+  seqNo: 1,
+  name,
+  nameKana: null,
+  affiliation: null,
+  prefecture: null,
+  dan: null,
+  memberNo: null,
+  finalRank: null,
+  matches,
+})
+
+function classWith(
+  className: string,
+  grade: 'A' | 'B' | 'C' | 'D' | 'E' | null,
+  participants: Part[],
+): ParsedResultPayload['classes'][number] {
+  return { className, grade, sheetName: null, participants }
+}
+
+async function seed(
+  name: string,
+  eventDate: string | null,
+  classes: ParsedResultPayload['classes'],
+) {
+  return testDb.transaction(async (tx) =>
+    materializeResultDraft(
+      tx,
+      { parserVersion: '1.0.0', classes },
+      { tournamentName: name, eventDate, venue: null, sourceResultDraftId: 1 },
+    ),
+  )
+}
+
+function byKey<T extends { key: string }>(series: T[]): Map<string, T> {
+  return new Map(series.map((s) => [s.key, s]))
+}
+
+describe('getStatsDetail — score（枚数差ヒスト・全級＋各級）', () => {
+  it('全級は grade 無し級も含む・各級は自級のみ・6 系列', async () => {
+    await seed('大会', '2025-04-01', [
+      classWith('A級', 'A', [p('a', [mt(1, 'x', 5, 'win')])]),
+      classWith('B級', 'B', [p('b', [mt(1, 'y', 3, 'win')])]),
+      classWith('無級', null, [p('n', [mt(1, 'z', 5, 'win')])]),
+    ])
+
+    const res = await getStatsDetail('score')
+    expect(res.metric).toBe('score')
+    const series = res.series as ScoreSeries[]
+    // 系列順は all→A→B→C→D→E
+    expect(series.map((s) => s.key)).toEqual(['all', 'A', 'B', 'C', 'D', 'E'])
+
+    const m = byKey(series)
+    // all：5 枚差 = A(1) + 無級(1) = 2、3 枚差 = B(1)
+    expect(m.get('all')!.bins[4]).toBe(2)
+    expect(m.get('all')!.bins[2]).toBe(1)
+    expect(m.get('all')!.average).toBeCloseTo((5 * 2 + 3) / 3, 5)
+    // A：5 枚差のみ
+    expect(m.get('A')!.bins[4]).toBe(1)
+    expect(m.get('A')!.average).toBeCloseTo(5, 5)
+    // B：3 枚差のみ
+    expect(m.get('B')!.bins[2]).toBe(1)
+    expect(m.get('B')!.average).toBeCloseTo(3, 5)
+    // 空級
+    expect(m.get('C')!.bins.every((b) => b === 0)).toBe(true)
+    expect(m.get('C')!.average).toBe(0)
+    // 各系列 25 本
+    for (const s of series) expect(s.bins).toHaveLength(25)
+  })
+})
+
+describe('getStatsDetail — competitors（年別 competitors・distinct）', () => {
+  it('全級は distinct（級合算だと重複）・各級は自級の distinct', async () => {
+    // 2025：A級に X,Y／B級に X（X は両級）
+    await seed('大会', '2025-04-01', [
+      classWith('A級', 'A', [p('X', []), p('Y', [])]),
+      classWith('B級', 'B', [p('X', [])]),
+    ])
+
+    const res = await getStatsDetail('competitors')
+    expect(res.metric).toBe('competitors')
+    const m = byKey(res.series as YearSeries[])
+    // 全級 = distinct(X,Y) = 2（A の 2 + B の 1 の単純合算 3 ではない）
+    expect(m.get('all')!.points).toEqual([{ year: 2025, count: 2 }])
+    expect(m.get('A')!.points).toEqual([{ year: 2025, count: 2 }])
+    expect(m.get('B')!.points).toEqual([{ year: 2025, count: 1 }])
+    expect(m.get('C')!.points).toEqual([])
+  })
+})
+
+describe('getStatsDetail — participations（年別 延べ参加・加算）', () => {
+  it('全級は grade 無し級も含む合算・各級は自級', async () => {
+    await seed('大会', '2025-04-01', [
+      classWith('A級', 'A', [p('X', []), p('Y', [])]), // 2
+      classWith('B級', 'B', [p('X', [])]), // 1
+      classWith('無級', null, [p('Z', [])]), // 1（all にのみ算入）
+    ])
+
+    const res = await getStatsDetail('participations')
+    const m = byKey(res.series as YearSeries[])
+    // 全級 = 2 + 1 + 1(無級) = 4
+    expect(m.get('all')!.points).toEqual([{ year: 2025, count: 4 }])
+    expect(m.get('A')!.points).toEqual([{ year: 2025, count: 2 }])
+    expect(m.get('B')!.points).toEqual([{ year: 2025, count: 1 }])
+    // 無級は各級系列には現れない
+    expect(m.get('C')!.points).toEqual([])
+  })
+})
+
+describe('getStatsDetail — 期間フィルタ / 防御', () => {
+  it('year 範囲で窓を絞る', async () => {
+    await seed('2018大会', '2018-04-01', [classWith('A級', 'A', [p('甲', [])])])
+    await seed('2020大会', '2020-04-01', [classWith('A級', 'A', [p('乙', [])])])
+
+    const res = await getStatsDetail('competitors', { yearFrom: 2019, yearTo: 2020 })
+    const m = byKey(res.series as YearSeries[])
+    expect(m.get('all')!.points).toEqual([{ year: 2020, count: 1 }])
+  })
+
+  it('不正 metric は score へ丸め・例外を投げない', async () => {
+    await seed('大会', '2025-04-01', [classWith('A級', 'A', [p('a', [mt(1, 'x', 4, 'win')])])])
+    const res = await getStatsDetail('bogus' as unknown as 'score')
+    expect(res.metric).toBe('score')
+    const m = byKey(res.series as ScoreSeries[])
+    expect(m.get('all')!.bins[3]).toBe(1) // 4 枚差
+  })
+})

--- a/apps/web/src/lib/stats/detail.ts
+++ b/apps/web/src/lib/stats/detail.ts
@@ -1,0 +1,223 @@
+import { sql } from 'drizzle-orm'
+import { db } from '@/lib/db'
+import { periodConds } from './filters'
+import {
+  ALL_GRADES,
+  coerceDetailMetric,
+  sanitizeStatsFilter,
+  type DetailMetric,
+  type Grade,
+  type StatsFilter,
+} from './types'
+import type { YearCountPoint } from './overview'
+
+/**
+ * ④大会統計・図詳細（`/tournaments/stats/[metric]`）のサーバー集計。requirements §3.6 / §4.2、
+ * design-spec §3.3。**全級＋各級（A〜E）**を並置して比較する（縦スモールマルチプル）。
+ * 期間フィルタのみ・級では絞らない（全級＋各級を常に並べる）。
+ *
+ * - `score` … 枚数差ヒスト（normal の勝者行で試合を 1 回だけ数える）
+ * - `competitors` … 年別 競技人口（distinct player）
+ * - `participations` … 年別 大会参加人数（延べ参加）
+ *
+ * 「全級（all）」は各級の単純合算ではない：competitors は選手が複数級に出ても distinct で
+ * 1 人（合算は重複）、participations は grade 無し級も含む（各級 A〜E の和より多くなり得る）。
+ * だから all は per-grade とは別に算出する。
+ */
+
+/** 系列キー：全級（参照）＋各級。表示順は all→A→…→E。 */
+export type SeriesKey = 'all' | Grade
+
+/** 系列の表示順（design-spec §3.3：全級参照を先頭に A〜E）。 */
+export const SERIES_KEYS: readonly SeriesKey[] = ['all', ...ALL_GRADES]
+
+/** score 詳細の 1 系列（枚数差ヒスト）。 */
+export interface ScoreSeries {
+  key: SeriesKey
+  /** length 25。index i＝枚数差 (i+1) 枚の試合数。 */
+  bins: number[]
+  /** 枚数差の平均（データ無しは 0）。 */
+  average: number
+}
+
+/** competitors / participations 詳細の 1 系列（年推移）。 */
+export interface YearSeries {
+  key: SeriesKey
+  /** 年昇順・データのある年のみ（UI が全級の年域で 0 埋め・軸整列）。 */
+  points: YearCountPoint[]
+}
+
+export type StatsDetail =
+  | { metric: 'score'; series: ScoreSeries[] }
+  | { metric: 'competitors'; series: YearSeries[] }
+  | { metric: 'participations'; series: YearSeries[] }
+
+const SCORE_BINS = 25
+
+function num(v: unknown): number {
+  return typeof v === 'number' ? v : Number(v ?? 0)
+}
+
+/**
+ * getStatsDetail — 図詳細（全級＋各級の比較）。読み取り専用・サーバー集計。metric は
+ * 動的セグメント由来なので `coerceDetailMetric` で許可リストへ丸め、期間は
+ * `sanitizeStatsFilter`（級は無視）で安全化してから集計する。
+ */
+export async function getStatsDetail(
+  metric: DetailMetric,
+  filter: StatsFilter = {},
+): Promise<StatsDetail> {
+  const safeMetric = coerceDetailMetric(metric)
+  const f = sanitizeStatsFilter(filter)
+  const period = periodConds(f)
+
+  switch (safeMetric) {
+    case 'score':
+      return { metric: 'score', series: await queryScoreDetail(period) }
+    case 'competitors':
+      return { metric: 'competitors', series: await queryCompetitorsDetail(period) }
+    case 'participations':
+      return { metric: 'participations', series: await queryParticipationsDetail(period) }
+  }
+}
+
+/** 空の 25 本ビン。 */
+function emptyBins(): number[] {
+  return new Array<number>(SCORE_BINS).fill(0)
+}
+
+/** ビンから平均（試合数で加重）を出す。 */
+function averageOfBins(bins: number[]): number {
+  let weighted = 0
+  let total = 0
+  for (let i = 0; i < bins.length; i++) {
+    weighted += (i + 1) * bins[i]!
+    total += bins[i]!
+  }
+  return total > 0 ? weighted / total : 0
+}
+
+/** score：(grade, diff) の試合数を all＋各級のヒストへ振り分ける。 */
+async function queryScoreDetail(
+  period: ReturnType<typeof periodConds>,
+): Promise<ScoreSeries[]> {
+  const res = await db.execute(sql`
+    SELECT tc.grade AS grade, m.score_diff::int AS diff, count(*)::int AS cnt
+    FROM matches m
+    JOIN tournament_classes tc ON tc.id = m.class_id
+    JOIN tournaments t ON t.id = tc.tournament_id
+    WHERE m.status = 'normal' AND m.result = 'win'
+      AND m.score_diff BETWEEN 1 AND ${SCORE_BINS} ${period}
+    GROUP BY tc.grade, diff
+  `)
+  const binsByKey = new Map<SeriesKey, number[]>()
+  for (const key of SERIES_KEYS) binsByKey.set(key, emptyBins())
+
+  for (const row of res.rows as Record<string, unknown>[]) {
+    const diff = num(row.diff)
+    const cnt = num(row.cnt)
+    if (diff < 1 || diff > SCORE_BINS) continue
+    // 全級（grade 無し級も含む）。
+    const allBins = binsByKey.get('all')!
+    allBins[diff - 1] = (allBins[diff - 1] ?? 0) + cnt
+    const grade = row.grade == null ? null : (String(row.grade) as Grade)
+    if (grade && ALL_GRADES.includes(grade)) {
+      const gradeBins = binsByKey.get(grade)!
+      gradeBins[diff - 1] = (gradeBins[diff - 1] ?? 0) + cnt
+    }
+  }
+
+  return SERIES_KEYS.map((key) => {
+    const bins = binsByKey.get(key)!
+    return { key, bins, average: averageOfBins(bins) }
+  })
+}
+
+/** 年→count の Map を昇順 points 配列へ。 */
+function toPoints(byYear: Map<number, number>): YearCountPoint[] {
+  return [...byYear.entries()]
+    .map(([year, count]) => ({ year, count }))
+    .sort((a, b) => a.year - b.year)
+}
+
+/**
+ * competitors：全級は distinct player の年集計（別クエリ＝級合算だと重複）。各級は
+ * (grade, year) の distinct player。
+ */
+async function queryCompetitorsDetail(
+  period: ReturnType<typeof periodConds>,
+): Promise<YearSeries[]> {
+  const [allRes, gradeRes] = await Promise.all([
+    db.execute(sql`
+      SELECT extract(year FROM t.event_date)::int AS year,
+             count(DISTINCT tp.player_id)::int AS cnt
+      FROM tournament_participants tp
+      JOIN tournament_classes tc ON tc.id = tp.class_id
+      JOIN tournaments t ON t.id = tc.tournament_id
+      WHERE tp.player_id IS NOT NULL AND t.event_date IS NOT NULL ${period}
+      GROUP BY year
+    `),
+    db.execute(sql`
+      SELECT tc.grade AS grade, extract(year FROM t.event_date)::int AS year,
+             count(DISTINCT tp.player_id)::int AS cnt
+      FROM tournament_participants tp
+      JOIN tournament_classes tc ON tc.id = tp.class_id
+      JOIN tournaments t ON t.id = tc.tournament_id
+      WHERE tp.player_id IS NOT NULL AND tc.grade IS NOT NULL AND t.event_date IS NOT NULL ${period}
+      GROUP BY tc.grade, year
+    `),
+  ])
+  return assembleYearSeries(allRes.rows as Record<string, unknown>[], gradeRes.rows as Record<string, unknown>[])
+}
+
+/**
+ * participations：延べ参加は加算的なので (grade, year) 1 クエリで済む。all＝年ごとの全行
+ * 合算（grade 無し級を含む）、各級＝そのグレードの行。
+ */
+async function queryParticipationsDetail(
+  period: ReturnType<typeof periodConds>,
+): Promise<YearSeries[]> {
+  const res = await db.execute(sql`
+    SELECT tc.grade AS grade, extract(year FROM t.event_date)::int AS year, count(*)::int AS cnt
+    FROM tournament_participants tp
+    JOIN tournament_classes tc ON tc.id = tp.class_id
+    JOIN tournaments t ON t.id = tc.tournament_id
+    WHERE t.event_date IS NOT NULL ${period}
+    GROUP BY tc.grade, year
+  `)
+  const rows = res.rows as Record<string, unknown>[]
+  // all＝年ごとに全 grade（null 含む）を合算。
+  const allByYear = new Map<number, number>()
+  for (const row of rows) {
+    const year = num(row.year)
+    allByYear.set(year, (allByYear.get(year) ?? 0) + num(row.cnt))
+  }
+  const allRows = [...allByYear.entries()].map(([year, cnt]) => ({ year, cnt }))
+  return assembleYearSeries(allRows, rows)
+}
+
+/**
+ * all の年集計行と (grade, year) 行から YearSeries[] を all→A〜E の順で組む。
+ * 各系列は年昇順・データのある年のみ（0 の年は落とす。UI が全級の年域で軸を整える）。
+ */
+function assembleYearSeries(
+  allRows: Record<string, unknown>[],
+  gradeRows: Record<string, unknown>[],
+): YearSeries[] {
+  const allByYear = new Map<number, number>()
+  for (const row of allRows) allByYear.set(num(row.year), num(row.cnt))
+
+  const byGrade = new Map<Grade, Map<number, number>>()
+  for (const g of ALL_GRADES) byGrade.set(g, new Map())
+  for (const row of gradeRows) {
+    const grade = row.grade == null ? null : (String(row.grade) as Grade)
+    if (grade && ALL_GRADES.includes(grade)) {
+      byGrade.get(grade)!.set(num(row.year), num(row.cnt))
+    }
+  }
+
+  return SERIES_KEYS.map((key) => ({
+    key,
+    points: toPoints(key === 'all' ? allByYear : byGrade.get(key)!),
+  }))
+}

--- a/apps/web/src/lib/stats/filters.ts
+++ b/apps/web/src/lib/stats/filters.ts
@@ -1,0 +1,26 @@
+import { sql, type SQL } from 'drizzle-orm'
+import type { StatsFilter } from './types'
+
+/**
+ * ④大会統計（getStatsOverview / getStatsDetail）の期間（年 from–to）WHERE 断片。
+ *
+ * 大会統計は**級では絞らない**（級は比較軸＝図内 or 詳細で並置。requirements §3.2）ので、
+ * ランキングの `filterConds`（period＋grades）とは別に、期間だけを絞るこの純 SQL ヘルパを
+ * 使う。生 SQL（`db.execute`）側で tournaments を **エイリアス `t`** で join している前提で、
+ * `t.event_date` を年境界の date と比較する。既存 WHERE 句に続けて **AND で連結**できるよう
+ * 先頭に `AND` を付けて返す（フィルタ無しなら空 SQL）。
+ *
+ * year 指定時は `event_date` の日付比較になるため、event_date 無し大会は自然に除外される
+ * （NULL 比較が偽）。呼び出し側は必ず `sanitizeStatsFilter` を通した値を渡すこと
+ * （不正年で DB エラー＝500 にならないように）。
+ */
+export function periodConds(filter: StatsFilter): SQL {
+  const parts: SQL[] = []
+  if (filter.yearFrom != null) {
+    parts.push(sql`t.event_date >= ${`${filter.yearFrom}-01-01`}::date`)
+  }
+  if (filter.yearTo != null) {
+    parts.push(sql`t.event_date <= ${`${filter.yearTo}-12-31`}::date`)
+  }
+  return parts.length > 0 ? sql`AND ${sql.join(parts, sql` AND `)}` : sql``
+}

--- a/apps/web/src/lib/stats/grade-tones.test.ts
+++ b/apps/web/src/lib/stats/grade-tones.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ALL_SERIES_TONE,
+  GRADE_TONES,
+  GRADE_TONE_ENTRIES,
+  gradeTone,
+  seriesLabel,
+} from './grade-tones'
+
+const ACCENT = '#b33c2d' // 朱（accent）
+
+describe('GRADE_TONES', () => {
+  it('A〜E の 5 トーン・A は藍（brand）', () => {
+    expect(Object.keys(GRADE_TONES)).toEqual(['A', 'B', 'C', 'D', 'E'])
+    expect(GRADE_TONES.A).toBe('#2b4e8c')
+  })
+
+  it('朱（accent）をデータ装飾トーンに使わない（design-spec §8）', () => {
+    for (const tone of Object.values(GRADE_TONES)) {
+      expect(tone.toLowerCase()).not.toBe(ACCENT)
+    }
+    expect(ALL_SERIES_TONE.toLowerCase()).not.toBe(ACCENT)
+  })
+
+  it('GRADE_TONE_ENTRIES は [grade, tone] 5 件', () => {
+    expect(GRADE_TONE_ENTRIES).toHaveLength(5)
+    expect(GRADE_TONE_ENTRIES[0]).toEqual(['A', '#2b4e8c'])
+  })
+})
+
+describe('gradeTone / seriesLabel', () => {
+  it('all は全級トーン・A〜E は級トーン', () => {
+    expect(gradeTone('all')).toBe(ALL_SERIES_TONE)
+    expect(gradeTone('C')).toBe(GRADE_TONES.C)
+  })
+
+  it('seriesLabel は 全級 / N級', () => {
+    expect(seriesLabel('all')).toBe('全級')
+    expect(seriesLabel('B')).toBe('B級')
+  })
+})

--- a/apps/web/src/lib/stats/grade-tones.ts
+++ b/apps/web/src/lib/stats/grade-tones.ts
@@ -1,0 +1,35 @@
+import { ALL_GRADES, type Grade } from './types'
+
+/**
+ * 級（A〜E）の色トーンランプ。design-spec §8 の「藍→砂トーンランプ（虹色でない）」。
+ * A=藍（brand）から E=砂（生成り）へ単調に振る。虹色（色相を回す）ではなく、藍→中立→砂の
+ * 明度/彩度ランプなので級の順序が色で読める。級別構成の 100% 積み上げ・図詳細のスウォッチ・
+ * 一人当たり平均年参加数の棒・（PR-5 の）級構成トーンドットで共有する。
+ *
+ * 朱（accent）はデータ装飾に使わない（design-spec §8）ため、この 5 色に朱は含めない。
+ */
+export const GRADE_TONES: Record<Grade, string> = {
+  A: '#2b4e8c', // 藍（brand）
+  B: '#4e658b',
+  C: '#727c8b',
+  D: '#95938a',
+  E: '#b8aa8a', // 砂（border-strong 近似）
+}
+
+/** 全級（詳細の参照系列）の中立トーン。藍でも砂でもない中立インク寄り。 */
+export const ALL_SERIES_TONE = '#5b4f33' // neutral-fg（中立インク）
+
+/** 級のトーンを返す（A〜E 以外は全級トーン）。 */
+export function gradeTone(key: 'all' | Grade): string {
+  return key === 'all' ? ALL_SERIES_TONE : GRADE_TONES[key]
+}
+
+/** 系列キーの表示ラベル（全級 / A級〜E級）。 */
+export function seriesLabel(key: 'all' | Grade): string {
+  return key === 'all' ? '全級' : `${key}級`
+}
+
+/** A〜E の [grade, tone] 一覧（凡例用）。 */
+export const GRADE_TONE_ENTRIES: readonly (readonly [Grade, string])[] = ALL_GRADES.map(
+  (g) => [g, GRADE_TONES[g]] as const,
+)

--- a/apps/web/src/lib/stats/overview.test.ts
+++ b/apps/web/src/lib/stats/overview.test.ts
@@ -74,7 +74,8 @@ describe('getStatsOverview — 絶対数カード', () => {
     expect(totals.tournaments).toBe(2)
     expect(totals.competitors).toBe(2) // X太郎・Y太郎（X は 2 大会でも 1 人）
     expect(totals.participations).toBe(3) // 大会A 2 + 大会B 1
-    expect(totals.matches).toBe(4) // 大会A 3 行 + 大会B 1 行
+    // 実試合数＝normal 勝者行のみ：X(win) + Y(win) + 大会B X(win) = 3。X の lose 行は除外。
+    expect(totals.matches).toBe(3)
   })
 
   it('期間フィルタで event_date 無し大会・範囲外を除外する', async () => {

--- a/apps/web/src/lib/stats/overview.test.ts
+++ b/apps/web/src/lib/stats/overview.test.ts
@@ -1,0 +1,207 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import type { ParsedResultPayload } from '@kagetra/mail-worker/result-import/schema'
+import { closeTestDb, testDb, truncateAll } from '@/test-utils/db'
+import { materializeResultDraft } from '@/lib/result-import/materialize'
+import { getStatsOverview } from './overview'
+
+beforeEach(async () => {
+  await truncateAll()
+})
+
+afterAll(async () => {
+  await closeTestDb()
+})
+
+type Part = ParsedResultPayload['classes'][number]['participants'][number]
+type Mt = Part['matches'][number]
+
+const mt = (
+  round: number,
+  roundLabel: string | null,
+  opponentName: string | null,
+  scoreDiff: number | null,
+  result: 'win' | 'lose',
+  status: 'normal' | 'walkover' | 'forfeit' = 'normal',
+): Mt => ({ round, roundLabel, opponentName, scoreDiff, result, status })
+
+const p = (name: string, matches: Mt[] = []): Part => ({
+  seqNo: 1,
+  name,
+  nameKana: null,
+  affiliation: null,
+  prefecture: null,
+  dan: null,
+  memberNo: null,
+  finalRank: null,
+  matches,
+})
+
+function classWith(
+  className: string,
+  grade: 'A' | 'B' | 'C' | 'D' | 'E' | null,
+  participants: Part[],
+): ParsedResultPayload['classes'][number] {
+  return { className, grade, sheetName: null, participants }
+}
+
+async function seed(
+  name: string,
+  eventDate: string | null,
+  classes: ParsedResultPayload['classes'],
+) {
+  return testDb.transaction(async (tx) =>
+    materializeResultDraft(
+      tx,
+      { parserVersion: '1.0.0', classes },
+      { tournamentName: name, eventDate, venue: null, sourceResultDraftId: 1 },
+    ),
+  )
+}
+
+describe('getStatsOverview — 絶対数カード', () => {
+  it('競技人口=distinct player・大会数・総対戦数(行)・延べ参加を返す', async () => {
+    await seed('大会A', '2025-04-01', [
+      classWith('D級', 'D', [
+        p('X太郎', [mt(1, null, '相手a', 5, 'win'), mt(2, null, '相手b', 3, 'lose')]),
+        p('Y太郎', [mt(1, null, '相手c', 4, 'win')]),
+      ]),
+    ])
+    await seed('大会B', '2025-05-01', [
+      classWith('C級', 'C', [p('X太郎', [mt(1, null, '相手d', 5, 'win')])]),
+    ])
+
+    const { totals } = await getStatsOverview()
+    expect(totals.tournaments).toBe(2)
+    expect(totals.competitors).toBe(2) // X太郎・Y太郎（X は 2 大会でも 1 人）
+    expect(totals.participations).toBe(3) // 大会A 2 + 大会B 1
+    expect(totals.matches).toBe(4) // 大会A 3 行 + 大会B 1 行
+  })
+
+  it('期間フィルタで event_date 無し大会・範囲外を除外する', async () => {
+    await seed('2018大会', '2018-04-01', [classWith('D級', 'D', [p('甲', [])])])
+    await seed('2020大会', '2020-04-01', [classWith('D級', 'D', [p('乙', [])])])
+    await seed('日付不明', null, [classWith('D級', 'D', [p('丙', [])])])
+
+    const all = await getStatsOverview()
+    expect(all.totals.tournaments).toBe(3)
+    expect(all.totals.participations).toBe(3)
+
+    // 2019〜2020：2020大会のみ（2018 範囲外・null 除外）
+    const ranged = await getStatsOverview({ yearFrom: 2019, yearTo: 2020 })
+    expect(ranged.totals.tournaments).toBe(1)
+    expect(ranged.totals.participations).toBe(1)
+    expect(ranged.totals.competitors).toBe(1)
+  })
+})
+
+describe('getStatsOverview — 図1 級別構成の推移', () => {
+  it('年×級の延べ参加を pivot（grade 無し級は除外・A〜E 0 埋め）', async () => {
+    await seed('2025大会', '2025-04-01', [
+      classWith('A級', 'A', [p('a1', []), p('a2', [])]),
+      classWith('B級', 'B', [p('b1', [])]),
+      classWith('無級', null, [p('n1', [])]), // grade null → 構成から除外
+    ])
+    await seed('2026大会', '2026-04-01', [classWith('A級', 'A', [p('a3', [])])])
+
+    const { gradeComposition } = await getStatsOverview()
+    expect(gradeComposition).toEqual([
+      { year: 2025, counts: { A: 2, B: 1, C: 0, D: 0, E: 0 } },
+      { year: 2026, counts: { A: 1, B: 0, C: 0, D: 0, E: 0 } },
+    ])
+  })
+})
+
+describe('getStatsOverview — 図2 新規参入者（初出場年・2011〜）', () => {
+  it('初出場年は全データ由来・2010 は除外・再出場年には数えない', async () => {
+    // 太郎A：2010 初出場（除外）
+    await seed('2010大会', '2010-04-01', [classWith('D級', 'D', [p('太郎A', [])])])
+    // 太郎B：2012 初出場 → 2013 再出場（2012 のみ）
+    await seed('2012大会1', '2012-04-01', [classWith('D級', 'D', [p('太郎B', []), p('太郎C', [])])])
+    await seed('2013大会', '2013-04-01', [classWith('D級', 'D', [p('太郎B', [])])])
+    // 太郎D：2014 初出場
+    await seed('2014大会', '2014-04-01', [classWith('D級', 'D', [p('太郎D', [])])])
+
+    const all = await getStatsOverview()
+    expect(all.newcomers).toEqual([
+      { year: 2012, count: 2 }, // 太郎B・太郎C
+      { year: 2014, count: 1 }, // 太郎D
+    ])
+
+    // 期間窓：2013〜 → 2014 のみ（デビュー年自体は全データ由来だが表示窓で絞る）
+    const windowed = await getStatsOverview({ yearFrom: 2013 })
+    expect(windowed.newcomers).toEqual([{ year: 2014, count: 1 }])
+  })
+})
+
+describe('getStatsOverview — 図3 一人当たり 平均年参加数（x=級）', () => {
+  it('(選手,年) の distinct 大会数を級で平均・A〜E を常に返す', async () => {
+    // D級 2026：X は 2 大会・Y は 1 大会 → 平均 (2+1)/2 = 1.5
+    await seed('大会1', '2026-04-01', [classWith('D級', 'D', [p('X', [])])])
+    await seed('大会2', '2026-05-01', [classWith('D級', 'D', [p('X', []), p('Y', [])])])
+
+    const { perPlayerAvg } = await getStatsOverview()
+    const byGrade = new Map(perPlayerAvg.map((g) => [g.grade, g.avg]))
+    expect(byGrade.get('D')).toBeCloseTo(1.5, 5)
+    expect(byGrade.get('A')).toBe(0)
+    // A〜E の 5 本を必ず返す
+    expect(perPlayerAvg.map((g) => g.grade)).toEqual(['A', 'B', 'C', 'D', 'E'])
+  })
+})
+
+describe('getStatsOverview — 図4 スコア統計（枚数差ヒスト）', () => {
+  it('normal の勝者行のみ・1〜25 の 25 本・平均は試合数で加重', async () => {
+    await seed('大会', '2025-04-01', [
+      classWith('D級', 'D', [
+        p('P1', [mt(1, null, 'x', 5, 'win'), mt(2, null, 'y', 10, 'lose')]), // lose は除外
+        p('P2', [mt(1, null, 'z', 5, 'win')]),
+        p('P3', [mt(1, null, 'w', 3, 'win')]),
+        p('P4', [mt(1, null, null, null, 'win', 'walkover')]), // 不戦勝は除外
+      ]),
+    ])
+
+    const { scoreHistogram } = await getStatsOverview()
+    expect(scoreHistogram.bins).toHaveLength(25)
+    expect(scoreHistogram.bins[4]).toBe(2) // 5 枚差 ×2
+    expect(scoreHistogram.bins[2]).toBe(1) // 3 枚差 ×1
+    expect(scoreHistogram.bins[9]).toBe(0) // 10 枚差は lose なので 0
+    // 平均 = (5*2 + 3*1) / 3 = 13/3
+    expect(scoreHistogram.average).toBeCloseTo(13 / 3, 5)
+  })
+
+  it('データ無しは全 0・平均 0', async () => {
+    const { scoreHistogram } = await getStatsOverview()
+    expect(scoreHistogram.bins.every((b) => b === 0)).toBe(true)
+    expect(scoreHistogram.average).toBe(0)
+  })
+})
+
+describe('getStatsOverview — 図5/6 年別 競技人口・大会参加人数', () => {
+  it('競技人口=distinct player・大会参加人数=延べ参加を年別に', async () => {
+    await seed('2025大会', '2025-04-01', [classWith('D級', 'D', [p('X', []), p('Y', [])])])
+    await seed('2026大会', '2026-04-01', [classWith('D級', 'D', [p('X', [])])])
+
+    const { competitorsByYear, participationsByYear } = await getStatsOverview()
+    expect(competitorsByYear).toEqual([
+      { year: 2025, count: 2 },
+      { year: 2026, count: 1 },
+    ])
+    expect(participationsByYear).toEqual([
+      { year: 2025, count: 2 },
+      { year: 2026, count: 1 },
+    ])
+  })
+})
+
+describe('getStatsOverview — 不正入力の防御', () => {
+  it('改変された年/級でも例外を投げず既定集計（級は無視）', async () => {
+    await seed('大会', '2025-04-01', [classWith('D級', 'D', [p('防御', [])])])
+    const res = await getStatsOverview({
+      yearFrom: Number.NaN,
+      yearTo: -1,
+      grades: ['Z'] as unknown as Array<'A'>,
+    })
+    // フィルタ実質無効 → 大会統計は級を無視するので防御選手が数えられる
+    expect(res.totals.competitors).toBe(1)
+    expect(res.totals.participations).toBe(1)
+  })
+})

--- a/apps/web/src/lib/stats/overview.ts
+++ b/apps/web/src/lib/stats/overview.ts
@@ -24,7 +24,11 @@ export interface StatsTotals {
   competitors: number
   /** 収録大会数＝tournaments 件数（期間指定時は event_date 無しを除外）。 */
   tournaments: number
-  /** 総対戦数＝matches 行数（勝者/敗者 2 行のロスレス保持をそのまま数える）。 */
+  /**
+   * 総対戦数＝**実試合数**。matches は通常対戦を勝者/敗者 2 行で保持するため、単純な
+   * count(*) では 2 倍・不戦勝/棄権も混入する。試合を 1 回だけ数えるためスコアヒストと
+   * 同じく normal の勝者行のみ（status='normal' AND result='win'）を数える。
+   */
   matches: number
   /** 大会参加人数＝延べ参加（tournament_participants 行数）。 */
   participations: number
@@ -138,7 +142,7 @@ async function queryTotals(period: ReturnType<typeof periodConds>): Promise<Stat
       FROM matches m
       JOIN tournament_classes tc ON tc.id = m.class_id
       JOIN tournaments t ON t.id = tc.tournament_id
-      WHERE true ${period}
+      WHERE m.status = 'normal' AND m.result = 'win' ${period}
     `),
     db.execute(sql`
       SELECT count(*)::int AS n

--- a/apps/web/src/lib/stats/overview.ts
+++ b/apps/web/src/lib/stats/overview.ts
@@ -1,0 +1,306 @@
+import { sql } from 'drizzle-orm'
+import { db } from '@/lib/db'
+import { periodConds } from './filters'
+import { ALL_GRADES, sanitizeStatsFilter, type Grade, type StatsFilter } from './types'
+
+/**
+ * ④大会統計・全体サマリー（`/tournaments/stats`）のサーバー集計。requirements §3.6 / §4.2、
+ * design-spec §3.2。全級固定・**期間フィルタのみ**（級では絞らない＝級は図内 or 詳細の比較軸）。
+ *
+ * 用語：**競技人口**＝ユニーク選手数（player_id 非 null の distinct）／**大会参加人数**＝延べ
+ * 参加（tournament_participants の行数、未解決 player_id 含む）。
+ *
+ * 6 図の内訳（うち 1〜3 はこの画面で完結＝詳細なし、4〜6 は `getStatsDetail` へドリル）：
+ *   1. 級別構成の推移（年×A〜E の 100% 積み上げ・延べ参加）
+ *   2. 新規参入者の推移（初出場年別・**2011〜**＝収録開始 2010 は既存選手を含むため左側打ち切り）
+ *   3. 一人当たり 平均年参加数（x=級 A〜E・その人がその年に出た大会数の平均）
+ *   4. スコア統計（枚数差 1〜25 の 25 本ヒスト＋平均）
+ *   5. 年別 競技人口 ／ 6. 年別 大会参加人数
+ */
+
+/** 絶対数カード（4）。全て期間フィルタ適用後の値。 */
+export interface StatsTotals {
+  /** 競技人口＝distinct player（player_id 非 null）。 */
+  competitors: number
+  /** 収録大会数＝tournaments 件数（期間指定時は event_date 無しを除外）。 */
+  tournaments: number
+  /** 総対戦数＝matches 行数（勝者/敗者 2 行のロスレス保持をそのまま数える）。 */
+  matches: number
+  /** 大会参加人数＝延べ参加（tournament_participants 行数）。 */
+  participations: number
+}
+
+/** 図1：級別構成の推移。1 年 = 各級（A〜E）の延べ参加。UI で 100% 積み上げに正規化。 */
+export interface GradeCompositionPoint {
+  year: number
+  /** A〜E の延べ参加数（その年にその級が無ければ 0）。 */
+  counts: Record<Grade, number>
+}
+
+/** 図2/5/6 の年推移 1 点。 */
+export interface YearCountPoint {
+  year: number
+  count: number
+}
+
+/** 図3：一人当たり 平均年参加数（級別）。 */
+export interface PerPlayerAvgPoint {
+  grade: Grade
+  /** その級に出た (選手, 年) について「その年に出た大会数」の平均（大会/年）。 */
+  avg: number
+}
+
+/** 図4：スコア統計（枚数差ヒスト）。 */
+export interface ScoreHistogram {
+  /** length 25。index i＝枚数差 (i+1) 枚の試合数。 */
+  bins: number[]
+  /** 枚数差の平均（試合数で加重・小数）。データ無しは 0。 */
+  average: number
+}
+
+export interface StatsOverview {
+  totals: StatsTotals
+  /** 図1（年昇順）。 */
+  gradeComposition: GradeCompositionPoint[]
+  /** 図2（初出場年昇順・2011〜・期間で窓を絞る）。 */
+  newcomers: YearCountPoint[]
+  /** 図3（A〜E の 5 本・データ無し級は avg=0）。 */
+  perPlayerAvg: PerPlayerAvgPoint[]
+  /** 図4。 */
+  scoreHistogram: ScoreHistogram
+  /** 図5（年昇順）。 */
+  competitorsByYear: YearCountPoint[]
+  /** 図6（年昇順）。 */
+  participationsByYear: YearCountPoint[]
+}
+
+/** 枚数差ヒストのビン数（1〜25 枚差・design-spec §3.2）。 */
+const SCORE_BINS = 25
+
+/** pg の QueryResult 行は Record<string, unknown>。数値列を安全に number へ（bigint 文字列も許容）。 */
+function num(v: unknown): number {
+  return typeof v === 'number' ? v : Number(v ?? 0)
+}
+
+/**
+ * getStatsOverview — メイン全体サマリー（絶対数4＋6図）。読み取り専用・サーバー集計。
+ * 各集計は独立なので Promise.all で並行実行する。信頼できない入力（Server Action・
+ * searchParams）でも DB エラー（500）にならないよう choke point で `sanitizeStatsFilter`。
+ * 級（grades）は無視する（大会統計は級で絞らない）。
+ */
+export async function getStatsOverview(filter: StatsFilter = {}): Promise<StatsOverview> {
+  const f = sanitizeStatsFilter(filter)
+  const period = periodConds(f)
+
+  const [
+    totals,
+    gradeComposition,
+    newcomers,
+    perPlayerAvg,
+    scoreHistogram,
+    competitorsByYear,
+    participationsByYear,
+  ] = await Promise.all([
+    queryTotals(period),
+    queryGradeComposition(period),
+    queryNewcomers(f),
+    queryPerPlayerAvg(period),
+    queryScoreHistogram(period),
+    queryCompetitorsByYear(period),
+    queryParticipationsByYear(period),
+  ])
+
+  return {
+    totals,
+    gradeComposition,
+    newcomers,
+    perPlayerAvg,
+    scoreHistogram,
+    competitorsByYear,
+    participationsByYear,
+  }
+}
+
+/** 絶対数カード。competitors/participations は participants 1 パス、matches/tournaments は別。 */
+async function queryTotals(period: ReturnType<typeof periodConds>): Promise<StatsTotals> {
+  const [participantAgg, matchAgg, tournamentAgg] = await Promise.all([
+    db.execute(sql`
+      SELECT
+        count(*)::int AS participations,
+        count(DISTINCT tp.player_id) FILTER (WHERE tp.player_id IS NOT NULL)::int AS competitors
+      FROM tournament_participants tp
+      JOIN tournament_classes tc ON tc.id = tp.class_id
+      JOIN tournaments t ON t.id = tc.tournament_id
+      WHERE true ${period}
+    `),
+    db.execute(sql`
+      SELECT count(*)::int AS n
+      FROM matches m
+      JOIN tournament_classes tc ON tc.id = m.class_id
+      JOIN tournaments t ON t.id = tc.tournament_id
+      WHERE true ${period}
+    `),
+    db.execute(sql`
+      SELECT count(*)::int AS n
+      FROM tournaments t
+      WHERE true ${period}
+    `),
+  ])
+  const pr = participantAgg.rows[0] ?? {}
+  return {
+    competitors: num((pr as Record<string, unknown>).competitors),
+    participations: num((pr as Record<string, unknown>).participations),
+    matches: num((matchAgg.rows[0] as Record<string, unknown> | undefined)?.n),
+    tournaments: num((tournamentAgg.rows[0] as Record<string, unknown> | undefined)?.n),
+  }
+}
+
+/** 図1：年×級の延べ参加を pivot。grade 無し級は除外（構成は A〜E 固定）。 */
+async function queryGradeComposition(
+  period: ReturnType<typeof periodConds>,
+): Promise<GradeCompositionPoint[]> {
+  const res = await db.execute(sql`
+    SELECT extract(year FROM t.event_date)::int AS year, tc.grade AS grade, count(*)::int AS cnt
+    FROM tournament_participants tp
+    JOIN tournament_classes tc ON tc.id = tp.class_id
+    JOIN tournaments t ON t.id = tc.tournament_id
+    WHERE t.event_date IS NOT NULL AND tc.grade IS NOT NULL ${period}
+    GROUP BY year, tc.grade
+    ORDER BY year
+  `)
+  const byYear = new Map<number, GradeCompositionPoint>()
+  for (const row of res.rows as Record<string, unknown>[]) {
+    const year = num(row.year)
+    const grade = String(row.grade) as Grade
+    if (!ALL_GRADES.includes(grade)) continue
+    let point = byYear.get(year)
+    if (!point) {
+      point = { year, counts: { A: 0, B: 0, C: 0, D: 0, E: 0 } }
+      byYear.set(year, point)
+    }
+    point.counts[grade] = num(row.cnt)
+  }
+  return [...byYear.values()].sort((a, b) => a.year - b.year)
+}
+
+/**
+ * 図2：新規参入者。**初出場年は全データで確定**（一人の真のデビュー年）し、その分布を
+ * 描く。期間フィルタは表示する年の窓を絞るだけ（部分集合内での「新規」ではない）。
+ * 収録開始 2010 年は既存選手を含むため 2011〜（`>= 2011` かつ期間下限）。
+ */
+async function queryNewcomers(f: StatsFilter): Promise<YearCountPoint[]> {
+  // 初出場年サブクエリは period を掛けない（デビュー年は全データ由来）。
+  const lo = Math.max(2011, f.yearFrom ?? 2011)
+  const hiCond = f.yearTo != null ? sql`AND yr <= ${f.yearTo}` : sql``
+  const res = await db.execute(sql`
+    SELECT yr AS year, count(*)::int AS cnt
+    FROM (
+      SELECT tp.player_id, min(extract(year FROM t.event_date))::int AS yr
+      FROM tournament_participants tp
+      JOIN tournament_classes tc ON tc.id = tp.class_id
+      JOIN tournaments t ON t.id = tc.tournament_id
+      WHERE tp.player_id IS NOT NULL AND t.event_date IS NOT NULL
+      GROUP BY tp.player_id
+    ) s
+    WHERE yr >= ${lo} ${hiCond}
+    GROUP BY yr
+    ORDER BY yr
+  `)
+  return (res.rows as Record<string, unknown>[]).map((r) => ({
+    year: num(r.year),
+    count: num(r.cnt),
+  }))
+}
+
+/** 図3：一人当たり 平均年参加数（x=級）。(級, 選手, 年) の distinct 大会数を級で平均。 */
+async function queryPerPlayerAvg(
+  period: ReturnType<typeof periodConds>,
+): Promise<PerPlayerAvgPoint[]> {
+  const res = await db.execute(sql`
+    SELECT grade, avg(cnt)::float8 AS avg
+    FROM (
+      SELECT tc.grade AS grade, tp.player_id, extract(year FROM t.event_date)::int AS yr,
+             count(DISTINCT t.id)::int AS cnt
+      FROM tournament_participants tp
+      JOIN tournament_classes tc ON tc.id = tp.class_id
+      JOIN tournaments t ON t.id = tc.tournament_id
+      WHERE tp.player_id IS NOT NULL AND tc.grade IS NOT NULL AND t.event_date IS NOT NULL ${period}
+      GROUP BY tc.grade, tp.player_id, yr
+    ) s
+    GROUP BY grade
+  `)
+  const byGrade = new Map<Grade, number>()
+  for (const row of res.rows as Record<string, unknown>[]) {
+    const grade = String(row.grade) as Grade
+    if (ALL_GRADES.includes(grade)) byGrade.set(grade, num(row.avg))
+  }
+  // A〜E を常に返す（データ無し級は 0）。
+  return ALL_GRADES.map((grade) => ({ grade, avg: byGrade.get(grade) ?? 0 }))
+}
+
+/** 図4：枚数差ヒスト（1〜25）。試合を 1 回だけ数えるため normal の勝者行のみ集計。 */
+async function queryScoreHistogram(
+  period: ReturnType<typeof periodConds>,
+): Promise<ScoreHistogram> {
+  const res = await db.execute(sql`
+    SELECT m.score_diff::int AS diff, count(*)::int AS cnt
+    FROM matches m
+    JOIN tournament_classes tc ON tc.id = m.class_id
+    JOIN tournaments t ON t.id = tc.tournament_id
+    WHERE m.status = 'normal' AND m.result = 'win'
+      AND m.score_diff BETWEEN 1 AND ${SCORE_BINS} ${period}
+    GROUP BY diff
+  `)
+  const bins = new Array<number>(SCORE_BINS).fill(0)
+  let weighted = 0
+  let total = 0
+  for (const row of res.rows as Record<string, unknown>[]) {
+    const diff = num(row.diff)
+    const cnt = num(row.cnt)
+    if (diff >= 1 && diff <= SCORE_BINS) {
+      bins[diff - 1] = cnt
+      weighted += diff * cnt
+      total += cnt
+    }
+  }
+  return { bins, average: total > 0 ? weighted / total : 0 }
+}
+
+/** 図5：年別 競技人口（distinct player）。 */
+async function queryCompetitorsByYear(
+  period: ReturnType<typeof periodConds>,
+): Promise<YearCountPoint[]> {
+  const res = await db.execute(sql`
+    SELECT extract(year FROM t.event_date)::int AS year,
+           count(DISTINCT tp.player_id)::int AS cnt
+    FROM tournament_participants tp
+    JOIN tournament_classes tc ON tc.id = tp.class_id
+    JOIN tournaments t ON t.id = tc.tournament_id
+    WHERE tp.player_id IS NOT NULL AND t.event_date IS NOT NULL ${period}
+    GROUP BY year
+    ORDER BY year
+  `)
+  return (res.rows as Record<string, unknown>[]).map((r) => ({
+    year: num(r.year),
+    count: num(r.cnt),
+  }))
+}
+
+/** 図6：年別 大会参加人数（延べ参加）。 */
+async function queryParticipationsByYear(
+  period: ReturnType<typeof periodConds>,
+): Promise<YearCountPoint[]> {
+  const res = await db.execute(sql`
+    SELECT extract(year FROM t.event_date)::int AS year, count(*)::int AS cnt
+    FROM tournament_participants tp
+    JOIN tournament_classes tc ON tc.id = tp.class_id
+    JOIN tournaments t ON t.id = tc.tournament_id
+    WHERE t.event_date IS NOT NULL ${period}
+    GROUP BY year
+    ORDER BY year
+  `)
+  return (res.rows as Record<string, unknown>[]).map((r) => ({
+    year: num(r.year),
+    count: num(r.cnt),
+  }))
+}

--- a/apps/web/src/lib/stats/types.test.ts
+++ b/apps/web/src/lib/stats/types.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { coerceRankingMetric, sanitizeStatsFilter } from './types'
+import { coerceDetailMetric, coerceRankingMetric, sanitizeStatsFilter } from './types'
 
 describe('coerceRankingMetric', () => {
   it('妥当な指標はそのまま通す', () => {
@@ -14,6 +14,24 @@ describe('coerceRankingMetric', () => {
     expect(coerceRankingMetric(null)).toBe('participations')
     expect(coerceRankingMetric(42)).toBe('participations')
     expect(coerceRankingMetric({ metric: 'wins' })).toBe('participations')
+  })
+})
+
+describe('coerceDetailMetric', () => {
+  it('妥当な詳細指標はそのまま通す', () => {
+    expect(coerceDetailMetric('score')).toBe('score')
+    expect(coerceDetailMetric('competitors')).toBe('competitors')
+    expect(coerceDetailMetric('participations')).toBe('participations')
+  })
+
+  it('未知/非文字列は既定（score）へ丸める', () => {
+    expect(coerceDetailMetric('bogus')).toBe('score')
+    // ランキング指標（wins 等）は詳細指標ではない → 既定へ
+    expect(coerceDetailMetric('wins')).toBe('score')
+    expect(coerceDetailMetric('')).toBe('score')
+    expect(coerceDetailMetric(undefined)).toBe('score')
+    expect(coerceDetailMetric(null)).toBe('score')
+    expect(coerceDetailMetric(7)).toBe('score')
   })
 })
 

--- a/apps/web/src/lib/stats/types.ts
+++ b/apps/web/src/lib/stats/types.ts
@@ -61,6 +61,34 @@ export function coerceRankingMetric(value: unknown): RankingMetric {
     : DEFAULT_RANKING_METRIC
 }
 
+/**
+ * ④大会統計・図詳細（`/tournaments/stats/[metric]`）でドリルできる指標。requirements §3.6 / §4.2。
+ * - `score` 枚数差ヒスト ／ `competitors` 年別競技人口 ／ `participations` 年別大会参加人数。
+ *   いずれも「全級＋各級（A〜E）」を並べて比較する（メインの完結図＝級別構成/新規参入者/
+ *   一人当たり平均年参加数は詳細を持たない）。
+ */
+export type DetailMetric = 'score' | 'competitors' | 'participations'
+
+export const DETAIL_METRIC_KEYS: readonly DetailMetric[] = [
+  'score',
+  'competitors',
+  'participations',
+]
+
+/** 既定の詳細指標（不正な [metric] セグメントのフォールバック）。 */
+export const DEFAULT_DETAIL_METRIC: DetailMetric = 'score'
+
+/**
+ * 未知の値を安全な DetailMetric に丸める。`/tournaments/stats/[metric]` の動的セグメントは
+ * ユーザーが任意に打てるため、許可リスト外は既定（score）へ落として集計が例外化しないようにする。
+ */
+export function coerceDetailMetric(value: unknown): DetailMetric {
+  return typeof value === 'string' &&
+    (DETAIL_METRIC_KEYS as readonly string[]).includes(value)
+    ? (value as DetailMetric)
+    : DEFAULT_DETAIL_METRIC
+}
+
 /** 年として妥当（整数・現実的な範囲）な値のみ通す。他は undefined。 */
 function validYear(n: unknown): number | undefined {
   return typeof n === 'number' && Number.isInteger(n) && n >= 1900 && n <= 3000

--- a/docs/features/senseki-stats/implementation-plan.md
+++ b/docs/features/senseki-stats/implementation-plan.md
@@ -91,7 +91,7 @@ status: completed
 - **完了条件:** フロントテスト green・375px で横スクロールなし（チップ列除く）・同順位表示・空/長大状態。
 
 ### タスク7: 大会統計 クエリ（getStatsOverview / getStatsDetail）（PR-4）
-- [ ] 完了
+- [x] 完了
 - **概要:** `getStatsOverview(filter)`＝絶対数4＋6図（級別構成推移/新規参入者[初出場年・**2011〜**左側打ち切り]/
   一人当たり平均年参加数[**x=級A〜E**]/スコアヒスト25本/年別競技人口/年別大会参加人数）。`getStatsDetail(metric,filter)`＝
   score/competitors/participations の**全級＋各級A〜E**系列。期間フィルタのみ。requirements §3.6/§4.2。

--- a/docs/features/senseki-stats/implementation-plan.md
+++ b/docs/features/senseki-stats/implementation-plan.md
@@ -102,7 +102,7 @@ status: completed
 - **完了条件:** 集計テスト green・event_date 無し大会は期間集計から除外・競技人口=distinct player。
 
 ### タスク8: 大会統計 画面（メイン＋図詳細）（PR-4）
-- [ ] 完了
+- [x] 完了
 - **概要:** `/tournaments/stats`（4カード＋6図・期間フィルタ・完結図は級別構成直下・図4〜6に「級別比較 ›」）＋
   `/tournaments/stats/[metric]`（縦スモールマルチプル・図ごと個別正規化・平均は中立インク破線）。design-spec §3.2/§3.3。
 - **変更対象ファイル:**


### PR DESCRIPTION
## Summary
senseki-stats 統計タブ再編の **PR-4「大会統計」**（タスク7 クエリ＋タスク8 画面）。親 #208 ／ Fixes #215, #216。migration なし（derived_bracket は PR-1 の 0037 で既出）。

### タスク7: クエリ（`apps/web/src/lib/stats/`）
- `getStatsOverview(filter)` — 絶対数4カード（大会数/対戦数/競技人口/延べ参加）＋6図：
  級別構成推移（年×A〜E）／新規参入者（初出場年別・**2011〜**）／一人当たり平均年参加数（x=級）／
  スコアヒスト（枚数差1〜25・平均）／年別競技人口／年別大会参加人数。**期間フィルタのみ**（級で絞らない）。
- `getStatsDetail(metric, filter)` — score / competitors / participations の **全級＋各級A〜E** 系列。
- `filters.ts`（periodConds）／types.ts に `DetailMetric` + `coerceDetailMetric`。
- 設計の要点：新規参入者の初出場年は**全データで確定**し期間は表示窓のみ／**全級(all)は per-grade の合算ではない**
  （competitors は distinct、participations は grade null 級も含む）→ all は別集計／スコアヒストは normal の
  勝者行のみで試合を1回だけ数える。

### タスク8: 画面（`apps/web/src/app/(app)/tournaments/stats/`・`components/stats/`）
- `/tournaments/stats`（メイン：4カード＋6図・図1〜3は完結・図4〜6は「級別比較 ›」ドリル）
- `/tournaments/stats/[metric]`（図詳細：全級＋A〜E の縦スモールマルチプル・図ごと個別正規化）
- 純SVGチャート `charts/`（BarChart / Histogram / StackedComposition・y目盛＋値ラベル・フックなし）＋
  `chart-utils.ts`（niceMax/axisTicks/formatCompact/denseYears）＋`grade-tones.ts`（**藍→砂トーンランプ・
  朱はデータ装飾に使わない・平均線＝中立インク破線**）＋`StatsPeriodFilter`（期間のみ・basePath 共用）。
- section-tabs 配下に配線。E2E senseki-stats-nav は本実装UIへ追随（旧 scaffold h1 撤去）。

## Test plan
- [x] 単体：stats+ranking 全 111 tests green（overview9/detail5/types10/chart-utils9/BarChart4/Histogram5/StackedComposition3/PeriodFilter4/params6/grade-tones5 ほか）
- [x] typecheck（tsc --noEmit）green
- [x] lint（eslint）green
- [ ] E2E（CI）
- [ ] 本番実機目視（ship 後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)