### PR TITLE
fix(stats): 枚数差統計 分析文差し替え＋左軸0〜10%固定

### DIFF
--- a/apps/web/src/app/(app)/tournaments/stats/[metric]/page.tsx
+++ b/apps/web/src/app/(app)/tournaments/stats/[metric]/page.tsx
@@ -26,7 +26,7 @@ const MIN_YEAR = 2010
  */
 const METRIC_ANALYSIS: Partial<Record<DetailMetric, string>> = {
   score:
-    '各級共に運命戦が一番多い。級毎の比較を行うと、E級からB級までは平均枚数差は減少傾向にあり、このことから級が上がるにつれ選手間の実力の差が小さくなってくことが予想される。一方でB→A級は+0.4枚と若干の増加であり、これはA級には昇級がないためB級と比べ同級内でも実力に差異が生じやすいためであると考えられる。枚数差で判断すると最も参加者間に実力差があるのはE級、実力差が小さいのはB級である。',
+    '各級共に運命戦での決着が一番多い。級毎の比較を行うとE級からB級までは平均枚数差は減少傾向であり、このことから級が上がるにつれ選手間の実力差も小さくなっていくことが予想される。一方でB級→A級では+0.4枚と若干増であり、これはA級には昇級がないため同級であっても実力に差が生じやすいためであると考えられる。枚数差から推測されるに、参加者の中に最も実力差があるのはE級、逆にそれが小さいのはB級である。',
   competitors:
     'グラフはその年に1度以上大会に参加した選手数（＝競技人口）をカウントしたものです。2020年はコロナ禍の影響で競技人口の落ち込みが顕著ですが、翌年以降は徐々に回復傾向にあることがうかがえます。',
 }
@@ -34,8 +34,9 @@ const METRIC_ANALYSIS: Partial<Record<DetailMetric, string>> = {
 /**
  * /tournaments/stats/[metric] — ④ 大会統計・図詳細（級別比較）。requirements §3.6・design-spec §3.3。
  *
- * 全級（参照）＋各級（A〜E）を**縦スモールマルチプル**で並べる。縦軸は形状比較のため図ごと
- * 個別正規化（各ミニ図が自分の最大でスケール）。metric = score / competitors / participations。
+ * 全級（参照）＋各級（A〜E）を**縦スモールマルチプル**で並べる。縦軸は score＝全図共通
+ * 0〜10% 固定（級間で高さを直接比較）、competitors/participations＝形状比較のため図ごと
+ * 個別正規化。metric = score / competitors / participations。
  * プッシュ表示のため SectionTabs は出さず戻る導線のみ。期間フィルタは有効（級では絞らない）。
  */
 export default async function StatsDetailPage({
@@ -74,7 +75,9 @@ export default async function StatsDetailPage({
       <StatsPeriodFilter basePath={`/tournaments/stats/${metric}`} filter={filter} years={years} />
 
       <p className="text-xs text-ink-meta">
-        全級（参照）と各級（A〜E）を並べて比較します。縦軸は形状比較のため図ごとに個別正規化しています。
+        {metric === 'score'
+          ? '全級（参照）と各級（A〜E）を並べて比較します。縦軸は全図共通の0〜10%、右軸は累積割合（0〜100%）です。'
+          : '全級（参照）と各級（A〜E）を並べて比較します。縦軸は形状比較のため図ごとに個別正規化しています。'}
       </p>
       {METRIC_ANALYSIS[metric] ? (
         <p className="text-xs leading-relaxed text-ink-meta">{METRIC_ANALYSIS[metric]}</p>

--- a/apps/web/src/components/stats/charts/Histogram.test.tsx
+++ b/apps/web/src/components/stats/charts/Histogram.test.tsx
@@ -25,15 +25,24 @@ describe('Histogram', () => {
     expect(texts.some((t) => t?.endsWith('%'))).toBe(true)
   })
 
-  it('縦軸は合計に対する割合(%)で正規化する', () => {
-    const bins = new Array<number>(25).fill(0)
-    bins[0] = 1 // 唯一の試合 → 枚数差 1 が 100%
-    const { container } = render(<Histogram bins={bins} average={1} ariaLabel="pct" />)
-    // 右軸（累積%）にも 100% が常に出るため、左軸ラベル（text-anchor=end）に限定して確認する。
+  it('左軸は全図共通の 0〜10% 固定（目盛 0/2.5/5/7.5/10%）', () => {
+    const { container } = render(<Histogram bins={bins25()} average={6} ariaLabel="pct" />)
+    // 右軸（累積%）ラベルは text-anchor=start なので、左軸ラベル（text-anchor=end）に限定する。
     const leftTexts = [...container.querySelectorAll('text[text-anchor="end"]')].map(
       (t) => t.textContent,
     )
-    expect(leftTexts).toContain('100%')
+    expect(leftTexts).toEqual(['0%', '2.5%', '5%', '7.5%', '10%'])
+  })
+
+  it('10% を超えるビンは上端（y=PT）で頭打ちに描く', () => {
+    const bins = new Array<number>(25).fill(0)
+    bins[0] = 1 // 唯一の試合 → 枚数差 1 が 100% ＝ 固定軸 10% を超過
+    const { container } = render(<Histogram bins={bins} average={1} ariaLabel="clamp" />)
+    const rects = [...container.querySelectorAll('rect')]
+    expect(rects).toHaveLength(25)
+    // 既定 height=150・PT=14・PB=20 → plotH=116。頭打ちの棒は y=14・height=116。
+    expect(rects[0]!.getAttribute('y')).toBe('14')
+    expect(rects[0]!.getAttribute('height')).toBe('116')
   })
 
   it('累積%の折れ線（パレート）を描き、終点は右軸 100%（上端）に達する', () => {

--- a/apps/web/src/components/stats/charts/Histogram.tsx
+++ b/apps/web/src/components/stats/charts/Histogram.tsx
@@ -1,4 +1,4 @@
-import { axisTicks, formatDecimal1, formatPercentTick, niceMax } from './chart-utils'
+import { formatDecimal1, formatPercentTick } from './chart-utils'
 
 export interface HistogramProps {
   /** 枚数差ヒスト（length 25：index i＝枚数差 i+1 の試合数）。 */
@@ -21,12 +21,17 @@ const PT = 14
 const PB = 20
 /** x 軸ラベルを出す枚数差（1・5・10・15・20・25）。 */
 const X_TICKS = [1, 5, 10, 15, 20, 25]
+/** 左軸（試合割合%）の上端。全図共通の固定スケール（級間で高さを直接比較できるように）。 */
+const Y_MAX = 10
+/** 左軸の目盛（0/2.5/5/7.5/10%）。右軸 0/25/50/75/100 と同じ4等分＝罫線を共有する。 */
+const Y_TICKS = [0, 2.5, 5, 7.5, 10]
 /** 右軸（累積%）の目盛。累積は必ず 0〜100% なので固定刻み。 */
 const CUM_TICKS = [0, 25, 50, 75, 100]
 
 /**
  * 枚数差パレート図（棒 25 本＋累積%折れ線＋平均線）。design-spec §3.2 / §3.3。
- * 左軸＝枚数差ごとの試合割合(%・図ごと個別正規化)、右軸＝累積割合(0〜100%固定)。
+ * 左軸＝枚数差ごとの試合割合(%・全図共通 0〜10% 固定)、右軸＝累積割合(0〜100%固定)。
+ * 10% を超えるビン（期間を狭く絞った小母数の級で起こり得る）は上端で頭打ちに描く。
  * 累積線は中立インクの実線、平均マーカーは **中立インクの破線**（いずれも朱不使用・
  * design-spec §8 / R2）、平均の数値ラベルは藍。純粋 SVG（フックなし）。棒が密（25 本）
  * なので値ラベルは出さず y 目盛（割合 %）で読む。
@@ -44,14 +49,13 @@ export function Histogram({
   const plotH = height - PT - PB
   // 縦軸は「全試合に対する割合(%)」。各図（メイン＝全級／詳細＝各級）ごとに自分の合計を
   // 分母に正規化するので、絶対数(数千〜万)ではなく枚数差分布の形として読める。
+  // スケールは全図共通の 0〜Y_MAX(10%) 固定（全期間表示の最大ビンは 9.7% 弱で収まる実測）。
   const total = bins.reduce((s, v) => s + v, 0)
   const pct = bins.map((v) => (total > 0 ? (v / total) * 100 : 0))
-  const maxVal = pct.reduce((m, v) => Math.max(m, v), 0)
-  // 割合(%)軸なので小数ステップ可（axisTicks が 0/5/10… のきりの良い値に丸める）。
-  const top = niceMax(maxVal)
-  const ticks = axisTicks(maxVal)
+  const top = Y_MAX
+  const ticks = Y_TICKS
 
-  const yOf = (v: number) => PT + (1 - v / top) * plotH
+  const yOf = (v: number) => PT + (1 - Math.min(v, top) / top) * plotH
   const baseY = yOf(0)
   const n = bins.length // 25
   const slot = plotW / n


### PR DESCRIPTION
## Summary
- 級別比較ページの分析文（`METRIC_ANALYSIS.score`）をユーザー指定の新文言へ差し替え
- パレート図の左軸を個別正規化から**全図共通 0〜10% 固定**に変更（目盛 0/2.5/5/7.5/10%）。右軸は従来どおり 0/25/50/75/100 で、罫線は両軸4等分を共有
- 10% を超えるビンは上端で頭打ちに描画（全期間表示は最大 9.68%＝B級運命戦で収まることをリハDB実測で確認。期間を狭く絞ると最大 13.7% のケースあり）
- 級別比較ページの注記を score のみ「縦軸は全図共通の0〜10%、右軸は累積割合」に分岐

## Test plan
- [x] `pnpm test`（web 88 files / 1105 tests green・固定軸目盛/頭打ちテスト追加）
- [x] `pnpm check-types` / `pnpm lint` green
- [ ] 実機目視（/tournaments/stats 図4・/tournaments/stats/score）

🤖 Generated with [Claude Code](https://claude.com/claude-code)