### PR TITLE
fix(result-import): 勝ちマーク◯(U+25EF)対応＋「氏 名」ヘッダ＋見出しセル級導出

### DIFF
--- a/apps/mail-worker/src/result-import/normalize.ts
+++ b/apps/mail-worker/src/result-import/normalize.ts
@@ -51,12 +51,13 @@ export function normalizeDan(raw: string | null | undefined): number | null {
 
 /**
  * Parse a win/lose indicator cell value.
- * Accepts ○ (U+25CB), 〇 (U+3007), × (U+00D7 / U+00D7 lookalike), ● (U+25CF, used
+ * Accepts ○ (U+25CB), 〇 (U+3007), ◯ (U+25EF LARGE CIRCLE — NFKC は U+25CB に
+ * 畳まないため明示が必要), × (U+00D7 / U+00D7 lookalike), ● (U+25CF, used
  * as 負 in some 成績表). Returns null if unrecognized (row skipped / end-of-data).
  */
 export function parseResultChar(s: string): 'win' | 'lose' | null {
   const n = normalizeText(s)
-  if (n === '○' || n === '〇') return 'win'
+  if (n === '○' || n === '〇' || n === '◯') return 'win'
   if (n === '×' || n === '✕' || n === '×' || n === '●') return 'lose'
   return null
 }

--- a/apps/mail-worker/src/result-import/parser.ts
+++ b/apps/mail-worker/src/result-import/parser.ts
@@ -46,10 +46,13 @@ interface ColMap {
  * Handles: 「選手名」「氏名」「名前」「参加者」.
  */
 function isPlayerNameHeader(v: string): boolean {
+  // 「氏(U+3000)名」= 全角空白入りヘッダ (千葉2026 実ファイル) は normalizeText 後も
+  // "氏 名" と空白が残り /氏名/ に落ちるため、判定は空白除去後の文字列で行う。
+  const s = v.replace(/\s+/g, '')
   // Exclude furigana/reading columns (e.g.「選手名ふりがな」「氏名カナ」) which also contain
   // 選手名/氏名: the 出場者DB layout places 選手名 and 選手名ふりがな side by side, and
   // last-match-wins otherwise picked the kana column → every name imported as hiragana.
-  return /選手名|氏名|名前/.test(v) && !/ふりがな|フリガナ|カナ|読み|かな/.test(v)
+  return /選手名|氏名|名前/.test(s) && !/ふりがな|フリガナ|カナ|読み|かな/.test(s)
 }
 
 function isOpponentHeader(v: string): boolean {
@@ -400,6 +403,23 @@ function deriveClassNameFromSheet(sheet: SheetData): string | null {
     if (cell && /^[A-E]\d*$/.test(normalizeText(cell))) return normalizeText(cell)
   }
 
+  // Title-cell fallback: 級 is only in a merged heading like
+  // 「【第４回全国競技かるた千葉大会（Ａ級）】」(千葉2026) while the sheet name is a
+  // block label (優勝1/2/3). NFKC folds Ａ／（） to A/() so match the parenthesized
+  // grade after normalizeText. A trailing block number in the sheet name keeps
+  // blocks separate (優勝1 → A1) — merging them into a single class would collide
+  // round numbers across blocks (t995 東京東会2024E と同じ破綻になる).
+  for (let r = 0; r < Math.min(sheet.grid.length, 5); r++) {
+    for (const cell of sheet.grid[r] ?? []) {
+      if (!cell) continue
+      const m = normalizeText(cell).match(/\(([A-E]\d*)級\)/)
+      if (m) {
+        const block = normalizeText(sheet.name).match(/(\d+)$/)
+        return block ? `${m[1]}${block[1]}` : m[1]!
+      }
+    }
+  }
+
   return null
 }
 
@@ -482,7 +502,7 @@ function detectRoundLayoutSignature(
     const isOppHdr = (s: string) => /相手|対戦/.test(s) && !/(no|番号|所属|級|会|ふりがな|フリガナ|カナ)/i.test(s)
     // Header label, NOT a data mark: 勝敗 / 結果 / a combined "○✕" label (2+ mark
     // chars) / 勝 / 敗. A bare ○ or × is a data value, so must not match.
-    const isMarkHdr = (s: string) => /勝敗|結果/.test(s) || /^[○×✕●]{2,}$/.test(s) || s === '勝' || s === '敗'
+    const isMarkHdr = (s: string) => /勝敗|結果/.test(s) || /^[○〇◯×✕●]{2,}$/.test(s) || s === '勝' || s === '敗'
     // 枚数差: 枚数 / 枚差 / 点数 / lone 差 or 数 (abbreviated 枚数). Kept in sync with
     // the subHits 数/差 set below so a column counted as a sub-header is also read.
     const isScoreHdr = (s: string) => /枚数|枚差|点数|^差$|^数$/.test(s)

--- a/apps/mail-worker/src/result-import/round-cell.ts
+++ b/apps/mail-worker/src/result-import/round-cell.ts
@@ -12,7 +12,7 @@ export interface ParsedRoundCell {
   empty: boolean
 }
 
-const WIN_MARK = /[○〇]/ // ○ U+25CB, 〇 U+3007
+const WIN_MARK = /[○〇◯]/ // ○ U+25CB, 〇 U+3007, ◯ U+25EF (NFKC で畳まれない別字)
 const LOSE_MARK = /[×✕●]/ // × U+00D7, ✕ U+2715, ● U+25CF (used as 負 in some 成績表)
 
 /**
@@ -57,7 +57,7 @@ export function parseRoundCellText(raw: string): ParsedRoundCell {
   // to contain a digit (e.g. "山田2郎") is preserved — opponentName is handed to
   // materialize raw for normalizePlayerName-based opponent resolution.
   const tokens = text
-    .replace(/[○〇×✕●]/g, ' ')
+    .replace(/[○〇◯×✕●]/g, ' ')
     .replace(/不戦勝?|棄権/g, ' ')
     .split(/\s+/)
     .filter((t) => t.length > 0)

--- a/apps/mail-worker/test/result-import/normalize.test.ts
+++ b/apps/mail-worker/test/result-import/normalize.test.ts
@@ -40,6 +40,8 @@ describe('deriveGrade', () => {
 describe('parseResultChar', () => {
   it('parses ○ (U+25CB) as win', () => expect(parseResultChar('○')).toBe('win'))
   it('parses 〇 (U+3007) as win', () => expect(parseResultChar('〇')).toBe('win'))
+  it('parses ◯ (U+25EF LARGE CIRCLE, 東京東会79回/千葉の実ファイル) as win', () =>
+    expect(parseResultChar('◯')).toBe('win'))
   it('parses × as lose', () => expect(parseResultChar('×')).toBe('lose'))
   it('parses ● (U+25CF, 負 in some 成績表) as lose', () => expect(parseResultChar('●')).toBe('lose'))
   it('returns null for empty/unknown', () => {

--- a/apps/mail-worker/test/result-import/parser.test.ts
+++ b/apps/mail-worker/test/result-import/parser.test.ts
@@ -315,3 +315,99 @@ describe('parseResultExcel — 出場者DB with 選手名ふりがな + 所属�
     expect(p1.matches[0]?.opponentName).toBe('漢字次郎')
   })
 })
+
+/**
+ * ◯ (U+25EF LARGE CIRCLE) used as the win mark — the shape used by the real
+ * 東京東会79回 / 千葉2024+ result files. Regression for the mirror-missing-100% bug
+ * (Issue #264): pre-fix, every ◯ round was dropped as unparseable, so only the
+ * loser-side rows survived (winners had matches=[]) and no match had its mirror.
+ */
+const U25EF_VARIANT_SHEET: SheetData = makeSheet('対戦結果表_A級', [
+  [null, null, null, '1回戦', null, null, '2回戦', null, null],
+  ['No', '選手名', '所属', '相手', '枚数', '勝敗', '相手', '枚数', '勝敗', '順位'],
+  ['1', '大丸勝者', '甲会', '大丸敗者', '6', '◯', '大丸次鋒', '15', '◯', '優勝'],
+  ['2', '大丸敗者', '乙会', '大丸勝者', '6', '×', null, null, null, null],
+  ['3', '大丸次鋒', '丙会', null, '不戦勝', '◯', '大丸勝者', '15', '×', null],
+])
+
+describe('parseResultExcel — ◯ (U+25EF) treated as win (Issue #264 regression)', () => {
+  const classes = parseResultExcel([U25EF_VARIANT_SHEET])
+  const cls = classes[0]!
+
+  it('keeps the undefeated winner rows (pre-fix they were dropped entirely)', () => {
+    const winner = cls.participants.find((p) => p.name === '大丸勝者')!
+    expect(winner.matches).toHaveLength(2)
+    expect(winner.matches.map((m) => m.result)).toEqual(['win', 'win'])
+  })
+
+  it('produces both sides of every normal match (mirror completeness)', () => {
+    // every (player, round, opponent, result) must have the reciprocal row
+    for (const p of cls.participants) {
+      for (const m of p.matches) {
+        if (!m.opponentName) continue // 不戦勝 has no reciprocal
+        const opp = cls.participants.find((q) => q.name === m.opponentName)!
+        const back = opp.matches.find((bm) => bm.round === m.round)
+        expect(back?.opponentName).toBe(p.name)
+        expect(back?.result).toBe(m.result === 'win' ? 'lose' : 'win')
+      }
+    }
+  })
+
+  it('accepts ◯ on a walkover cell too', () => {
+    const bye = cls.participants.find((p) => p.name === '大丸次鋒')!
+    expect(bye.matches[0]).toMatchObject({ result: 'win', status: 'walkover', opponentName: null })
+  })
+})
+
+/**
+ * 「氏(U+3000)名」 header — ideographic space inside the label, real 千葉2026 layout.
+ * Pre-fix isPlayerNameHeader tested /氏名/ against the normalized cell where the
+ * full-width space survives as an ASCII space ("氏 名"), so the primary detector
+ * missed the sheet and fell through to the W2 positional fallback, which nulled
+ * every opponent/score. The row-0 title cell is the only place the grade appears
+ * (the sheet name is a block label), so this fixture also covers the title-cell
+ * class derivation: 優勝1 + （Ａ級） → className "A1", grade "A".
+ */
+const CHIBA_2026_SHEET: SheetData = makeSheet('優勝1', [
+  [null, '【第４回全国競技かるた千葉大会（Ａ級）】', null, null, null, null],
+  [null, null, null, '1回戦', null, null],
+  [null, '氏　名', '所属会名', '相手', '枚数', '勝敗'],
+  ['優勝', '千葉勝子', 'てすと会', '千葉負男', '3', '◯'],
+  [null, '千葉負男', 'てすと会2', '千葉勝子', '3', '×'],
+])
+
+describe('parseResultExcel — 「氏　名」 header + title-cell grade (千葉2026, Issue #264)', () => {
+  const classes = parseResultExcel([CHIBA_2026_SHEET])
+
+  it('detects the primary signature (opponents survive, unlike the W2 fallback)', () => {
+    expect(classes).toHaveLength(1)
+    const winner = classes[0]!.participants.find((p) => p.name === '千葉勝子')!
+    expect(winner.matches[0]).toMatchObject({
+      result: 'win',
+      scoreDiff: 3,
+      opponentName: '千葉負男',
+      round: 1,
+    })
+  })
+
+  it('derives className from the parenthesized grade in the title cell, not the sheet name', () => {
+    // 優勝1 (block label) would otherwise become the className with grade=null
+    expect(classes[0]!.className).toBe('A1')
+    expect(classes[0]!.grade).toBe('A')
+  })
+})
+
+describe('deriveClassNameFromSheet title-cell fallback — no trailing block number', () => {
+  it('uses the bare grade when the sheet name has no block suffix', () => {
+    const sheet = makeSheet('結果', [
+      ['【第５回テスト大会（Ｂ級）】', null, null, null, null],
+      ['氏　名', '所属会名', '相手', '枚数', '勝敗'],
+      ['勝田花子', '会イ', '負田太郎', '7', '◯'],
+      ['負田太郎', '会ロ', '勝田花子', '7', '×'],
+    ])
+    const classes = parseResultExcel([sheet])
+    expect(classes).toHaveLength(1)
+    expect(classes[0]!.className).toBe('B')
+    expect(classes[0]!.grade).toBe('B')
+  })
+})

--- a/apps/mail-worker/test/result-import/round-cell.test.ts
+++ b/apps/mail-worker/test/result-import/round-cell.test.ts
@@ -34,6 +34,16 @@ describe('parseRoundCellText', () => {
     expect(parseRoundCellText('〇 5 相手').result).toBe('win')
   })
 
+  it('treats ◯ (U+25EF LARGE CIRCLE) as win and strips it from the opponent name', () => {
+    expect(parseRoundCellText('◯ 5 相手')).toEqual({
+      result: 'win',
+      scoreDiff: 5,
+      status: 'normal',
+      opponentName: '相手',
+      empty: false,
+    })
+  })
+
   it('treats ✕ (U+2715) as lose', () => {
     expect(parseRoundCellText('✕ 5 相手').result).toBe('lose')
   })


### PR DESCRIPTION
## Summary
- 勝ちマーク `◯`(U+25EF LARGE CIRCLE) を win として受理（`parseResultChar`・`WIN_MARK`・`isMarkHdr`）。東京東会79回/千葉2024+ の実ファイル字形で、未対応だと勝ち行が全脱落し**ミラー欠落100%**（敗者視点のみ取込）になっていた
- 選手名ヘッダ「氏(U+3000)名」（全角空白入り、千葉2026 実ファイル）を検出できるよう `isPlayerNameHeader` を空白除去後判定に
- 級・クラス列が無い単一クラスシートで、シート内マージ見出し「（Ａ級）」から級を導出（シート名末尾の数字をブロック suffix 化: 優勝1→A1）。シート名ゴミ「優勝1/2/3」が級名になる問題の根治＋ブロック統合による round 衝突（t995型）回避
- 回帰テスト8件追加（既存 fixture 非変更）

## Bug
Fixes #264

根本原因の調査記録: docs/data-quality/DIAGNOSIS_ミラー欠落_現行取込経路_2026-07-03.md ＋ Issue コメントの原本突合エビデンス（原本の生 reciprocity 84-100% vs パーサ出力 0%、78回=U+25CB正常/79回=U+25EF退行の対照実験）

## Test plan
- [x] mail-worker: 409 tests green（+8 新規回帰: U+25EF 両視点/不戦・氏名U+3000・見出しセル級導出×2）
- [x] web: 1113 tests green（mail-worker ソースをバンドルするため巻き込み確認）
- [x] lint / check-types green
- [ ] マージ後: 対象11大会の再取込（別途、本番オペレーション）

🤖 Generated with [Claude Code](https://claude.com/claude-code)