### PR TITLE
feat(players): 大会名表示を通称+出場級に変更

### DIFF
--- a/apps/web/src/app/(app)/players/[id]/page.tsx
+++ b/apps/web/src/app/(app)/players/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { notFound, redirect } from 'next/navigation'
 import { auth } from '@/auth'
 import { getPlayerName, getPlayerRecord, type PlayerMatchView } from '@/lib/players/queries'
+import { formatTournamentLabel } from '@/lib/players/tournamentLabel'
 import { buildRankingHref, parseRankingParams } from '../ranking/metrics'
 import { BackButton } from './BackButton'
 import {
@@ -20,11 +21,6 @@ export const dynamic = 'force-dynamic'
  * sticky タイムライン（展開＝その年の全大会＋試合表）。順位は対戦から導出
  * （queries 側）、相手名タップでその選手の戦績へ（R1, 解決済みのみ）。
  */
-
-/** 「第N回」接頭を除去（全角数字も）。 */
-function stripKai(name: string): string {
-  return name.replace(/^第[0-9０-９]+回\s*/, '')
-}
 
 /** 枚数+勝敗を1トークン化。normal は ○|差| / ×|差|、不戦勝・棄権は語で。 */
 function scoreToken(m: PlayerMatchView): {
@@ -130,7 +126,11 @@ export default async function PlayerDetailPage({
     group.tournaments.push({
       participantId: part.participantId,
       dateLabel,
-      title: `${stripKai(part.tournamentName)}${part.grade ?? ''}`,
+      title: formatTournamentLabel({
+        name: part.tournamentName,
+        shortName: part.shortName,
+        grade: part.grade,
+      }),
       affiliation: part.affiliation,
       rank: part.rank,
       rankEmphasis:

--- a/apps/web/src/app/(app)/players/components/PlayerResultRow.test.tsx
+++ b/apps/web/src/app/(app)/players/components/PlayerResultRow.test.tsx
@@ -15,6 +15,8 @@ function player(overrides: Partial<PlayerSearchResult> = {}): PlayerSearchResult
     currentGrade: 'A',
     lastEventDate: '2026-06-01',
     lastTournamentName: '第40回高松宮記念杯',
+    lastShortName: null,
+    lastGrade: null,
     lastResult: '優勝',
     ...overrides,
   }
@@ -40,10 +42,34 @@ describe('PlayerResultRow', () => {
   it('最終出場を YYYY/MM＋大会名＋結果で 1 行集約し、入賞は藍（brand-fg）', () => {
     renderRow({ lastEventDate: '2026-05-01', lastTournamentName: '第72回全日本かるた選手権', lastResult: '準優勝' })
     expect(screen.getByText('2026/05')).toBeTruthy()
-    expect(screen.getByRole('link').textContent).toContain('第72回全日本かるた選手権')
+    // shortName 未設定＝フォールバック（「第N回」除去）＋級（デフォルト null＝級表示なし）
+    expect(screen.getByRole('link').textContent).toContain('全日本かるた選手権')
     const res = screen.getByText('準優勝')
     expect(res.className).toContain('text-brand-fg')
     expect(res.className).not.toContain('text-ink-muted')
+  })
+
+  it('通称（shortName）があれば通称＋出場級で表示する（「第N回」も正式名称も出さない）', () => {
+    renderRow({
+      lastTournamentName: '第72回全日本かるた選手権',
+      lastShortName: '全日本',
+      lastGrade: 'A',
+      lastResult: '準優勝',
+    })
+    expect(screen.getByRole('link').textContent).toContain('全日本A')
+    expect(screen.getByRole('link').textContent).not.toContain('第72回')
+    expect(screen.getByRole('link').textContent).not.toContain('全日本かるた選手権')
+  })
+
+  it('通称が無ければ正式名称から「第N回」を除去したもの＋出場級で表示する', () => {
+    renderRow({
+      lastTournamentName: '第72回全日本かるた選手権',
+      lastShortName: null,
+      lastGrade: 'B',
+      lastResult: '準優勝',
+    })
+    expect(screen.getByRole('link').textContent).toContain('全日本かるた選手権B')
+    expect(screen.getByRole('link').textContent).not.toContain('第72回')
   })
 
   it('結果が無い最終出場は「記録なし」を砂ミュートで出す（藍にしない）', () => {

--- a/apps/web/src/app/(app)/players/components/PlayerResultRow.tsx
+++ b/apps/web/src/app/(app)/players/components/PlayerResultRow.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
 import type { PlayerSearchResult } from '@/lib/players/queries'
+import { formatTournamentLabel } from '@/lib/players/tournamentLabel'
 
 /**
  * 最終出場が「引退の気配」に見えるまで古いと判定する境界年数。現在年から数えて
@@ -75,7 +76,12 @@ export function PlayerResultRow({
               >
                 {yearMonth}
               </span>
-              （{player.lastTournamentName}{' '}
+              （
+              {formatTournamentLabel({
+                name: player.lastTournamentName,
+                shortName: player.lastShortName,
+                grade: player.lastGrade,
+              })}{' '}
               <span
                 className={cn(
                   hasResult ? 'font-semibold text-brand-fg' : 'font-normal text-ink-muted',

--- a/apps/web/src/lib/players/queries.test.ts
+++ b/apps/web/src/lib/players/queries.test.ts
@@ -1,3 +1,4 @@
+import { sql } from 'drizzle-orm'
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 import { tournamentParticipants } from '@kagetra/shared/schema'
 import type { ParsedResultPayload } from '@kagetra/mail-worker/result-import/schema'
@@ -909,6 +910,104 @@ describe('getPlayerRecord — ランキングドリルダウン絞り込み', ()
     expect(rec.championships).toBe(2)
     expect(rec.currentGrade).toBe('B')
     expect(rec.currentAffiliation).toBe('最新会')
+  })
+})
+
+describe('searchPlayers / getPlayerRecord — 大会シリーズ通称（shortName）＋出場級', () => {
+  it('series に short_name あり：searchPlayers の lastShortName/lastGrade、getPlayerRecord の participations[].shortName が返る', async () => {
+    // 「第N回<系列名>」の大会名で autoResolveEdition が回次をパースし系列に完全一致 → edition
+    // を link（apps/web/src/lib/stats/tournaments.test.ts §② と同じ仕込み方）。
+    await testDb.execute(sql`INSERT INTO tournament_series (name, short_name) VALUES ('大阪大会', '大阪')`)
+    await seedTournament(
+      {
+        parserVersion: '1.0.0',
+        classes: [
+          classWith('A級', 'A', [
+            {
+              seqNo: 1,
+              name: '通称太郎',
+              nameKana: null,
+              affiliation: null,
+              prefecture: null,
+              dan: null,
+              memberNo: null,
+              finalRank: null,
+              matches: [],
+            },
+          ]),
+        ],
+      },
+      { name: '第1回大阪大会', eventDate: '2026-04-01' },
+    )
+
+    const found = (await searchPlayers('通称太郎'))[0]!
+    expect(found.lastShortName).toBe('大阪')
+    expect(found.lastGrade).toBe('A')
+
+    const rec = (await getPlayerRecord(found.id))!
+    expect(rec.participations[0]!.shortName).toBe('大阪')
+  })
+
+  it('edition 未紐付き（系列に一致しない大会名）：lastShortName/shortName は null', async () => {
+    await seedTournament(
+      {
+        parserVersion: '1.0.0',
+        classes: [
+          classWith('B級', 'B', [
+            {
+              seqNo: 1,
+              name: '無名次郎',
+              nameKana: null,
+              affiliation: null,
+              prefecture: null,
+              dan: null,
+              memberNo: null,
+              finalRank: null,
+              matches: [],
+            },
+          ]),
+        ],
+      },
+      { name: '無名大会', eventDate: '2026-04-01' },
+    )
+
+    const found = (await searchPlayers('無名次郎'))[0]!
+    expect(found.lastShortName).toBeNull()
+    expect(found.lastGrade).toBe('B')
+
+    const rec = (await getPlayerRecord(found.id))!
+    expect(rec.participations[0]!.shortName).toBeNull()
+  })
+
+  it('series に紐付くが short_name 未設定：lastShortName/shortName は null（正式名称フォールバックは表示層の責務）', async () => {
+    await testDb.execute(sql`INSERT INTO tournament_series (name) VALUES ('無称大会')`)
+    await seedTournament(
+      {
+        parserVersion: '1.0.0',
+        classes: [
+          classWith('C級', 'C', [
+            {
+              seqNo: 1,
+              name: '未設定三郎',
+              nameKana: null,
+              affiliation: null,
+              prefecture: null,
+              dan: null,
+              memberNo: null,
+              finalRank: null,
+              matches: [],
+            },
+          ]),
+        ],
+      },
+      { name: '第1回無称大会', eventDate: '2026-04-01' },
+    )
+
+    const found = (await searchPlayers('未設定三郎'))[0]!
+    expect(found.lastShortName).toBeNull()
+
+    const rec = (await getPlayerRecord(found.id))!
+    expect(rec.participations[0]!.shortName).toBeNull()
   })
 })
 

--- a/apps/web/src/lib/players/queries.ts
+++ b/apps/web/src/lib/players/queries.ts
@@ -5,6 +5,8 @@ import {
   players,
   tournamentClasses,
   tournamentParticipants,
+  tournamentSeries,
+  tournamentSeriesEditions,
   tournaments,
 } from '@kagetra/shared/schema'
 import { normalizePlayerName } from '@kagetra/mail-worker/result-import/normalize'
@@ -35,6 +37,10 @@ export interface PlayerSearchResult {
   lastEventDate: string | null
   /** 最終出場の大会名。参加がなければ null。 */
   lastTournamentName: string | null
+  /** 最終出場大会が紐づくシリーズの通称（tournament_series.short_name）。未紐付き/未設定は null。 */
+  lastShortName: string | null
+  /** 最終出場での本人の出場級（大会全体の開催級ではない）。参加がなければ null。 */
+  lastGrade: 'A' | 'B' | 'C' | 'D' | 'E' | null
   /**
    * 最終出場の結果表示：①導出 `derived_bracket`→ラベル（優勝/準優勝/ベストN）
    * ②生 `final_rank`（例「3位」）③どちらも無ければ null（＝記録なし）。詳細画面の
@@ -63,6 +69,8 @@ export interface PlayerParticipationView {
   participantId: number
   tournamentId: number
   tournamentName: string
+  /** 大会シリーズの通称（tournament_series.short_name）。未紐付き/未設定は null。 */
+  shortName: string | null
   eventDate: string | null
   className: string
   grade: 'A' | 'B' | 'C' | 'D' | 'E' | null
@@ -148,10 +156,14 @@ export async function searchPlayers(query: string): Promise<PlayerSearchResult[]
       finalRank: tournamentParticipants.finalRank,
       eventDate: tournaments.eventDate,
       tournamentName: tournaments.name,
+      grade: tournamentClasses.grade,
+      shortName: tournamentSeries.shortName,
     })
     .from(tournamentParticipants)
     .innerJoin(tournamentClasses, eq(tournamentClasses.id, tournamentParticipants.classId))
     .innerJoin(tournaments, eq(tournaments.id, tournamentClasses.tournamentId))
+    .leftJoin(tournamentSeriesEditions, eq(tournamentSeriesEditions.id, tournaments.editionId))
+    .leftJoin(tournamentSeries, eq(tournamentSeries.id, tournamentSeriesEditions.seriesId))
     .where(eq(tournamentParticipants.playerId, players.id))
     .orderBy(sql`${tournaments.eventDate} desc nulls last`, desc(tournaments.id))
     .limit(1)
@@ -183,6 +195,8 @@ export async function searchPlayers(query: string): Promise<PlayerSearchResult[]
       affiliation: latest.affiliation,
       lastEventDate: latest.eventDate,
       lastTournamentName: latest.tournamentName,
+      lastShortName: latest.shortName,
+      lastGrade: latest.grade,
       lastBracket: latest.derivedBracket,
       lastFinalRank: latest.finalRank,
       participationCount,
@@ -212,6 +226,8 @@ export async function searchPlayers(query: string): Promise<PlayerSearchResult[]
     currentGrade: r.currentGrade,
     lastEventDate: r.lastEventDate,
     lastTournamentName: r.lastTournamentName,
+    lastShortName: r.lastShortName,
+    lastGrade: r.lastGrade,
     // 最終出場の結果：①導出 bracket→ラベル ②生 final_rank ③null（＝記録なし）。
     // 導出は詳細画面 rank と単一ソース（derived_bracket は materialize 時に確定・
     // 保存値 == 詳細 rankBracket の不変条件を queries.test で担保済み）。
@@ -320,6 +336,15 @@ export async function getPlayerRecord(
               with: {
                 tournament: {
                   columns: { id: true, name: true, eventDate: true },
+                  with: {
+                    edition: {
+                      with: {
+                        series: {
+                          columns: { shortName: true },
+                        },
+                      },
+                    },
+                  },
                 },
               },
             },
@@ -410,6 +435,7 @@ export async function getPlayerRecord(
       participantId: p.id,
       tournamentId: p.class.tournament.id,
       tournamentName: p.class.tournament.name,
+      shortName: p.class.tournament.edition?.series?.shortName ?? null,
       eventDate: p.class.tournament.eventDate,
       className: p.class.className,
       grade: p.class.grade,

--- a/apps/web/src/lib/players/tournamentLabel.test.ts
+++ b/apps/web/src/lib/players/tournamentLabel.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { formatTournamentLabel, stripKai } from './tournamentLabel'
+
+describe('stripKai', () => {
+  it('半角数字の「第N回」接頭を除去する', () => {
+    expect(stripKai('第40回高松宮記念杯近江神宮全国大会')).toBe('高松宮記念杯近江神宮全国大会')
+  })
+
+  it('全角数字の「第N回」接頭を除去する', () => {
+    expect(stripKai('第４０回高松宮記念杯近江神宮全国大会')).toBe('高松宮記念杯近江神宮全国大会')
+  })
+
+  it('「第N回」が無ければそのまま返す', () => {
+    expect(stripKai('北海道選手権')).toBe('北海道選手権')
+  })
+})
+
+describe('formatTournamentLabel', () => {
+  it('shortName ありのとき shortName + grade を返す', () => {
+    expect(
+      formatTournamentLabel({ name: '第40回高松宮記念杯近江神宮全国大会', shortName: '高松宮', grade: 'A' }),
+    ).toBe('高松宮A')
+  })
+
+  it('shortName あり + grade null のとき shortName のみ返す', () => {
+    expect(
+      formatTournamentLabel({ name: '第40回高松宮記念杯近江神宮全国大会', shortName: '高松宮', grade: null }),
+    ).toBe('高松宮')
+  })
+
+  it('shortName null のとき「第N回」除去した正式名称 + grade にフォールバックする', () => {
+    expect(
+      formatTournamentLabel({ name: '第40回高松宮記念杯近江神宮全国大会', shortName: null, grade: 'B' }),
+    ).toBe('高松宮記念杯近江神宮全国大会B')
+  })
+
+  it('shortName null + grade null のとき「第N回」除去した正式名称のみ返す', () => {
+    expect(
+      formatTournamentLabel({ name: '第40回高松宮記念杯近江神宮全国大会', shortName: null, grade: null }),
+    ).toBe('高松宮記念杯近江神宮全国大会')
+  })
+
+  it('全角数字の「第N回」を含む正式名称でも除去してフォールバックする', () => {
+    expect(
+      formatTournamentLabel({ name: '第４０回高松宮記念杯近江神宮全国大会', shortName: null, grade: 'C' }),
+    ).toBe('高松宮記念杯近江神宮全国大会C')
+  })
+})

--- a/apps/web/src/lib/players/tournamentLabel.ts
+++ b/apps/web/src/lib/players/tournamentLabel.ts
@@ -1,0 +1,16 @@
+/** 「第N回」接頭を除去（全角数字も）。 */
+export function stripKai(name: string): string {
+  return name.replace(/^第[0-9０-９]+回\s*/, '')
+}
+
+/**
+ * 大会名+級の表示ラベル。通称（shortName）があればそれを優先し、無ければ正式名称から
+ * 「第N回」を除去したものにフォールバックする。級は本人の出場級のみ（大会全体の開催級ではない）。
+ */
+export function formatTournamentLabel(t: {
+  name: string
+  shortName: string | null
+  grade: string | null
+}): string {
+  return (t.shortName ?? stripKai(t.name)) + (t.grade ?? '')
+}

--- a/docs/features/player-tournament-shortname/implementation-plan.md
+++ b/docs/features/player-tournament-shortname/implementation-plan.md
@@ -28,7 +28,7 @@ status: completed
 - **対応Issue:** #270
 
 ### タスク3: 戦績詳細画面 `/players/[id]` の表示差し替え
-- [ ] 完了
+- [x] 完了
 - **概要:** ローカル `stripKai` を撤去し、`formatTournamentLabel` を使って年別大会見出しの `title` を組み立てる。通称が使えない大会は現行と同じ見た目（回帰なし）。
 - **変更対象ファイル:**
   - `apps/web/src/app/(app)/players/[id]/page.tsx` — ローカル `stripKai` 関数定義を削除。`title: \`${stripKai(part.tournamentName)}${part.grade ?? ''}\`` を `title: formatTournamentLabel({ name: part.tournamentName, shortName: part.shortName, grade: part.grade })` に置換（`tournamentLabel.ts` から import）。

--- a/docs/features/player-tournament-shortname/implementation-plan.md
+++ b/docs/features/player-tournament-shortname/implementation-plan.md
@@ -37,7 +37,7 @@ status: completed
 - **対応Issue:** #271
 
 ### タスク4: 選手検索結果一覧の表示差し替え（`PlayerResultRow`）
-- [ ] 完了
+- [x] 完了
 - **概要:** 「最終出場：YYYY/MM（大会名 結果）」の大会名部分を `formatTournamentLabel` 経由の表示に差し替え、級を新規に付加する。`lastTournamentName` が null＝出場記録なし、の分岐ロジックは変更しない。
 - **変更対象ファイル:**
   - `apps/web/src/app/(app)/players/components/PlayerResultRow.tsx` — `{player.lastTournamentName}` の直接表示を `{formatTournamentLabel({ name: player.lastTournamentName, shortName: player.lastShortName, grade: player.lastGrade })}` に置換（`lastTournamentName` は null チェック済みの分岐内なので non-null として渡せる）。

--- a/docs/features/player-tournament-shortname/implementation-plan.md
+++ b/docs/features/player-tournament-shortname/implementation-plan.md
@@ -1,0 +1,51 @@
+---
+status: completed
+---
+# player-tournament-shortname 実装手順書
+
+> 入力＝[requirements.md](./requirements.md)（`design_required: false`・design-spec なし）。既存画面 `/players` と `/players/[id]` の表示ロジック改修のみ。新規 API/DB/migration なし。
+
+## 実装タスク
+
+### タスク1: 大会名フォーマット純関数＋ユニットテスト【テスト先行】
+- [x] 完了
+- **概要:** `stripKai`（「第N回」除去、既存 `page.tsx` のプライベート関数）を共有モジュールへ移設し、通称優先の合成ロジック `formatTournamentLabel` を新設する。
+- **変更対象ファイル:**
+  - `apps/web/src/lib/players/tournamentLabel.ts` — 新規。`stripKai(name: string): string`（既存正規表現 `^第[0-9０-９]+回\s*` をそのまま移設）／`formatTournamentLabel(t: { name: string; shortName: string | null; grade: string | null }): string`（`(t.shortName ?? stripKai(t.name)) + (t.grade ?? '')`）。
+  - `apps/web/src/lib/players/tournamentLabel.test.ts` — 新規（先に書く）。ケース: shortName あり+grade あり／shortName あり+grade null／shortName null+正式名称に「第N回」あり／shortName null+grade null／全角数字の回次除去。
+- **依存タスク:** なし
+- **対応Issue:** #269
+
+### タスク2: クエリ層の拡張（`getPlayerRecord` / `searchPlayers`）＋テスト【テスト先行】
+- [ ] 完了
+- **概要:** 通称解決（`tournaments.edition_id → tournament_series_editions.series_id → tournament_series.short_name`）を両クエリに追加し、戻り値の型に通称・級フィールドを足す。既存フィールド（`tournamentName`/`lastTournamentName` 等）は変更しない（後方互換）。
+- **変更対象ファイル:**
+  - `apps/web/src/lib/players/queries.ts`
+    - `getPlayerRecord`: `tournamentParticipants.findMany` の `with.class.with.tournament` に `with: { edition: { with: { series: { columns: { shortName: true } } } } }` を追加。`PlayerParticipationView` に `shortName: string | null` を追加し、マッピングで `p.class.tournament.edition?.series?.shortName ?? null` を設定。
+    - `searchPlayers`: `latest` LATERAL サブクエリ（`tournamentClasses`/`tournaments` 既存 join 済み）に `tournamentSeriesEditions`・`tournamentSeries` への `leftJoin` を追加。select に `tournamentClasses.grade`（ラテラル内で既存 join 済み）と `tournamentSeries.shortName` を追加。`PlayerSearchResult` に `lastShortName: string | null` と `lastGrade: 'A'|'B'|'C'|'D'|'E'|null` を追加。
+  - `apps/web/src/lib/players/queries.test.ts` — 追加ケース: series 紐付き大会（shortName 取得）／edition 未紐付き大会（shortName null）／series 紐付きだが short_name 未設定（shortName null）。`getPlayerRecord`・`searchPlayers` 両方で検証。既存テスト（`tournamentName`/`lastTournamentName` アサーション）は変更不要。
+- **依存タスク:** なし（タスク1と並行可）
+- **対応Issue:** #270
+
+### タスク3: 戦績詳細画面 `/players/[id]` の表示差し替え
+- [ ] 完了
+- **概要:** ローカル `stripKai` を撤去し、`formatTournamentLabel` を使って年別大会見出しの `title` を組み立てる。通称が使えない大会は現行と同じ見た目（回帰なし）。
+- **変更対象ファイル:**
+  - `apps/web/src/app/(app)/players/[id]/page.tsx` — ローカル `stripKai` 関数定義を削除。`title: \`${stripKai(part.tournamentName)}${part.grade ?? ''}\`` を `title: formatTournamentLabel({ name: part.tournamentName, shortName: part.shortName, grade: part.grade })` に置換（`tournamentLabel.ts` から import）。
+  - 既存のページレベルテスト（あれば）で見出し文字列のアサーションを更新。shortName ありのケースを追加。
+- **依存タスク:** タスク1・タスク2
+- **対応Issue:** #271
+
+### タスク4: 選手検索結果一覧の表示差し替え（`PlayerResultRow`）
+- [ ] 完了
+- **概要:** 「最終出場：YYYY/MM（大会名 結果）」の大会名部分を `formatTournamentLabel` 経由の表示に差し替え、級を新規に付加する。`lastTournamentName` が null＝出場記録なし、の分岐ロジックは変更しない。
+- **変更対象ファイル:**
+  - `apps/web/src/app/(app)/players/components/PlayerResultRow.tsx` — `{player.lastTournamentName}` の直接表示を `{formatTournamentLabel({ name: player.lastTournamentName, shortName: player.lastShortName, grade: player.lastGrade })}` に置換（`lastTournamentName` は null チェック済みの分岐内なので non-null として渡せる）。
+  - `apps/web/src/app/(app)/players/components/PlayerResultRow.test.tsx` — 表示文字列アサーションを新フォーマットに更新。shortName あり（級付き表示）／shortName なし（フォールバック＋第N回除去＋級表示）のケースを追加。
+- **依存タスク:** タスク1・タスク2
+- **対応Issue:** #272
+
+## 実装順序
+1. タスク1（依存なし）・タスク2（依存なし）— 並行実装可
+2. タスク3（タスク1・2に依存）
+3. タスク4（タスク1・2に依存）

--- a/docs/features/player-tournament-shortname/implementation-plan.md
+++ b/docs/features/player-tournament-shortname/implementation-plan.md
@@ -17,7 +17,7 @@ status: completed
 - **対応Issue:** #269
 
 ### タスク2: クエリ層の拡張（`getPlayerRecord` / `searchPlayers`）＋テスト【テスト先行】
-- [ ] 完了
+- [x] 完了
 - **概要:** 通称解決（`tournaments.edition_id → tournament_series_editions.series_id → tournament_series.short_name`）を両クエリに追加し、戻り値の型に通称・級フィールドを足す。既存フィールド（`tournamentName`/`lastTournamentName` 等）は変更しない（後方互換）。
 - **変更対象ファイル:**
   - `apps/web/src/lib/players/queries.ts`

--- a/docs/features/player-tournament-shortname/requirements.md
+++ b/docs/features/player-tournament-shortname/requirements.md
@@ -1,0 +1,84 @@
+---
+status: completed
+design_required: false
+---
+# player-tournament-shortname 要件定義書
+
+## 1. 概要
+- **目的:** 統計画面の選手まわり2画面で表示される「大会名」を、正式名称ベースの表記から「大会シリーズの通称（`tournament_series.short_name`）＋選手の出場級」の合成表示に変更する。
+- **背景・動機:** 大会結果統計（`/tournaments` 大会別一覧）では既に通称表示（例「大阪ABC」）が実装済み（`tournamentDisplayTitle`, `TournamentYearList.tsx`）。選手個人の戦績側（検索結果・戦績詳細）はまだ正式名称ベースの表記のままで、会内で使う短い通称と表記が揃っていない。データ（`tournament_series.short_name`）は既に180系列分が本番投入済みのため、**追加のデータ整備は不要**、表示ロジックの追加のみで実現できる。
+
+## 2. ユーザーストーリー
+- **対象ユーザー:** 統計画面で選手を検索・閲覧する全ログインユーザー（会員）。
+- **ユーザーの目的:** 大会名を長い正式名称（例「第40回高松宮記念杯近江神宮全国大会」）でなく、会内で通じる短い通称＋出場級（例「高松宮A」）でパッと識別したい。
+- **利用シナリオ:**
+  1. 選手検索結果一覧の各行「最終出場：YYYY/MM（大会名 結果）」で、大会名部分が通称＋出場級になる。
+  2. 選手をタップして開く戦績詳細画面 `/players/[id]` の年別大会見出しでも、同じ通称＋出場級で表示される。
+  3. 通称が未設定、またはシリーズ未紐付きの大会は、現行同様「正式名称から『第N回』を除去した表記」＋出場級にフォールバックする（表示が消えたり空欄になったりしない）。
+
+## 3. 機能要件
+
+### 3.1 画面仕様
+
+**対象画面A: `/players`（選手検索結果一覧・`PlayerResultRow.tsx`）**
+- 各行の「最終出場：YYYY/MM（大会名 結果）」の大会名部分を変更。
+- **現行:** `lastTournamentName`（正式名称そのまま。「第N回」を含む） を無加工表示。
+- **変更後:** `通称 + 出場級`（例「大阪A」）。通称が使えない場合は「正式名称から『第N回』を除去したもの」＋出場級にフォールバック（＝この画面にも新たに『第N回』除去を導入）。
+- 級の表示は今回**新規追加**（現行はこの行に級を一切出していない）。
+- それ以外（日付・結果・レイアウト）は変更しない。
+
+**対象画面B: `/players/[id]`（選手戦績詳細・年別大会見出し）**
+- **現行:** `stripKai(tournamentName) + grade`（正式名称から「第N回」を除去し、出場級を後置。例「北海道選手権A」）。
+- **変更後:** 通称が使えるときは `shortName + grade`（例「大阪A」）。通称が使えないときは現行と同じ `stripKai(tournamentName) + grade` にフォールバック（見た目の後退なし）。
+
+**共通仕様**
+- **級の範囲＝その選手がその参加で出場した1級のみ**（大会全体で開催された全級ではない。例：大会全体はABC開催でも本人がA級のみ出場なら「大阪A」）。
+- **回次（「第〇〇回」）は表示に含めない**（ご提示例の「第〇〇回大阪AB」から回次部分は除く、との確認済み）。
+- 級が不明（`grade` が null）の参加は級表記なし（通称またはフォールバック名のみ）。
+- 通称・正式名称のどちらの場合も、大会名と級の間に区切り文字は入れない（既存 `/tournaments` の「大阪ABC」表記と同じ連結スタイル）。
+
+### 3.2 ビジネスルール
+- **通称の解決経路:** `tournaments.edition_id → tournament_series_editions.series_id → tournament_series.short_name`（3ホップ）。`short_name` は既存 migration 0038 で180系列に投入済み・本番稼働中。**新たな大会シリーズマスタ整備は不要**。
+- **優先順位:** `short_name` が非 null → `short_name + grade`。`short_name` が null（`edition_id` 未設定、または紐付いた series の `short_name` 未設定）→ `stripKai(正式名称) + grade`。
+- **後方互換:** 戦績詳細画面（対象画面B）は通称が使えない大会について現行と全く同じ見た目を維持（回帰なし）。選手検索結果一覧（対象画面A）は通称が使えない大会でも「第N回」を新たに除去する仕様変更になる（両画面の表記ルールを統一するため）。
+
+### 3.3 エラーケース・境界条件
+- `short_name` null・`edition_id` null・級 null は全て上記フォールバック規則で吸収し、表示が欠落することはない。
+- 通称データの追加投入・修正は本機能のスコープ外（既存180系列のデータをそのまま使う）。
+
+## 4. 技術設計
+
+### 4.1 API設計
+新規エンドポイントなし。既存のサーバーサイド関数（Server Component から直接呼ばれる読み取り専用クエリ）の戻り値を拡張する。
+
+### 4.2 DB設計
+変更なし。既存の `tournament_series.short_name`（migration 0038）／`tournaments.edition_id`（migration 0033）／既存 Drizzle relations（`tournaments.edition → tournamentSeriesEditions.series → tournamentSeries`）をそのまま利用する。
+
+### 4.3 フロントエンド設計
+- **新規共有モジュール** `apps/web/src/lib/players/tournamentLabel.ts`
+  - `stripKai(name: string): string` — 現行 `page.tsx` 内のプライベート関数をここへ移設。
+  - `formatTournamentLabel(t: { name: string; shortName: string | null; grade: string | null }): string` — `t.shortName ?? stripKai(t.name)` に `t.grade ?? ''` を連結する純関数。ユニットテスト先行（`tournamentLabel.test.ts`）。
+- **`apps/web/src/app/(app)/players/[id]/page.tsx`**: ローカル `stripKai` 定義を削除し、新モジュールの `formatTournamentLabel` を呼び出す形に置換。`participations` 由来の `shortName` を渡す。
+- **`apps/web/src/app/(app)/players/components/PlayerResultRow.tsx`**: `lastTournamentName` 直接表示を、`lastTournamentName`/`lastShortName`/`lastGrade` から `formatTournamentLabel` で組み立てた文字列の表示に置換（`lastTournamentName` が null＝出場記録なし、の判定ロジックは変更しない）。
+
+### 4.4 データ取得層設計（`apps/web/src/lib/players/queries.ts`）
+- **`getPlayerRecord`**: `tournamentParticipants.findMany` の `with.class.with.tournament` に `with: { edition: { with: { series: { columns: { shortName: true } } } } }` を追加。`PlayerParticipationView` に `shortName: string | null` を追加（`p.class.tournament.edition?.series?.shortName ?? null`）。既存フィールド（`tournamentName` 等）は変更しない。
+- **`searchPlayers`**: `latest` LATERAL サブクエリに `tournamentSeriesEditions`・`tournamentSeries` への `leftJoin` を追加し、`short_name` と（同ラテラル内で既に JOIN 済みの）`tournamentClasses.grade` を select に追加。`PlayerSearchResult` に `lastShortName: string | null` と `lastGrade: 'A'|'B'|'C'|'D'|'E'|null` を追加。既存フィールド（`lastTournamentName` 等）は変更しない。
+
+## 5. 影響範囲
+- `apps/web/src/lib/players/queries.ts`（型拡張＋クエリJOIN追加。既存フィールドはそのまま＝後方互換）
+- `apps/web/src/app/(app)/players/[id]/page.tsx`（表示ロジック差し替え、ローカル `stripKai` 撤去）
+- `apps/web/src/app/(app)/players/components/PlayerResultRow.tsx`（表示ロジック差し替え）
+- 新規 `apps/web/src/lib/players/tournamentLabel.ts` ＋ `tournamentLabel.test.ts`
+- 既存テスト更新: `apps/web/src/lib/players/queries.test.ts`（新フィールドのテスト追加。既存 `tournamentName`/`lastTournamentName` アサーションは変更不要）、`PlayerResultRow.test.tsx`（表示文字列アサーションを新フォーマットに更新）
+- DB・migration: 変更なし
+- design-spec: 不要（`design_required: false`。既存デザイン語彙内の文言差し替えのみで新規UI要素・新規状態を伴わない。`PlayerResultRow` への級追加も既存の1行メタテキスト内の文字列変更に留まる）
+
+## 6. 設計判断の根拠
+- **専用関数として新設（既存 `tournamentDisplayTitle` を流用しない）:** `/tournaments` の通称表示は「大会全体の開催級（複数）」を対象にしているのに対し、本機能は「選手本人の出場級（単一）」が対象で、フォールバック時の「第N回」除去有無も両者で異なる（`/tournaments` は shortName null 時に正式名称をそのまま出す＝除去しない）。仕様が異なるため使い回さず、`formatTournamentLabel` として別関数にする。
+- **回次（第N回）を含めない:** ご提示の例には回次が含まれていたが、既存の戦績詳細画面が可読性のため意図的に除去してきた経緯を踏襲する方針として確認済み。
+- **データ整備なしで実現:** `tournament_series.short_name` は既に180系列分・本番投入済み（migration 0038）。本機能は表示層のみに閉じ、大会シリーズマスタの追加データ作業は行わない。
+- **選手検索結果一覧のフォールバックも「第N回」除去に統一:** 2画面の表記ルールを揃えるため、検索結果一覧側にも新たに除去ロジックを導入する（詳細画面は現行動作を維持）。
+
+## 進捗メモ
+- 2026-07-05: コード調査（現状表示ロジック・`tournament_series`/`tournament_series_editions` の Drizzle 定義済み・`short_name` 本番投入済みを確認）→ ユーザーヒアリングで対象画面（2画面）・回次の要否（含めない）・フォールバック統一方針（両画面で第N回除去）・級の範囲（本人出場級のみ）・検索結果一覧への級追加（する）を確定。design_required=false（既存デザイン語彙内の文言差し替え）。


### PR DESCRIPTION
## Summary
- 選手検索結果一覧（`/players`）・戦績詳細（`/players/[id]`）の大会名表示を、正式名称ベースから「大会シリーズの通称（`tournament_series.short_name`）＋本人の出場級」の合成表示に変更
- 共有純関数 `formatTournamentLabel`（`apps/web/src/lib/players/tournamentLabel.ts`）を新設し、通称未設定時は正式名称から「第N回」を除去してフォールバック
- `getPlayerRecord`/`searchPlayers` に通称・出場級フィールドを非破壊で追加（既存フィールドは変更なし）
- 通称データは既存 migration 0038 で本番投入済みのため、追加のデータ整備なし（表示層のみの変更）

Closes #268, #269, #270, #271, #272

## Test plan
- [x] `tournamentLabel.test.ts`（新規・8ケース）
- [x] `queries.test.ts`（通称あり/edition未紐付き/short_name未設定の3ケース追加、既存37+3ケース全green）
- [x] `PlayerResultRow.test.tsx`（通称あり/フォールバックの2ケース追加、既存アサーション更新、全12ケースgreen）
- [x] `pnpm --filter web test` 全体green
- [x] `pnpm --filter web check-types` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)