### PR TITLE
fix(ui): ボトムシートを Portal 化＋svh カスケードで下端はみ出しを根治

### DIFF
--- a/apps/web/src/app/(app)/admin/mail-inbox/components/ExistingEventLinkSheet.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/components/ExistingEventLinkSheet.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useState, useTransition } from 'react'
+import { createPortal } from 'react-dom'
 import { useRouter } from 'next/navigation'
 import type { EventStatus } from '@kagetra/shared/types'
 import { Btn, Card } from '@/components/ui'
@@ -82,12 +83,15 @@ export function ExistingEventLinkSheet({
       <Btn kind={buttonKind} size="md" onClick={() => setOpen(true)} disabled={pending}>
         {buttonLabel}
       </Btn>
-      {open && (
+      {/* Portal + .modal-overlay-h (svh cascade): 祖先の stacking context を脱出し、
+          iOS viewport-fit=cover の dvh 罠を svh で回避（RankingFilterBar の同コメント参照）。
+          open はクリック起点でしか true にならないので SSR で portal は走らない。 */}
+      {open && createPortal(
         <div
           role="dialog"
           aria-modal="true"
           aria-labelledby="link-event-sheet-title"
-          className="fixed inset-x-0 top-0 z-50 flex h-[100dvh] items-end justify-center bg-black/40 sm:items-center sm:p-4"
+          className="modal-overlay-h fixed inset-x-0 top-0 z-50 flex items-end justify-center bg-black/40 sm:items-center sm:p-4"
           onClick={() => !pending && setOpen(false)}
         >
           <div
@@ -207,7 +211,8 @@ export function ExistingEventLinkSheet({
               </Btn>
             </div>
           </div>
-        </div>
+        </div>,
+        document.body,
       )}
     </>
   )

--- a/apps/web/src/app/(app)/players/ranking/RankingFilterBar.tsx
+++ b/apps/web/src/app/(app)/players/ranking/RankingFilterBar.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useRouter } from 'next/navigation'
 import type { RankingMetric } from '@/lib/stats/ranking'
 import type { Grade, StatsFilter } from '@/lib/stats/types'
@@ -128,12 +129,17 @@ export function RankingFilterBar({
         </button>
       </div>
 
-      {open ? (
+      {/* Portal + .modal-overlay-h (svh cascade): body 直下に描画して sticky
+          z-10 ヘッダ等の stacking context から脱出しつつ、iOS の dvh 罠
+          （viewport-fit=cover では URL バー込みの高さが返り、items-end の
+          フッター＝適用/クリアが UA クローム裏に落ちる）を svh で回避する。
+          open はクリック起点でしか true にならないので SSR で portal は走らない。 */}
+      {open ? createPortal(
         <div
           role="dialog"
           aria-modal="true"
           aria-label="絞り込み"
-          className="fixed inset-x-0 top-0 z-50 flex h-[100dvh] items-end justify-center bg-black/40 sm:items-center"
+          className="modal-overlay-h fixed inset-x-0 top-0 z-50 flex items-end justify-center bg-black/40 sm:items-center"
           onClick={() => setOpen(false)}
         >
           <div
@@ -278,7 +284,8 @@ export function RankingFilterBar({
               </button>
             </div>
           </div>
-        </div>
+        </div>,
+        document.body,
       ) : null}
     </>
   )

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -219,3 +219,17 @@ body {
   height: 100dvh;
   height: 100svh;
 }
+
+/* Bottom-sheet / modal overlay height. Same svh-last cascade as
+   .mobile-shell-h and for the same reason: with viewport-fit=cover, iOS
+   Safari reports 100dvh *including* the bottom URL-bar overlay, so a
+   dvh-sized overlay pushes an `items-end` sheet's footer (apply/clear
+   buttons) underneath the UA chrome. 100svh keeps the sheet bottom inside
+   the always-visible region. Applied by the shared bottom-sheet dialogs
+   (RankingFilterBar, StatsPeriodFilter, account-menu, InviteCodeModal,
+   RegistrationInviteModal, ManualLinkModal, ExistingEventLinkSheet). */
+.modal-overlay-h {
+  height: 100vh;
+  height: 100dvh;
+  height: 100svh;
+}

--- a/apps/web/src/components/admin/ManualLinkModal.tsx
+++ b/apps/web/src/components/admin/ManualLinkModal.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useTransition } from 'react'
+import { createPortal } from 'react-dom'
 import { Btn } from '@/components/ui'
 
 export interface LinkableEventOption {
@@ -88,12 +89,15 @@ export function ManualLinkModal({
       <Btn kind="secondary" size="sm" onClick={() => setOpen(true)}>
         手動紐付け
       </Btn>
-      {open ? (
+      {/* Portal + .modal-overlay-h (svh cascade): 祖先の stacking context を脱出し、
+          iOS viewport-fit=cover の dvh 罠を svh で回避（RankingFilterBar の同コメント参照）。
+          open はクリック起点でしか true にならないので SSR で portal は走らない。 */}
+      {open ? createPortal(
         <div
           role="dialog"
           aria-modal="true"
           aria-label={`${channelLabel} 手動紐付け`}
-          className="fixed inset-x-0 top-0 z-50 flex h-[100dvh] items-end sm:items-center justify-center bg-black/40"
+          className="modal-overlay-h fixed inset-x-0 top-0 z-50 flex items-end sm:items-center justify-center bg-black/40"
           onClick={handleClose}
         >
           <div
@@ -162,7 +166,8 @@ export function ManualLinkModal({
               </form>
             )}
           </div>
-        </div>
+        </div>,
+        document.body,
       ) : null}
     </>
   )

--- a/apps/web/src/components/admin/RegistrationInviteModal.tsx
+++ b/apps/web/src/components/admin/RegistrationInviteModal.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState, useTransition } from 'react'
+import { createPortal } from 'react-dom'
 import { Btn } from '@/components/ui'
 
 export interface RegistrationInvitePayload {
@@ -76,12 +77,15 @@ export function RegistrationInviteModal({ payload, onClose }: RegistrationInvite
     })
   }
 
-  return (
+  // Portal + .modal-overlay-h (svh cascade): 祖先の stacking context を脱出し、
+  // iOS viewport-fit=cover の dvh 罠を svh で回避（RankingFilterBar の同コメント参照）。
+  // payload はクリック起点でしか非 null にならないので SSR で portal は走らない。
+  return createPortal(
     <div
       role="dialog"
       aria-modal="true"
       aria-label="招待リンク"
-      className="fixed inset-x-0 top-0 z-50 flex h-[100dvh] items-end sm:items-center justify-center bg-black/40"
+      className="modal-overlay-h fixed inset-x-0 top-0 z-50 flex items-end sm:items-center justify-center bg-black/40"
       onClick={onClose}
     >
       <div
@@ -125,6 +129,7 @@ export function RegistrationInviteModal({ payload, onClose }: RegistrationInvite
           </Btn>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   )
 }

--- a/apps/web/src/components/events/InviteCodeModal.tsx
+++ b/apps/web/src/components/events/InviteCodeModal.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState, useTransition } from 'react'
+import { createPortal } from 'react-dom'
 import { Btn } from '@/components/ui'
 
 export interface InviteCodePayload {
@@ -71,12 +72,15 @@ export function InviteCodeModal({
     })
   }
 
-  return (
+  // Portal + .modal-overlay-h (svh cascade): 祖先の stacking context を脱出し、
+  // iOS viewport-fit=cover の dvh 罠を svh で回避（RankingFilterBar の同コメント参照）。
+  // payload はクリック起点でしか非 null にならないので SSR で portal は走らない。
+  return createPortal(
     <div
       role="dialog"
       aria-modal="true"
       aria-label={`${eventTitle} の LINE 配信 招待コード`}
-      className="fixed inset-x-0 top-0 z-50 flex h-[100dvh] items-end sm:items-center justify-center bg-black/40"
+      className="modal-overlay-h fixed inset-x-0 top-0 z-50 flex items-end sm:items-center justify-center bg-black/40"
       onClick={onClose}
     >
       <div
@@ -141,6 +145,7 @@ export function InviteCodeModal({
           </Btn>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   )
 }

--- a/apps/web/src/components/layout/account-menu.tsx
+++ b/apps/web/src/components/layout/account-menu.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
 import Link from 'next/link'
 
 export interface AccountMenuProps {
@@ -66,12 +67,15 @@ export function AccountMenu({ user, isAdmin, signOutAction }: AccountMenuProps) 
         {user || 'メニュー'}
       </button>
 
-      {open ? (
+      {/* Portal + .modal-overlay-h (svh cascade): 祖先の stacking context を脱出し、
+          iOS viewport-fit=cover の dvh 罠を svh で回避（RankingFilterBar の同コメント参照）。
+          open はクリック起点でしか true にならないので SSR で portal は走らない。 */}
+      {open ? createPortal(
         <div
           role="dialog"
           aria-modal="true"
           aria-label="設定"
-          className="fixed inset-x-0 top-0 z-50 flex h-[100dvh] items-end sm:items-center justify-center bg-black/40"
+          className="modal-overlay-h fixed inset-x-0 top-0 z-50 flex items-end sm:items-center justify-center bg-black/40"
           onClick={close}
         >
           <div
@@ -131,7 +135,8 @@ export function AccountMenu({ user, isAdmin, signOutAction }: AccountMenuProps) 
               </form>
             </div>
           </div>
-        </div>
+        </div>,
+        document.body,
       ) : null}
     </>
   )

--- a/apps/web/src/components/stats/StatsPeriodFilter.tsx
+++ b/apps/web/src/components/stats/StatsPeriodFilter.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useRouter } from 'next/navigation'
 import type { StatsFilter } from '@/lib/stats/types'
 import { buildStatsHref } from '@/app/(app)/tournaments/stats/params'
@@ -83,12 +84,16 @@ export function StatsPeriodFilter({
         </button>
       </div>
 
-      {open ? (
+      {/* Portal + .modal-overlay-h (svh cascade): 祖先の stacking context を
+          脱出し、iOS viewport-fit=cover の dvh 罠（URL バー込みの高さ→
+          items-end のフッターが UA クローム裏に落ちる）を svh で回避。
+          詳細は RankingFilterBar の同コメント参照。 */}
+      {open ? createPortal(
         <div
           role="dialog"
           aria-modal="true"
           aria-label="期間で絞り込み"
-          className="fixed inset-x-0 top-0 z-50 flex h-[100dvh] items-end justify-center bg-black/40 sm:items-center"
+          className="modal-overlay-h fixed inset-x-0 top-0 z-50 flex items-end justify-center bg-black/40 sm:items-center"
           onClick={() => setOpen(false)}
         >
           <div
@@ -161,7 +166,8 @@ export function StatsPeriodFilter({
               </button>
             </div>
           </div>
-        </div>
+        </div>,
+        document.body,
       ) : null}
     </>
   )


### PR DESCRIPTION
## Summary
PR #253/#254 の dvh ベース修正では**実機（iOS）で直っていなかった**（絞り込みシートの適用/クリアが依然画面外）。スクリーンショット＋コード再調査で根本原因を2つ特定し、全ボトムシート7箇所に根治策を適用。

**根本原因:**
1. **iOS の dvh 罠**: viewport-fit=cover の iOS は `100dvh` を下部 URL バー込みの高さで返す（シェルが PR #67 で踏んだ既知の罠）。`h-[100dvh]` のオーバーレイは可視領域より下まで伸び、`items-end` のフッター（適用/クリア）が UA クローム裏に落ちる。
2. **stacking context の閉じ込め**: シートは `<main>` 内の `sticky z-10` フィルタヘッダ等の stacking context 内に描画されており、`z-50` がその文脈内でしか効かない（実機でボトムナビが暗転せずシート手前に見えることから判明）。

**対策（挙動不変・全7シート）:**
- `createPortal(…, document.body)` で body 直下に描画 → 祖先の stacking context / containing block の影響を根絶。open/payload はクリック起点でしか立たないため SSR 安全。
- globals.css に `.modal-overlay-h`（`100vh→100dvh→100svh` カスケード＝ `.mobile-shell-h` と同手法）を新設し `h-[100dvh]` を置換 → シート下端が常に可視領域内。
- `max-h-full overflow-y-auto` は維持。

対象: `RankingFilterBar` / `StatsPeriodFilter` / `InviteCodeModal` / `RegistrationInviteModal` / `ManualLinkModal` / `account-menu` / `ExistingEventLinkSheet` ＋ `globals.css`

## Test plan
- lint / tsc / 関連テスト38件 green（テストは `screen`＝document 全体検索のため Portal 化の影響なし）。
- [ ] **実機（iPhone）**: 統計→ランキング→絞り込み（勝率タブ＋級選択の最長状態）で適用/クリアが見える・押せる。背後のボトムナビが暗転する。設定シート等の他モーダルも同様。

🤖 Generated with [Claude Code](https://claude.com/claude-code)