### PR TITLE
fix(result-import): 全角Ｘ/ｘ負けマーク対応＋練習シートskipの恒久ガード

### DIFF
--- a/apps/mail-worker/src/result-import/parser.ts
+++ b/apps/mail-worker/src/result-import/parser.ts
@@ -718,6 +718,9 @@ export function parseResultExcel(sheets: SheetData[]): ParsedClass[] {
   const order: string[] = []
 
   for (const sheet of sheets) {
+    // 練習シート(例:「対戦結果表_E級練習」)は本番の級と同じ className に解決されて
+    // 上記 merge 規則で本番参加者へ合流してしまうため、結果対象外として丸ごと skip。
+    if (sheet.name.includes('練習')) continue
     const parsed = parseSheet(sheet)
     for (const cls of parsed) {
       const existing = byClassName.get(cls.className)

--- a/apps/mail-worker/src/result-import/round-cell.ts
+++ b/apps/mail-worker/src/result-import/round-cell.ts
@@ -14,6 +14,10 @@ export interface ParsedRoundCell {
 
 const WIN_MARK = /[○〇◯]/ // ○ U+25CB, 〇 U+3007, ◯ U+25EF (NFKC で畳まれない別字)
 const LOSE_MARK = /[×✕●]/ // × U+00D7, ✕ U+2715, ● U+25CF (used as 負 in some 成績表)
+// 全角Ｘ(U+FF38)/ｘ(U+FF58) も負けマークに使われる(大垣系成績表)が、normalizeText の
+// NFKC で ASCII X/x に畳まれて届くため文字クラスには足せない — ローマ字の相手名
+// (例: "Alex") の x に誤爆する。単独トークンの場合のみ負けマークとして扱う。
+const LOSE_MARK_TOKEN = /(?:^|\s)[Xx](?:\s|$)/
 
 /**
  * Parse the text content of one "round" cell into a structured match.
@@ -47,7 +51,7 @@ export function parseRoundCellText(raw: string): ParsedRoundCell {
   // Result from an explicit ○/× mark; fall back to bye/forfeit semantics.
   let result: 'win' | 'lose' | null = null
   if (WIN_MARK.test(text)) result = 'win'
-  else if (LOSE_MARK.test(text)) result = 'lose'
+  else if (LOSE_MARK.test(text) || LOSE_MARK_TOKEN.test(text)) result = 'lose'
   if (result === null && isWalkover) result = 'win' // 不戦勝 = 進出 = win
   if (result === null && isForfeit) result = 'lose' // 棄権 = the withdrawing player loses
 
@@ -60,7 +64,9 @@ export function parseRoundCellText(raw: string): ParsedRoundCell {
     .replace(/[○〇◯×✕●]/g, ' ')
     .replace(/不戦勝?|棄権/g, ' ')
     .split(/\s+/)
-    .filter((t) => t.length > 0)
+    // 単独トークンの X/x は負けマーク(NFKC 済みの全角Ｘ/ｘ)なので相手名から落とす。
+    // 名前の一部の x ("Alex" 等) はトークンが 1 文字でないため保持される。
+    .filter((t) => t.length > 0 && t !== 'X' && t !== 'x')
 
   // Always lift the first standalone integer token (枚数) out of the name — even
   // for walkover/forfeit compound cells like "不戦 ○ 1 相手" / "棄権 × 4 相手" — so the

--- a/apps/mail-worker/test/result-import/parser.test.ts
+++ b/apps/mail-worker/test/result-import/parser.test.ts
@@ -229,6 +229,29 @@ describe('parseResultExcel — all non-signature sheets', () => {
   })
 })
 
+// 練習シートは本番の級と同じ className に解決されて merge 規則で本番参加者へ
+// 合流してしまう(東京東会「対戦結果表_E級練習」の実害)ため、丸ごと skip する。
+describe('parseResultExcel — sheets named 練習 are skipped', () => {
+  const PRACTICE_SHEET: SheetData = makeSheet('対戦結果表_D1級練習', [
+    ['D1', null, null, null, null, null],
+    [null, null, null, '1回戦', null, null],
+    ['No', '選手名', '所属', '相手', '枚数', '勝敗'],
+    ['1', '練習選手甲', '練習会', '練習選手乙', '3', '○'],
+    ['2', '練習選手乙', '練習会', '練習選手甲', '3', '×'],
+  ])
+
+  it('does not merge a 練習 sheet into the real class of the same name', () => {
+    const classes = parseResultExcel([STANDARD_SHEET, PRACTICE_SHEET])
+    expect(classes).toHaveLength(1)
+    expect(classes[0]?.participants).toHaveLength(4)
+    expect(classes[0]?.participants.some((p) => p.name.startsWith('練習選手'))).toBe(false)
+  })
+
+  it('returns empty when only 練習 sheets are present', () => {
+    expect(parseResultExcel([PRACTICE_SHEET])).toEqual([])
+  })
+})
+
 // Codex R4 blocker: a class split across two sheets (same derived className)
 // must MERGE participants, not silently drop the second sheet.
 describe('parseResultExcel — duplicate className across sheets is merged', () => {

--- a/apps/mail-worker/test/result-import/round-cell.test.ts
+++ b/apps/mail-worker/test/result-import/round-cell.test.ts
@@ -56,6 +56,36 @@ describe('parseRoundCellText', () => {
     })
   })
 
+  it('treats a standalone 全角Ｘ (U+FF38, NFKC→X) as lose and strips it (大垣系成績表)', () => {
+    expect(parseRoundCellText('相手花子 Ｘ 6')).toEqual({
+      result: 'lose',
+      scoreDiff: 6,
+      status: 'normal',
+      opponentName: '相手花子',
+      empty: false,
+    })
+  })
+
+  it('treats a standalone 全角ｘ (U+FF58, NFKC→x) as lose and strips it', () => {
+    expect(parseRoundCellText('ｘ 9 相手太郎')).toEqual({
+      result: 'lose',
+      scoreDiff: 9,
+      status: 'normal',
+      opponentName: '相手太郎',
+      empty: false,
+    })
+  })
+
+  it('does NOT treat x inside a romaji opponent name as a lose mark', () => {
+    expect(parseRoundCellText('○ 5 Alex')).toMatchObject({
+      result: 'win',
+      scoreDiff: 5,
+      opponentName: 'Alex',
+    })
+    // no mark at all + name starting with X → still no result (round skipped)
+    expect(parseRoundCellText('6 Xavier').result).toBe(null)
+  })
+
   it('collapses heavy whitespace/newlines (HTML cell shape)', () => {
     expect(parseRoundCellText('\n\t\t○\n\t\t4\n\t\t相手花子\n')).toEqual({
       result: 'win',


### PR DESCRIPTION
## Summary
- **round-cell.ts**: 大垣3〜5回・10回の成績表が使う負けマーク **全角Ｘ(U+FF38)/ｘ(U+FF58)** を認識（従来は敗者行が丸ごとskip→ミラー欠落100%）。セルは `normalizeText` のNFKCでASCII X/xに畳まれて届くため、文字クラスへの単純追加ではローマ字相手名（例: Alex）のxに誤爆する。**単独トークンの場合のみ**負けマークとして扱う `LOSE_MARK_TOKEN` を追加し、トークン化時も単独X/xのみ除去
- **parser.ts**: シート名に「練習」を含むシートを `parseResultExcel` で除外。東京東会78回Eで「対戦結果表_E級練習」が本番E級と同じclassNameに解決され、merge規則で本番参加者へ合流した実害（t995・Tier2③）の再発防止
- 回帰テスト5件追加（Ｘ/ｘ/誤爆ガード/練習シートskip×2）

## 背景
Tier2データ品質調査で確定した取込パーサ欠陥の恒久ガード（PR#265の◯U+25EF対応と同系）。根拠: docs/data-quality/REPORT_tier2-0405_大垣・相手未解決下調べ_2026-07-04.md / REPORT_tier2-03_構造破綻調査_2026-07-04.md §3。マーク使用級とDB欠落級・件数の完全一致まで裏取り済み。既存データの再取込は別途（④の大垣再取込タスク）。

## Test plan
- [x] mail-worker 414 tests green（新規5件含む・隔離test DB）
- [x] check-types / lint green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)