### PR TITLE
fix(stats): スコア統計→枚数差統計 改称＋パレート図化＋級別比較の分析文

### DIFF
--- a/apps/web/src/app/(app)/tournaments/stats/[metric]/page.tsx
+++ b/apps/web/src/app/(app)/tournaments/stats/[metric]/page.tsx
@@ -25,6 +25,8 @@ const MIN_YEAR = 2010
  * 図の内容は指標ごとに異なるため文章も指標単位で持ち、未設定の指標は共通注記のみ表示する。
  */
 const METRIC_ANALYSIS: Partial<Record<DetailMetric, string>> = {
+  score:
+    '各級共に運命戦が一番多い。級毎の比較を行うと、E級からB級までは平均枚数差は減少傾向にあり、このことから級が上がるにつれ選手間の実力の差が小さくなってくことが予想される。一方でB→A級は+0.4枚と若干の増加であり、これはA級には昇級がないためB級と比べ同級内でも実力に差異が生じやすいためであると考えられる。枚数差で判断すると最も参加者間に実力差があるのはE級、実力差が小さいのはB級である。',
   competitors:
     'グラフはその年に1度以上大会に参加した選手数（＝競技人口）をカウントしたものです。2020年はコロナ禍の影響で競技人口の落ち込みが顕著ですが、翌年以降は徐々に回復傾向にあることがうかがえます。',
 }
@@ -129,7 +131,7 @@ function PanelHeader({
   )
 }
 
-/** score 詳細の 1 パネル（枚数差ヒスト・個別正規化・平均線）。 */
+/** score 詳細の 1 パネル（枚数差パレート図・個別正規化・平均線・累積%右軸）。 */
 function ScorePanel({ series }: { series: ScoreSeries }) {
   const total = series.bins.reduce((s, v) => s + v, 0)
   const tone = gradeTone(series.key)
@@ -147,7 +149,7 @@ function ScorePanel({ series }: { series: ScoreSeries }) {
         color={tone}
         height={120}
         showAverageLabel={false}
-        ariaLabel={`${seriesLabel(series.key)}の枚数差ヒストグラム`}
+        ariaLabel={`${seriesLabel(series.key)}の枚数差パレート図`}
       />
     </Card>
   )

--- a/apps/web/src/app/(app)/tournaments/stats/page.tsx
+++ b/apps/web/src/app/(app)/tournaments/stats/page.tsx
@@ -87,16 +87,16 @@ export default async function TournamentStatsPage({
           />
         </ChartCard>
 
-        {/* 図4：スコア統計（ドリル） */}
+        {/* 図4：枚数差統計（ドリル） */}
         <ChartCard
-          title="スコア統計"
-          note="枚数差ごとの試合割合（%・1〜25枚・平均線）"
+          title="枚数差統計"
+          note="枚数差ごとの試合割合（%・1〜25枚・平均線）と累積割合（右軸）"
           drill={detailHref('score', filter)}
         >
           <Histogram
             bins={ov.scoreHistogram.bins}
             average={ov.scoreHistogram.average}
-            ariaLabel="スコア統計（枚数差ヒストグラム）"
+            ariaLabel="枚数差統計（枚数差パレート図）"
           />
         </ChartCard>
 

--- a/apps/web/src/app/(app)/tournaments/stats/params.test.ts
+++ b/apps/web/src/app/(app)/tournaments/stats/params.test.ts
@@ -47,7 +47,7 @@ describe('buildStatsHref / detailHref', () => {
 
 describe('detailMetricTitle / coerceDetailMetric', () => {
   it('指標のタイトル', () => {
-    expect(detailMetricTitle('score')).toBe('スコア統計')
+    expect(detailMetricTitle('score')).toBe('枚数差統計')
     expect(detailMetricTitle('competitors')).toBe('年別 競技人口')
     expect(detailMetricTitle('participations')).toBe('年別 大会参加人数')
   })

--- a/apps/web/src/app/(app)/tournaments/stats/params.ts
+++ b/apps/web/src/app/(app)/tournaments/stats/params.ts
@@ -52,7 +52,7 @@ export interface DetailMetricDef {
 }
 
 export const DETAIL_METRICS: readonly DetailMetricDef[] = [
-  { key: 'score', title: 'スコア統計' },
+  { key: 'score', title: '枚数差統計' },
   { key: 'competitors', title: '年別 競技人口' },
   { key: 'participations', title: '年別 大会参加人数' },
 ]

--- a/apps/web/src/components/stats/charts/Histogram.test.tsx
+++ b/apps/web/src/components/stats/charts/Histogram.test.tsx
@@ -29,8 +29,46 @@ describe('Histogram', () => {
     const bins = new Array<number>(25).fill(0)
     bins[0] = 1 // 唯一の試合 → 枚数差 1 が 100%
     const { container } = render(<Histogram bins={bins} average={1} ariaLabel="pct" />)
-    const texts = [...container.querySelectorAll('text')].map((t) => t.textContent)
-    expect(texts).toContain('100%')
+    // 右軸（累積%）にも 100% が常に出るため、左軸ラベル（text-anchor=end）に限定して確認する。
+    const leftTexts = [...container.querySelectorAll('text[text-anchor="end"]')].map(
+      (t) => t.textContent,
+    )
+    expect(leftTexts).toContain('100%')
+  })
+
+  it('累積%の折れ線（パレート）を描き、終点は右軸 100%（上端）に達する', () => {
+    const { container } = render(
+      <Histogram bins={bins25()} average={6} ariaLabel="パレート" />,
+    )
+    const line = container.querySelector('polyline')
+    expect(line).not.toBeNull()
+    expect(line!.getAttribute('fill')).toBe('none')
+    // 実線の中立インク（破線の平均線と区別・朱不使用）。
+    expect(line!.getAttribute('class') ?? '').toContain('neutral')
+    expect(line!.hasAttribute('stroke-dasharray')).toBe(false)
+    // 25 点（枚数差 1〜25）で、累積 100% の終点はプロット上端 y=PT(14)。
+    const points = (line!.getAttribute('points') ?? '').split(' ')
+    expect(points).toHaveLength(25)
+    expect(points[points.length - 1]!.endsWith(',14')).toBe(true)
+  })
+
+  it('右軸（累積%）の目盛 0/25/50/75/100% を出す', () => {
+    const { container } = render(
+      <Histogram bins={bins25()} average={6} ariaLabel="右軸" />,
+    )
+    const rightTexts = [...container.querySelectorAll('text[text-anchor="start"]')].map(
+      (t) => t.textContent,
+    )
+    for (const t of ['0%', '25%', '50%', '75%', '100%']) {
+      expect(rightTexts).toContain(t)
+    }
+  })
+
+  it('合計 0 なら累積折れ線を出さない', () => {
+    const { container } = render(
+      <Histogram bins={new Array(25).fill(0)} average={0} ariaLabel="空パレート" />,
+    )
+    expect(container.querySelector('polyline')).toBeNull()
   })
 
   it('平均線は中立インクの破線（朱不使用）', () => {

--- a/apps/web/src/components/stats/charts/Histogram.tsx
+++ b/apps/web/src/components/stats/charts/Histogram.tsx
@@ -16,16 +16,20 @@ export interface HistogramProps {
 
 const VW = 320
 const PL = 32
-const PR = 6
+const PR = 26
 const PT = 14
 const PB = 20
 /** x 軸ラベルを出す枚数差（1・5・10・15・20・25）。 */
 const X_TICKS = [1, 5, 10, 15, 20, 25]
+/** 右軸（累積%）の目盛。累積は必ず 0〜100% なので固定刻み。 */
+const CUM_TICKS = [0, 25, 50, 75, 100]
 
 /**
- * 枚数差ヒストグラム（25 本）＋平均線。design-spec §3.2 / §3.3。
- * 平均マーカーは **中立インクの破線**（朱不使用・design-spec §8 / R2）、平均の数値ラベルは藍。
- * 純粋 SVG（フックなし）。棒が密（25 本）なので値ラベルは出さず y 目盛（割合 %）で読む。
+ * 枚数差パレート図（棒 25 本＋累積%折れ線＋平均線）。design-spec §3.2 / §3.3。
+ * 左軸＝枚数差ごとの試合割合(%・図ごと個別正規化)、右軸＝累積割合(0〜100%固定)。
+ * 累積線は中立インクの実線、平均マーカーは **中立インクの破線**（いずれも朱不使用・
+ * design-spec §8 / R2）、平均の数値ラベルは藍。純粋 SVG（フックなし）。棒が密（25 本）
+ * なので値ラベルは出さず y 目盛（割合 %）で読む。
  */
 export function Histogram({
   bins,
@@ -57,6 +61,17 @@ export function Histogram({
   const cxOfDiff = (d: number) => PL + slot * (d - 1) + slot / 2
   const avgClamped = Math.min(Math.max(average, 1), n)
   const avgX = cxOfDiff(avgClamped)
+
+  // パレート用の累積割合(%)。左軸（個別正規化）とはスケールが異なるため右軸（0〜100%固定）
+  // で写像する。合計 0 のときは折れ線を描かない（0 除算による NaN 座標を避ける）。
+  const cum: number[] = []
+  pct.reduce((acc, v) => {
+    const next = acc + v
+    cum.push(next)
+    return next
+  }, 0)
+  const yOfCum = (v: number) => PT + (1 - v / 100) * plotH
+  const cumPoints = cum.map((v, i) => `${cxOfDiff(i + 1)},${yOfCum(v)}`).join(' ')
 
   return (
     <svg
@@ -91,6 +106,20 @@ export function Histogram({
         )
       })}
 
+      {/* 右軸（累積%）の目盛ラベル */}
+      {CUM_TICKS.map((t) => (
+        <text
+          key={`c${t}`}
+          x={VW - PR + 3}
+          y={yOfCum(t) + 3}
+          textAnchor="start"
+          className="fill-ink-muted"
+          fontSize={8}
+        >
+          {formatPercentTick(t)}
+        </text>
+      ))}
+
       {pct.map((v, i) => {
         const x = PL + slot * i + (slot - barW) / 2
         const y = yOf(v)
@@ -105,6 +134,11 @@ export function Histogram({
           />
         )
       })}
+
+      {/* 累積%の折れ線（パレート・右軸スケール・中立インク実線＝破線の平均線と区別） */}
+      {total > 0 ? (
+        <polyline points={cumPoints} fill="none" className="stroke-neutral-fg" strokeWidth={1.2} />
+      ) : null}
 
       {/* x 軸ラベル（1・5・…・25） */}
       {X_TICKS.map((d) => (

--- a/apps/web/src/lib/stats/overview.test.ts
+++ b/apps/web/src/lib/stats/overview.test.ts
@@ -149,7 +149,7 @@ describe('getStatsOverview — 図3 一人当たり 平均年参加数（x=級�
   })
 })
 
-describe('getStatsOverview — 図4 スコア統計（枚数差ヒスト）', () => {
+describe('getStatsOverview — 図4 枚数差統計（枚数差ヒスト）', () => {
   it('normal の勝者行のみ・1〜25 の 25 本・平均は試合数で加重', async () => {
     await seed('大会', '2025-04-01', [
       classWith('D級', 'D', [

--- a/apps/web/src/lib/stats/overview.ts
+++ b/apps/web/src/lib/stats/overview.ts
@@ -14,7 +14,7 @@ import { ALL_GRADES, sanitizeStatsFilter, type Grade, type StatsFilter } from '.
  *   1. 級別構成の推移（年×A〜E の 100% 積み上げ・延べ参加）
  *   2. 新規参入者の推移（初出場年別・**2011〜**＝収録開始 2010 は既存選手を含むため左側打ち切り）
  *   3. 一人当たり 平均年参加数（x=級 A〜E・その人がその年に出た大会数の平均）
- *   4. スコア統計（枚数差 1〜25 の 25 本ヒスト＋平均）
+ *   4. 枚数差統計（枚数差 1〜25 の 25 本ヒスト＋平均。UI ではパレート図＝累積%右軸つき）
  *   5. 年別 競技人口 ／ 6. 年別 大会参加人数
  */
 
@@ -54,7 +54,7 @@ export interface PerPlayerAvgPoint {
   avg: number
 }
 
-/** 図4：スコア統計（枚数差ヒスト）。 */
+/** 図4：枚数差統計（枚数差ヒスト）。 */
 export interface ScoreHistogram {
   /** length 25。index i＝枚数差 (i+1) 枚の試合数。 */
   bins: number[]


### PR DESCRIPTION
## Summary
- **改称**: 大会統計タブ 図4 とその図詳細のタイトルを「スコア統計」→「枚数差統計」に変更（URL キー `score` は据え置き＝既存リンク非破壊）
- **パレート図化**: `Histogram` に累積%の折れ線と**右側第二軸（0〜100%固定・0/25/50/75/100 目盛）**を追加。メイン図4と級別比較の全パネル（全級＋A〜E）両方に適用。棒は枚数差 1〜25 の順序を維持（運命戦=1枚差が最頻でほぼ降順のため実質パレート順・ユーザー承認済み）。累積線は中立インク実線で破線の平均線と区別（朱不使用ルール遵守）
- **分析文追加**: 枚数差統計の級別比較ページに指定の分析文（運命戦最多／E→B で平均枚数差減少＝実力差縮小／B→A は +0.4 枚で A 級は昇級なしのため差異が生じやすい／実力差最大は E 級・最小は B 級）を `METRIC_ANALYSIS.score` として追加
- **テスト**: タイトル期待値更新、累積折れ線（25点・終点=右軸100%）／右軸目盛／合計0時の非描画テストを追加。左軸100%検証は text-anchor で左右を区別するよう強化

## Test plan
- [x] `pnpm test`（web 88 files / 1104 tests green）
- [x] `pnpm check-types` / `pnpm lint` green
- [x] `next build` コンパイル成功（standalone symlink EPERM はローカル Windows 権限の環境問題・CI で最終確認）
- [ ] 実機目視（/tournaments/stats 図4・/tournaments/stats/score 級別比較）

🤖 Generated with [Claude Code](https://claude.com/claude-code)