### PR TITLE
fix(stats): タブ下線の張り付き・競技人口の文言・スコア統計縦軸の割合化

### DIFF
--- a/apps/web/src/app/(app)/tournaments/stats/page.tsx
+++ b/apps/web/src/app/(app)/tournaments/stats/page.tsx
@@ -88,7 +88,11 @@ export default async function TournamentStatsPage({
         </ChartCard>
 
         {/* 図4：スコア統計（ドリル） */}
-        <ChartCard title="スコア統計" note="枚数差の分布（1〜25枚・平均線）" drill={detailHref('score', filter)}>
+        <ChartCard
+          title="スコア統計"
+          note="枚数差ごとの試合割合（%・1〜25枚・平均線）"
+          drill={detailHref('score', filter)}
+        >
           <Histogram
             bins={ov.scoreHistogram.bins}
             average={ov.scoreHistogram.average}
@@ -97,7 +101,11 @@ export default async function TournamentStatsPage({
         </ChartCard>
 
         {/* 図5：年別 競技人口（ドリル） */}
-        <ChartCard title="年別 競技人口" note="各年のユニーク選手数" drill={detailHref('competitors', filter)}>
+        <ChartCard
+          title="年別 競技人口"
+          note="一回以上大会に参加した選手の数"
+          drill={detailHref('competitors', filter)}
+        >
           <BarChart data={competitors} ariaLabel="年別 競技人口の推移" />
         </ChartCard>
 

--- a/apps/web/src/components/stats/charts/Histogram.test.tsx
+++ b/apps/web/src/components/stats/charts/Histogram.test.tsx
@@ -16,11 +16,21 @@ describe('Histogram', () => {
     )
     expect(screen.getByRole('img', { name: '枚数差ヒスト' })).toBeTruthy()
     expect(container.querySelectorAll('rect')).toHaveLength(25)
-    // y 目盛（0,2,4,6,8,10）と衝突しない x 目盛だけを検証する。
+    // x 目盛（枚数差）。y 目盛は割合(%)で末尾に % が付く＝x 目盛の数字と文字列衝突しない。
     const texts = [...container.querySelectorAll('text')].map((t) => t.textContent)
     for (const t of ['1', '5', '15', '20', '25']) {
       expect(texts).toContain(t)
     }
+    // 縦軸は割合(%)＝目盛ラベルは % 付き。
+    expect(texts.some((t) => t?.endsWith('%'))).toBe(true)
+  })
+
+  it('縦軸は合計に対する割合(%)で正規化する', () => {
+    const bins = new Array<number>(25).fill(0)
+    bins[0] = 1 // 唯一の試合 → 枚数差 1 が 100%
+    const { container } = render(<Histogram bins={bins} average={1} ariaLabel="pct" />)
+    const texts = [...container.querySelectorAll('text')].map((t) => t.textContent)
+    expect(texts).toContain('100%')
   })
 
   it('平均線は中立インクの破線（朱不使用）', () => {

--- a/apps/web/src/components/stats/charts/Histogram.tsx
+++ b/apps/web/src/components/stats/charts/Histogram.tsx
@@ -1,4 +1,4 @@
-import { axisTicks, formatCompact, formatDecimal1, niceMax } from './chart-utils'
+import { axisTicks, formatDecimal1, formatPercentTick, niceMax } from './chart-utils'
 
 export interface HistogramProps {
   /** 枚数差ヒスト（length 25：index i＝枚数差 i+1 の試合数）。 */
@@ -25,7 +25,7 @@ const X_TICKS = [1, 5, 10, 15, 20, 25]
 /**
  * 枚数差ヒストグラム（25 本）＋平均線。design-spec §3.2 / §3.3。
  * 平均マーカーは **中立インクの破線**（朱不使用・design-spec §8 / R2）、平均の数値ラベルは藍。
- * 純粋 SVG（フックなし）。棒が密（25 本）なので値ラベルは出さず y 目盛で桁を読む。
+ * 純粋 SVG（フックなし）。棒が密（25 本）なので値ラベルは出さず y 目盛（割合 %）で読む。
  */
 export function Histogram({
   bins,
@@ -38,10 +38,14 @@ export function Histogram({
 }: HistogramProps) {
   const plotW = VW - PL - PR
   const plotH = height - PT - PB
-  const maxVal = bins.reduce((m, v) => Math.max(m, v), 0)
-  // 試合数（件数）軸なので整数目盛で刻む（0.25 等の小数・重複ラベルを避ける）。
-  const top = niceMax(maxVal, true)
-  const ticks = axisTicks(maxVal, true)
+  // 縦軸は「全試合に対する割合(%)」。各図（メイン＝全級／詳細＝各級）ごとに自分の合計を
+  // 分母に正規化するので、絶対数(数千〜万)ではなく枚数差分布の形として読める。
+  const total = bins.reduce((s, v) => s + v, 0)
+  const pct = bins.map((v) => (total > 0 ? (v / total) * 100 : 0))
+  const maxVal = pct.reduce((m, v) => Math.max(m, v), 0)
+  // 割合(%)軸なので小数ステップ可（axisTicks が 0/5/10… のきりの良い値に丸める）。
+  const top = niceMax(maxVal)
+  const ticks = axisTicks(maxVal)
 
   const yOf = (v: number) => PT + (1 - v / top) * plotH
   const baseY = yOf(0)
@@ -81,13 +85,13 @@ export function Histogram({
               className="fill-ink-muted"
               fontSize={8}
             >
-              {formatCompact(t)}
+              {formatPercentTick(t)}
             </text>
           </g>
         )
       })}
 
-      {bins.map((v, i) => {
+      {pct.map((v, i) => {
         const x = PL + slot * i + (slot - barW) / 2
         const y = yOf(v)
         return (

--- a/apps/web/src/components/stats/charts/chart-utils.ts
+++ b/apps/web/src/components/stats/charts/chart-utils.ts
@@ -28,6 +28,11 @@ export function formatDecimal1(n: number): string {
   return n.toFixed(1)
 }
 
+/** 割合軸の目盛表記（整数はそのまま・端数は小数第1位・末尾 %）。 */
+export function formatPercentTick(n: number): string {
+  return `${Number.isInteger(n) ? n : n.toFixed(1)}%`
+}
+
 /** 目盛のおおよその目標本数（実際の本数はステップ丸めで前後する）。 */
 const TICK_TARGET = 5
 

--- a/apps/web/src/components/stats/section-tabs.tsx
+++ b/apps/web/src/components/stats/section-tabs.tsx
@@ -71,22 +71,21 @@ export function SectionTabs() {
       {SECTIONS.map((s) => {
         const active = s.href === current
         return (
+          // アクティブ下線は Link（タブ全幅・全高）に直接 border-b で付ける。nav は
+          // items-stretch なので下線はタブ下辺にピタッと張り付き（浮かない）、幅もタブ全幅。
+          // -mb-px で nav 自身の 1px 区切り線に重ね、下辺ラインとして揃える。
           <Link
             key={s.id}
             href={s.href}
             aria-current={active ? 'page' : undefined}
-            className="flex flex-1 items-center justify-center text-[13px]"
+            className={cn(
+              'flex flex-1 items-center justify-center border-b-[3px] text-[13px] transition-colors -mb-px',
+              active
+                ? 'border-brand font-medium text-brand'
+                : 'border-transparent text-ink-meta',
+            )}
           >
-            <span
-              className={cn(
-                'inline-block rounded-[2px] border-b-[2.5px] pb-1 transition-colors',
-                active
-                  ? 'border-brand font-medium text-brand'
-                  : 'border-transparent text-ink-meta',
-              )}
-            >
-              {s.label}
-            </span>
+            {s.label}
           </Link>
         )
       })}


### PR DESCRIPTION
## Summary
統計画面の3点のUI修正（ユーザー指摘 /quickfix）。

1. **セクションタブのアクティブ下線** — 文字幅ぶんで下辺から浮いていたのを、`Link`（タブ全幅・全高）に `border-b-[3px]` を直付けし、`items-stretch` の下辺にピタッと張り付く全幅の下線に変更（`-mb-px` で nav の1px区切り線に重ねる）。`<span>` ラッパー廃止。
2. **年別競技人口の注記** — 「各年のユニーク選手数」→「一回以上大会に参加した選手の数」。
3. **スコア統計の縦軸** — 試合数（絶対数＝数千〜万）→ **全試合に対する割合（%）** に変更。各図（メイン＝全級／詳細＝各級）ごとに自分の合計を分母に正規化。横軸＝枚数差・破線＝平均枚数差は不変。集計ロジック（サーバ）は変更なし、割合はコンポーネント側で算出。

## 変更ファイル
- `apps/web/src/components/stats/section-tabs.tsx` — アクティブ下線を Link 全幅・下辺へ
- `apps/web/src/app/(app)/tournaments/stats/page.tsx` — 図5注記の文言・図4注記を割合表記へ
- `apps/web/src/components/stats/charts/Histogram.tsx` — 縦軸を割合(%)へ（合計で正規化）
- `apps/web/src/components/stats/charts/chart-utils.ts` — `formatPercentTick` 追加
- `apps/web/src/components/stats/charts/Histogram.test.tsx` — % 表示のカバレッジ追加

## Test plan
- [x] 単体テスト（Histogram / section-tabs / params）22件 green
- [x] typecheck / eslint green
- [ ] スマホ実機で3点の見た目確認（下線の張り付き・文言・縦軸%）

🤖 Generated with [Claude Code](https://claude.com/claude-code)