### PR TITLE
fix(stats): 絞り込みボトムシートの下端（適用ボタン）が画面外に隠れる不具合を修正

### DIFF
--- a/apps/web/src/app/(app)/players/ranking/RankingFilterBar.tsx
+++ b/apps/web/src/app/(app)/players/ranking/RankingFilterBar.tsx
@@ -133,11 +133,11 @@ export function RankingFilterBar({
           role="dialog"
           aria-modal="true"
           aria-label="絞り込み"
-          className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 sm:items-center"
+          className="fixed inset-x-0 top-0 z-50 flex h-[100dvh] items-end justify-center bg-black/40 sm:items-center"
           onClick={() => setOpen(false)}
         >
           <div
-            className="flex w-full flex-col gap-4 rounded-t-2xl bg-surface p-4 pb-[calc(1rem_+_env(safe-area-inset-bottom))] sm:max-w-md sm:rounded-2xl sm:pb-4"
+            className="flex max-h-full w-full flex-col gap-4 overflow-y-auto rounded-t-2xl bg-surface p-4 pb-[calc(1rem_+_env(safe-area-inset-bottom))] sm:max-w-md sm:rounded-2xl sm:pb-4"
             onClick={(e) => e.stopPropagation()}
           >
             <header className="flex items-center justify-between">

--- a/apps/web/src/components/stats/StatsPeriodFilter.tsx
+++ b/apps/web/src/components/stats/StatsPeriodFilter.tsx
@@ -88,11 +88,11 @@ export function StatsPeriodFilter({
           role="dialog"
           aria-modal="true"
           aria-label="期間で絞り込み"
-          className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 sm:items-center"
+          className="fixed inset-x-0 top-0 z-50 flex h-[100dvh] items-end justify-center bg-black/40 sm:items-center"
           onClick={() => setOpen(false)}
         >
           <div
-            className="flex w-full flex-col gap-4 rounded-t-2xl bg-surface p-4 pb-[calc(1rem_+_env(safe-area-inset-bottom))] sm:max-w-md sm:rounded-2xl sm:pb-4"
+            className="flex max-h-full w-full flex-col gap-4 overflow-y-auto rounded-t-2xl bg-surface p-4 pb-[calc(1rem_+_env(safe-area-inset-bottom))] sm:max-w-md sm:rounded-2xl sm:pb-4"
             onClick={(e) => e.stopPropagation()}
           >
             <header className="flex items-center justify-between">


### PR DESCRIPTION
## Summary
統計画面の絞り込みボトムシート（ランキングタブ／期間絞り込み）で、シート下端の**クリア/適用ボタンが画面外に隠れて押せない**不具合を修正。

- **原因:** 外側コンテナが `fixed inset-0`（レイアウトビューポート基準の全画面）で、パネルを `items-end` で下端に固定していた。モバイルブラウザではレイアウトビューポート下端が URL バーの裏＝可視領域外に来るため、下端に貼ったパネルの一番下（ボタン）が画面外に隠れる。さらにパネルに高さ上限・スクロールが無く、内容が高い勝率タブ（最低試合数欄）や級選択時（昇段済みトグル）で一層はみ出していた。
- **修正（CSS のみ・挙動/ロジック不変）:**
  - 外側コンテナを可視ビューポート高追従に（`inset-0` → `inset-x-0 top-0 h-[100dvh]`）。`items-end` の貼り付き先が可視領域の下端になる。
  - パネルに `max-h-full overflow-y-auto` を付与。内容が可視領域を超えたらパネル内スクロールにし、適用/クリアを常に到達可能に（安全領域の下パディングは維持）。
- 対象: `RankingFilterBar.tsx`（ランキングタブ）＋ 同一マークアップの `StatsPeriodFilter.tsx`（他統計タブの期間絞り込み）の両方。

## Test plan
- lint / tsc / 対象コンポーネントテスト18件 green。
- [ ] 実機（iPhone/PWA）で、統計→ランキング→絞り込みを開き、勝率タブ＋級選択の最長状態でも適用/クリアが表示・スクロール到達できることを目視。期間絞り込みシートも同様。

🤖 Generated with [Claude Code](https://claude.com/claude-code)