### PR TITLE
fix(senseki): ランキングの指標チップ・フィルタ・件数をタブ直下に固定

### DIFF
--- a/apps/web/src/app/(app)/players/ranking/page.tsx
+++ b/apps/web/src/app/(app)/players/ranking/page.tsx
@@ -42,7 +42,14 @@ export default async function PlayerRankingPage({
   return (
     <div>
       <SectionTabs />
-      <div className="flex flex-col gap-3 p-4">
+
+      {/*
+        指標チップ・フィルタ行・該当件数を区画ごとタブ直下に固定（選手検索バーと同じ挙動）。
+        surface 背景＋下境界＋淡い影で「ヘッダ」を作り、順位リストがその裏に潜って流れる。
+        top-11 はタブ（`sticky top-0 h-11`）分のオフセット。z-10 はタブ（z-20）より後ろ・
+        本文より前。チップの `-mx-4` フルブリード横スクロールを保つため px-4 を持たせる。
+      */}
+      <div className="sticky top-11 z-10 flex flex-col gap-3 border-b border-border bg-surface px-4 pb-3 pt-4 shadow-[0_3px_6px_rgba(60,45,20,0.06)]">
         <RankingMetricChips metric={metric} filter={filter} explicit={explicit} />
         <RankingFilterBar metric={metric} filter={filter} years={years} />
 
@@ -52,7 +59,9 @@ export default async function PlayerRankingPage({
           <span className="text-ink tabular-nums">{total}</span>
           {' 人'}
         </p>
+      </div>
 
+      <div className="px-4 pb-4 pt-3">
         <RankingList
           key={buildRankingHref(metric, filter, explicit)}
           initialRows={rows}


### PR DESCRIPTION
## Summary
- 統計ランキングタブで、スクロール時に **指標チップ（出場/勝利…）・期間/級フィルタ行・「該当N人」件数行** が画面上部（SectionTabs 直下）に固定されるようにした。
- 隣の「選手検索」バーと同じ `sticky top-11 z-10`（bg-surface＋下境界＋淡い影）パターンで区画ごと固定し、順位リストはその裏を流れる。
- チップの `-mx-4` フルブリード横スクロールを保つため固定ヘッダに `px-4` を継承。子コンポーネント（Chips/FilterBar/List）の props・ロジックは不変、`page.tsx` のレイアウトラッパーのみ変更。

## 変更ファイル
- `apps/web/src/app/(app)/players/ranking/page.tsx`（+10 / -1）

## Test plan
- [x] lint（ESLint 警告/エラー 0）
- [x] check-types（tsc --noEmit クリーン）
- [x] ランキング配下テスト 50 件 green（metrics / RankingList / RankingFilterBar / RankingMetricChips）
- [ ] スマホ実機で、下スクロール時にチップ・フィルタ・件数がタブ直下に固定され、リストが裏を流れることを目視
- [ ] 絞り込みボトムシート（fixed inset-0 z-50）が固定ヘッダに影響されず全画面表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)