### PR TITLE
fix(ui): 残りのボトムシート全モーダルの下端が画面外に隠れる不具合を修正

### DIFF
--- a/apps/web/src/app/(app)/admin/mail-inbox/components/ExistingEventLinkSheet.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/components/ExistingEventLinkSheet.tsx
@@ -87,7 +87,7 @@ export function ExistingEventLinkSheet({
           role="dialog"
           aria-modal="true"
           aria-labelledby="link-event-sheet-title"
-          className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 sm:items-center sm:p-4"
+          className="fixed inset-x-0 top-0 z-50 flex h-[100dvh] items-end justify-center bg-black/40 sm:items-center sm:p-4"
           onClick={() => !pending && setOpen(false)}
         >
           <div

--- a/apps/web/src/components/admin/ManualLinkModal.tsx
+++ b/apps/web/src/components/admin/ManualLinkModal.tsx
@@ -93,11 +93,11 @@ export function ManualLinkModal({
           role="dialog"
           aria-modal="true"
           aria-label={`${channelLabel} 手動紐付け`}
-          className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40"
+          className="fixed inset-x-0 top-0 z-50 flex h-[100dvh] items-end sm:items-center justify-center bg-black/40"
           onClick={handleClose}
         >
           <div
-            className="w-full sm:max-w-md bg-surface rounded-t-2xl sm:rounded-2xl p-4 flex flex-col gap-3"
+            className="max-h-full overflow-y-auto w-full sm:max-w-md bg-surface rounded-t-2xl sm:rounded-2xl p-4 flex flex-col gap-3"
             onClick={(e) => e.stopPropagation()}
           >
             <h2 className="text-base font-semibold text-ink-1">手動紐付け</h2>

--- a/apps/web/src/components/admin/RegistrationInviteModal.tsx
+++ b/apps/web/src/components/admin/RegistrationInviteModal.tsx
@@ -81,11 +81,11 @@ export function RegistrationInviteModal({ payload, onClose }: RegistrationInvite
       role="dialog"
       aria-modal="true"
       aria-label="招待リンク"
-      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40"
+      className="fixed inset-x-0 top-0 z-50 flex h-[100dvh] items-end sm:items-center justify-center bg-black/40"
       onClick={onClose}
     >
       <div
-        className="w-full sm:max-w-md bg-surface rounded-t-2xl sm:rounded-2xl p-4 flex flex-col gap-4"
+        className="max-h-full overflow-y-auto w-full sm:max-w-md bg-surface rounded-t-2xl sm:rounded-2xl p-4 flex flex-col gap-4"
         onClick={(e) => e.stopPropagation()}
       >
         <header className="flex items-start justify-between gap-3">

--- a/apps/web/src/components/events/InviteCodeModal.tsx
+++ b/apps/web/src/components/events/InviteCodeModal.tsx
@@ -76,11 +76,11 @@ export function InviteCodeModal({
       role="dialog"
       aria-modal="true"
       aria-label={`${eventTitle} の LINE 配信 招待コード`}
-      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40"
+      className="fixed inset-x-0 top-0 z-50 flex h-[100dvh] items-end sm:items-center justify-center bg-black/40"
       onClick={onClose}
     >
       <div
-        className="w-full sm:max-w-md bg-surface rounded-t-2xl sm:rounded-2xl p-4 flex flex-col gap-4"
+        className="max-h-full overflow-y-auto w-full sm:max-w-md bg-surface rounded-t-2xl sm:rounded-2xl p-4 flex flex-col gap-4"
         onClick={(e) => e.stopPropagation()}
       >
         <header className="flex items-start justify-between gap-3">

--- a/apps/web/src/components/layout/account-menu.tsx
+++ b/apps/web/src/components/layout/account-menu.tsx
@@ -71,11 +71,11 @@ export function AccountMenu({ user, isAdmin, signOutAction }: AccountMenuProps) 
           role="dialog"
           aria-modal="true"
           aria-label="設定"
-          className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40"
+          className="fixed inset-x-0 top-0 z-50 flex h-[100dvh] items-end sm:items-center justify-center bg-black/40"
           onClick={close}
         >
           <div
-            className="w-full sm:max-w-md bg-surface rounded-t-2xl sm:rounded-2xl p-4 pb-[calc(1rem_+_env(safe-area-inset-bottom))] sm:pb-4 flex flex-col gap-1"
+            className="max-h-full overflow-y-auto w-full sm:max-w-md bg-surface rounded-t-2xl sm:rounded-2xl p-4 pb-[calc(1rem_+_env(safe-area-inset-bottom))] sm:pb-4 flex flex-col gap-1"
             onClick={(e) => e.stopPropagation()}
           >
             <header className="flex items-center justify-between gap-3 pb-2">


### PR DESCRIPTION
## Summary
PR #253 で直した「ボトムシートの下端（ボタン等）がモバイル URL バーの裏＝画面外に隠れる」不具合を、**同じ脆弱パターン（`fixed inset-0` + `items-end`）を持つ残り全モーダル**に横展開（ユーザー要望「全部直して」）。

- **原因:** 外側オーバーレイが `fixed inset-0`（レイアウトビューポート基準）＋パネルを `items-end` で下端固定。モバイルはレイアウトビューポート下端が URL バーの裏＝可視領域外に来るため、パネル下端が隠れる。高さ上限・スクロールが無いと内容が高いとき一層はみ出す。
- **修正（CSS のみ・挙動不変）:**
  - `InviteCodeModal` / `RegistrationInviteModal` / `ManualLinkModal` / `account-menu`: 外側 `inset-0` → `inset-x-0 top-0 h-[100dvh]`（可視VP追従）＋パネルに `max-h-full overflow-y-auto`。
  - `ExistingEventLinkSheet`: 外側のみ `inset-x-0 top-0 h-[100dvh]`（パネルは既に `max-h-[80vh]`＋内側スクロールを持つため据え置き）。

対象5ファイル。デスクトップ（`sm:items-center`）は不変。

## Test plan
- lint / tsc / account-menu・ExistingEventLinkSheet テスト14件 green。
- [ ] 実機（iPhone/PWA）で各モーダル（設定シート／招待コード／招待リンク／手動紐付け／既存イベント紐付け）を開き、下端の要素/ボタンが表示・スクロール到達できることを目視。

🤖 Generated with [Claude Code](https://claude.com/claude-code)