### PR TITLE
fix(result-import): parseResultChar に全角Ｘ/ｘ負けマーク対応を追加

### DIFF
--- a/apps/mail-worker/src/result-import/normalize.ts
+++ b/apps/mail-worker/src/result-import/normalize.ts
@@ -53,12 +53,14 @@ export function normalizeDan(raw: string | null | undefined): number | null {
  * Parse a win/lose indicator cell value.
  * Accepts ○ (U+25CB), 〇 (U+3007), ◯ (U+25EF LARGE CIRCLE — NFKC は U+25CB に
  * 畳まないため明示が必要), × (U+00D7 / U+00D7 lookalike), ● (U+25CF, used
- * as 負 in some 成績表). Returns null if unrecognized (row skipped / end-of-data).
+ * as 負 in some 成績表). Also accepts Ｘ (U+FF38) / ｘ (U+FF58) — NFKC で
+ * X/x に畳まれる負けマーク（大垣系成績表）。Returns null if unrecognized
+ * (row skipped / end-of-data).
  */
 export function parseResultChar(s: string): 'win' | 'lose' | null {
   const n = normalizeText(s)
   if (n === '○' || n === '〇' || n === '◯') return 'win'
-  if (n === '×' || n === '✕' || n === '×' || n === '●') return 'lose'
+  if (n === '×' || n === '✕' || n === '×' || n === '●' || n === 'X' || n === 'x') return 'lose'
   return null
 }
 

--- a/apps/mail-worker/test/result-import/normalize.test.ts
+++ b/apps/mail-worker/test/result-import/normalize.test.ts
@@ -44,6 +44,12 @@ describe('parseResultChar', () => {
     expect(parseResultChar('◯')).toBe('win'))
   it('parses × as lose', () => expect(parseResultChar('×')).toBe('lose'))
   it('parses ● (U+25CF, 負 in some 成績表) as lose', () => expect(parseResultChar('●')).toBe('lose'))
+  it('parses Ｘ (U+FF38, 大垣大会 成績表の負けマーク) as lose', () => expect(parseResultChar('Ｘ')).toBe('lose'))
+  it('parses ｘ (U+FF58) as lose', () => expect(parseResultChar('ｘ')).toBe('lose'))
+  it('parses X (ASCII) as lose', () => expect(parseResultChar('X')).toBe('lose'))
+  it('parses x (ASCII) as lose', () => expect(parseResultChar('x')).toBe('lose'))
+  it('does not misfire on romaji names like "Alex"', () => expect(parseResultChar('Alex')).toBeNull())
+  it('does not misfire on "XX" (single mark only)', () => expect(parseResultChar('XX')).toBeNull())
   it('returns null for empty/unknown', () => {
     expect(parseResultChar('')).toBeNull()
     expect(parseResultChar('-')).toBeNull()


### PR DESCRIPTION
## Summary
- main署名経路（`parser.ts::parseDataRow` → `normalize.ts::parseResultChar`）が勝敗列の全角Ｘ(U+FF38)/ｘ(U+FF58)を認識せず null → 負け行を丸ごと skip していた（大垣 t742/t767/t791 のミラー欠落 計813件の原因）
- `parseResultChar` の lose 判定に NFKC 正規化後の単独 `X`/`x` を追加。PR#266 が W2 positional 経路（`round-cell.ts` の `LOSE_MARK_TOKEN`）に入れた単独マーク判定と意味論を揃えた
- 勝敗列は単独マーク専用列のため、round-cell 側で懸念したローマ字相手名（例: "Alex"）への誤爆は構造的に起きない（検証レポート: c:/tmp/dq/tier2/reingest2/ogaki4_verify.md・Tier2台帳#19の解除条件）
- 回帰テスト6件追加（Ｘ/ｘ/X/x→lose、"Alex"→null、"XX"→null）。既存マーク（○/〇/◯/×/✕/●）の挙動は不変

## Test plan
- [x] `pnpm --filter @kagetra/mail-worker test` — 33 files / 420 tests pass（隔離テストDBで実行）
- [x] `check-types` / `lint` エラーなし
- [ ] ship 後: 大垣 t742/t767/t791 をリハDB検証→本番再取込（Tier2 台帳#21以降で記録）

🤖 Generated with [Claude Code](https://claude.com/claude-code)