### PR TITLE
chore(dev): /show-app コマンド + dev:session Cookieヘルパー (in-app pane 表示)

### DIFF
--- a/.claude/commands/show-app.md
+++ b/.claude/commands/show-app.md
@@ -1,0 +1,72 @@
+---
+description: Show the running kagetra web app live in the in-app Browser pane, logged in, without tripping the redirect-loop bug.
+argument-hint: "[local|prod] [route]  e.g. `prod /tournaments`"
+---
+
+# /show-app — view the app in the in-app Browser pane
+
+Goal: render the authenticated kagetra web app **live in the in-app Browser pane**.
+Args: `$1` = data source `local` (default) or `prod`; `$2` = route (default `/dashboard`).
+
+## THE GOLDEN RULE (why this command exists)
+
+The in-app Browser pane **cannot follow a top-level HTTP redirect** — it re-requests
+the same URL until the browser aborts with `ERR_TOO_MANY_REDIRECTS`, leaving a broken
+`(non-http)` page (screenshot times out, `document.cookie` denied). This app redirects
+on `/` (unauth → `/auth/signin`; authed → `/dashboard`). So:
+
+- **NEVER navigate the pane to `/`** or any redirecting URL.
+- Always land the pane on a **direct 200 page** (`/sw.js`, `/auth/signin` when logged out,
+  or any `/dashboard`, `/tournaments`, `/players`, … once a session cookie is set).
+- In-app **bottom-nav clicks are client-side (no redirect) and safe**; use them to move around.
+- The server itself is fine (curl/Playwright follow the redirect normally) — this is purely
+  an in-app-pane limitation.
+
+## Steps
+
+0. Confirm the dev server can start: `.claude/launch.json` `web` entry uses
+   `cmd /c corepack pnpm dev` (the preview runner's PATH lacks the pnpm global bin —
+   plain `pnpm` fails). Don't "fix" it back to bare `pnpm`.
+
+1. **If `$1` == prod** — point web at the production DB first (see the
+   `reference_prod_db_tunnel_connect` memory for full detail). Otherwise skip to step 2.
+   - Tunnel: if `netstat -ano | grep 127.0.0.1:5435` shows nothing, start it in the background:
+     `ssh -i ~/.ssh/id_ed25519_oracle -o BatchMode=yes -o ExitOnForwardFailure=yes -N -L 127.0.0.1:5435:127.0.0.1:5432 ubuntu@new.hokudaicarta.com`
+   - `.env.local`: if `apps/web/.env.local`'s active `DATABASE_URL` is not already on `:5435`,
+     switch it to `postgresql://kagetra:<PW>@127.0.0.1:5435/kagetra?sslmode=disable`
+     (comment the original for revert). Get `<PW>` at runtime — never hardcode it:
+     `ssh -i ~/.ssh/id_ed25519_oracle -o BatchMode=yes ubuntu@new.hokudaicarta.com 'sudo docker exec kagetra-postgres printenv POSTGRES_PASSWORD'`
+   - ⚠️ Tell the user: this is **session-scoped and read-WRITE against production** — the tunnel
+     dies with the session and `.env.local` must be reverted afterward.
+
+2. **Start the dev server**: `preview_start` with name `web`. It auto-opens the `seed` tab
+   (which loads `/` → redirect → will show the loop; ignore it, we override in step 4).
+
+3. **Mint a session cookie** for an existing user (never inserts — prod-safe):
+   ```
+   pnpm --silent --filter @kagetra/web dev:session -- --role=admin 2>/dev/null | tail -n1 | tr -d '\r\n'
+   ```
+   Use `--silent` + `tail -n1` or pnpm's banner mashes into the token. Capture the token.
+   (For a fresh LOCAL DB with no users, `dev:cookie` seeds one — but NEVER run `dev:cookie` against prod.)
+
+4. **Land the pane on a scriptable 200 page** (not `/`):
+   `navigate` the `seed` tab to `http://localhost:3000/sw.js` (static file, excluded from
+   auth middleware → always 200, no redirect).
+
+5. **Inject the cookie + verify** via `javascript_tool` on the `seed` tab:
+   ```js
+   document.cookie = "authjs.session-token=<TOKEN>; Path=/; Max-Age=604800; SameSite=Lax";
+   (async () => (await fetch('/api/auth/session',{credentials:'same-origin'})).text())()
+   ```
+   Expect JSON with the user (not `null`). `document.cookie` can set it because there's no
+   pre-existing HttpOnly session cookie (JS can't overwrite one; if session isn't null here,
+   sign out first via `/api/auth/signout` or clear cookies).
+
+6. **Navigate the pane directly to the target 200 page**: `http://localhost:3000$2`
+   (default `/dashboard`). With the session set this returns 200 (no redirect) and renders.
+
+7. **Screenshot** the `seed` tab to confirm, and report. Remind the user: click the bottom
+   nav to browse; never open `/`; ask you to jump to a specific page if needed.
+
+8. **If `$1` == prod**, remind the user to run the revert when done: stop the SSH tunnel and
+   restore `apps/web/.env.local`'s original `DATABASE_URL` (uncomment the saved line).

--- a/.claude/commands/show-app.md
+++ b/.claude/commands/show-app.md
@@ -8,65 +8,125 @@ argument-hint: "[local|prod] [route]  e.g. `prod /tournaments`"
 Goal: render the authenticated kagetra web app **live in the in-app Browser pane**.
 Args: `$1` = data source `local` (default) or `prod`; `$2` = route (default `/dashboard`).
 
+> **Fast path — do these in order, no detours (this ordering is the point):**
+> ① reconcile `.env.local` ↔ `$1` → ② make DB reachable → ③ **mint cookie = DB probe** →
+> ④ `preview_start web` → ⑤ land on `/sw.js` **and verify `origin` is http** →
+> ⑥ inject cookie + verify session → ⑦ navigate to the route → ⑧ prove with `read_page`.
+> Every slow run so far came from discovering a **wrong/dead DB *after*** starting the server.
+> Steps ①–③ front-load that failure so it costs seconds, not the whole pane dance.
+
 ## THE GOLDEN RULE (why this command exists)
 
-The in-app Browser pane **cannot follow a top-level HTTP redirect** — it re-requests
-the same URL until the browser aborts with `ERR_TOO_MANY_REDIRECTS`, leaving a broken
-`(non-http)` page (screenshot times out, `document.cookie` denied). This app redirects
-on `/` (unauth → `/auth/signin`; authed → `/dashboard`). So:
+The in-app Browser pane **cannot follow a top-level HTTP redirect** — it re-requests the same
+URL until the browser aborts with `ERR_TOO_MANY_REDIRECTS`, landing on a dead
+`chrome-error://chromewebdata/` page (`location.origin === "null"`, `document.cookie` throws
+`Access is denied`). This app redirects on `/` (unauth → `/auth/signin`; authed → `/dashboard`). So:
 
-- **NEVER navigate the pane to `/`** or any redirecting URL.
-- Always land the pane on a **direct 200 page** (`/sw.js`, `/auth/signin` when logged out,
-  or any `/dashboard`, `/tournaments`, `/players`, … once a session cookie is set).
+- **NEVER navigate the pane to `/`** or any redirecting URL — and never a **bare
+  `http://localhost:3000`** (that *is* `/`). Always include an explicit non-redirecting path.
+- Always land the pane on a **direct 200 page** (`/sw.js`, `/auth/signin` when logged out, or any
+  `/dashboard`, `/tournaments`, `/players`, … once a session cookie is set).
 - In-app **bottom-nav clicks are client-side (no redirect) and safe**; use them to move around.
-- The server itself is fine (curl/Playwright follow the redirect normally) — this is purely
-  an in-app-pane limitation.
+- The server itself is fine (curl/Playwright follow the redirect normally) — this is purely an
+  in-app-pane limitation.
+- **A `screenshot` timeout is NOT a reliable failure signal** — it times out both on the dead
+  chrome-error page AND on perfectly healthy pages (pane capture quirk). Never diagnose from a
+  screenshot; check `location.origin` / `document.readyState` and use `read_page` instead.
+
+## Ignore preview-runner "dev server failed" errors that aren't about `web`
+
+`.claude/launch.json` also defines `design-live` (cwd `C:/tmp/design-live/...`, an external
+worktree) and `postgres` (port 5433, permanently owned by the docker DB). Both are
+**categorically incompatible with the preview runner** — it rejects an external cwd, and it can't
+bind a port docker already holds. When the pane opens, the harness may try them and surface generic
+**"dev server failed"** popups naming `cwd must be a relative path` / `port 5433 (or 3100) in use`.
+
+- **These are NOT about `web`.** `preview_start web` starts cleanly on 3000 with those entries
+  present (verified 2026-07-13). Do **not** investigate them and do **not** edit `launch.json` in
+  response — that rabbit hole cost the last run ~10 minutes. (If the popups ever become annoying,
+  the only real fix is deleting those two entries and launching `design-live` outside this file —
+  a separate decision, not part of this command.)
 
 ## Steps
 
-0. Confirm the dev server can start: `.claude/launch.json` `web` entry uses
-   `cmd /c corepack pnpm dev` (the preview runner's PATH lacks the pnpm global bin —
-   plain `pnpm` fails). Don't "fix" it back to bare `pnpm`.
+1. **Pre-flight: reconcile the DB target — BEFORE anything else.**
+   Read `apps/web/.env.local`'s active (uncommented) `DATABASE_URL`:
+   - `@127.0.0.1:5435` → currently **prod** (a leftover tunnel from a past `/show-app prod` that
+     was never reverted — see `feedback_ship_dod_residual_check` / `reference_prod_db_tunnel_connect`).
+   - `@…:5433` → currently **local** (docker).
+   - **If the current target ≠ `$1`, STOP and ask the user which data they want.** A plain
+     `/show-app` inheriting a prod `.env.local` is the exact ambiguity that derailed the last run.
+     Don't silently revert (discards their prod setup) and don't silently use prod (contradicts the
+     command). Proceed only once the source is agreed.
 
-1. **If `$1` == prod** — point web at the production DB first (see the
-   `reference_prod_db_tunnel_connect` memory for full detail). Otherwise skip to step 2.
-   - Tunnel: if `netstat -ano | grep 127.0.0.1:5435` shows nothing, start it in the background:
-     `ssh -i ~/.ssh/id_ed25519_oracle -o BatchMode=yes -o ExitOnForwardFailure=yes -N -L 127.0.0.1:5435:127.0.0.1:5432 ubuntu@new.hokudaicarta.com`
-   - `.env.local`: if `apps/web/.env.local`'s active `DATABASE_URL` is not already on `:5435`,
-     switch it to `postgresql://kagetra:<PW>@127.0.0.1:5435/kagetra?sslmode=disable`
-     (comment the original for revert). Get `<PW>` at runtime — never hardcode it:
-     `ssh -i ~/.ssh/id_ed25519_oracle -o BatchMode=yes ubuntu@new.hokudaicarta.com 'sudo docker exec kagetra-postgres printenv POSTGRES_PASSWORD'`
-   - ⚠️ Tell the user: this is **session-scoped and read-WRITE against production** — the tunnel
-     dies with the session and `.env.local` must be reverted afterward.
+2. **Make `.env.local` match the agreed source, and make the DB reachable** (the reachability
+   proof happens in step 3):
+   - **local**: active `DATABASE_URL` = the `:5433` line (uncomment it, comment `:5435`). Confirm
+     docker db is up: `netstat -ano | grep ':5433' | grep LISTENING`.
+   - **prod**:
+     - **Tunnel**: if `netstat -ano | grep '127.0.0.1:5435'` shows no LISTENING line, start it in
+       the **background** and wait for the listener:
+       ```
+       ssh -i ~/.ssh/id_ed25519_oracle -o BatchMode=yes -o ExitOnForwardFailure=yes -N \
+         -L 127.0.0.1:5435:127.0.0.1:5432 ubuntu@new.hokudaicarta.com
+       ```
+       then poll: `for i in 1 2 3 4 5; do netstat -ano | grep -q '127.0.0.1:5435.*LISTENING' && echo UP && break; done`
+     - **`.env.local`**: if the active `DATABASE_URL` isn't already `@127.0.0.1:5435`, switch it to
+       `postgresql://kagetra:<PW>@127.0.0.1:5435/kagetra?sslmode=disable` (comment the original for
+       revert). Fetch `<PW>` at runtime — never hardcode:
+       `ssh -i ~/.ssh/id_ed25519_oracle -o BatchMode=yes ubuntu@new.hokudaicarta.com 'sudo docker exec kagetra-postgres printenv POSTGRES_PASSWORD'`
+     - ⚠️ Tell the user: **read-WRITE against production**, session-scoped — the tunnel dies with
+       the session and `.env.local` must be reverted afterward (step 9).
 
-2. **Start the dev server**: `preview_start` with name `web`. It auto-opens the `seed` tab
-   (which loads `/` → redirect → will show the loop; ignore it, we override in step 4).
-
-3. **Mint a session cookie** for an existing user (never inserts — prod-safe):
+3. **Mint the session cookie — this doubles as the DB reachability probe, so run it BEFORE
+   `preview_start`.** `dev:session` connects to the DB directly (no web server needed) and only
+   SELECTs an existing user (never inserts → prod-safe):
    ```
    pnpm --silent --filter @kagetra/web dev:session -- --role=admin 2>/dev/null | tail -n1 | tr -d '\r\n'
    ```
-   Use `--silent` + `tail -n1` or pnpm's banner mashes into the token. Capture the token.
-   (For a fresh LOCAL DB with no users, `dev:cookie` seeds one — but NEVER run `dev:cookie` against prod.)
+   `--silent` + `tail -n1` keep pnpm's banner out of the token.
+   - **If the output is empty or doesn't start with `eyJ`, the DB is unreachable** — re-run
+     WITHOUT `2>/dev/null` to read the error (`ECONNREFUSED :5435` = prod tunnel down;
+     `:5433` = docker db down). Fix step 2 and retry. **Do NOT proceed without a valid `eyJ…`
+     token** — a missing token is precisely what makes the later cookie step fail.
+   - (Fresh LOCAL DB with no users: `dev:cookie` seeds one — but NEVER run `dev:cookie` against prod.)
 
-4. **Land the pane on a scriptable 200 page** (not `/`):
-   `navigate` the `seed` tab to `http://localhost:3000/sw.js` (static file, excluded from
-   auth middleware → always 200, no redirect).
+4. **Start the dev server**: `preview_start` with name `web` (starts on 3000; **note the returned
+   `tabId`** and use it for every pane call below). It auto-opens a tab at `/` → redirect → dead
+   `chrome-error` page; we override it in step 5.
+   - Confirm `launch.json`'s `web` entry still uses `cmd /c corepack pnpm dev` — the runner's PATH
+     lacks the pnpm global bin, so bare `pnpm` fails. Don't "fix" it to bare `pnpm`.
 
-5. **Inject the cookie + verify** via `javascript_tool` on the `seed` tab:
+5. **Land the pane on a scriptable 200 page — and VERIFY you actually escaped the error page.**
+   `navigate` the tab to `http://localhost:3000/sw.js` (static file, excluded from auth middleware
+   → always 200). Then confirm with `javascript_tool`:
+   ```js
+   JSON.stringify({ href: location.href, origin: location.origin })
+   ```
+   **Expect `origin === "http://localhost:3000"`.** If `origin` is `"null"` (still the chrome-error
+   page — the first navigate off it often doesn't stick), `navigate` to `/sw.js` **again** and
+   re-check. **Do not inject the cookie until origin is confirmed http** — otherwise
+   `document.cookie` throws `Access is denied` and you waste a round-trip.
+
+6. **Inject the cookie + verify** via `javascript_tool` on the same tab:
    ```js
    document.cookie = "authjs.session-token=<TOKEN>; Path=/; Max-Age=604800; SameSite=Lax";
    (async () => (await fetch('/api/auth/session',{credentials:'same-origin'})).text())()
    ```
-   Expect JSON with the user (not `null`). `document.cookie` can set it because there's no
-   pre-existing HttpOnly session cookie (JS can't overwrite one; if session isn't null here,
-   sign out first via `/api/auth/signout` or clear cookies).
+   Expect JSON with the user (not `null`). JS can set the cookie only because there's no
+   pre-existing HttpOnly session cookie; if the session isn't null here, sign out first
+   (`/api/auth/signout`) or clear cookies, then re-inject.
 
-6. **Navigate the pane directly to the target 200 page**: `http://localhost:3000$2`
-   (default `/dashboard`). With the session set this returns 200 (no redirect) and renders.
+7. **Navigate to the target route**: `route = $2 || "/dashboard"`; `navigate` to
+   `http://localhost:3000` + `route`. **Assert `route` starts with `/` and is not `/`** (a bare host
+   = `/` = redirect loop). With the session set this renders a 200.
 
-7. **Screenshot** the `seed` tab to confirm, and report. Remind the user: click the bottom
-   nav to browse; never open `/`; ask you to jump to a specific page if needed.
+8. **Prove it + report.** Primary proof = `read_page` (a11y tree) plus a `javascript_tool` read of
+   `location.href` / `document.title` / heading text. Try one `screenshot` for a visual, but
+   **treat a screenshot timeout as a non-issue when the DOM is `complete` and the console is clean**
+   — don't retry-loop on it. Remind the user: click the bottom nav to browse; never open `/`; ask
+   to jump to a specific page.
 
-8. **If `$1` == prod**, remind the user to run the revert when done: stop the SSH tunnel and
-   restore `apps/web/.env.local`'s original `DATABASE_URL` (uncomment the saved line).
+9. **If `$1` == prod, remind the user to revert when done**: stop the SSH tunnel (kill the
+   background ssh) and restore `apps/web/.env.local`'s original `DATABASE_URL` (uncomment the
+   `:5433` line, re-comment `:5435`).

--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -86,6 +86,8 @@
 - [PR#6フォントウェイト方針](project_pr6_font_fix_r2.md) — Noto JPは実使用ウェイトのみ
 
 ## Reference
+- [in-app pane でアプリ画面表示(/show-app)](reference_inapp_pane_app_view.md) — in-appブラウザは307追従不可でERR_TOO_MANY_REDIRECTS。/を踏ませず/sw.js経由でcookie注入→200ページ直行。dev:session(既存user・INSERT無)
+- [本番DBへSSHトンネル接続(:5435)](reference_prod_db_tunnel_connect.md) — ローカルdev webを本番postgresへ。id_ed25519_oracle鍵・5435トンネル・.env.local切替(127.0.0.1)。read-write/session限り
 - [tool出力捏造の環境現象](reference_tool_output_fabrication.md) — Write/Bash成功表示でも実体無しがある。重要操作後は独立系統でverify
 - [旧kagetra DBダンプ](reference_legacy_dump.md) — scripts/migration/dump/myappdb.dump
 - [ローカル動作確認セットアップ](reference_local_dev_setup.md) — docs/dev/local-dev-setup.md がエントリ

--- a/.claude/memory/reference_inapp_pane_app_view.md
+++ b/.claude/memory/reference_inapp_pane_app_view.md
@@ -1,0 +1,21 @@
+---
+name: reference_inapp_pane_app_view
+description: Claude Code の in-app ブラウザで kagetra アプリのログイン後画面をライブ表示する手順（/show-app コマンド）
+metadata:
+  type: reference
+---
+
+Claude Code の in-app Browser pane で認証必須のアプリ画面を見る手順。**コマンド化済み: `/show-app [local|prod] [route]`**（`.claude/commands/show-app.md`。cookie 発行は `apps/web/scripts/dev-session-cookie.ts`）。
+
+**根本の罠**: in-app ブラウザは**トップレベルの HTTP リダイレクト(307)を追従できない**。同じ URL を再リクエストし続け `ERR_TOO_MANY_REDIRECTS` に陥り `(non-http)` エラーページになる（スクショ timeout・`document.cookie` 拒否は全部この二次症状）。このアプリは `/` でリダイレクトする（未認証→`/auth/signin`、認証→`/dashboard`）ので **pane を `/` に遷移させない**。必ず**リダイレクトしない 200 ページに直接遷移**する。サーバー自体は正常（curl/Playwright は普通に追従して 200 になる＝アプリの不具合ではない）。
+
+**手順**:
+1. `preview_start web`（launch.json は `cmd /c corepack pnpm dev`。preview ランナーの PATH に pnpm グローバル bin が無く素の `pnpm` は `ENOENT`/未認識になるため corepack 経由。ここを素の pnpm に戻さない）。
+2. Cookie 発行: `pnpm --silent --filter @kagetra/web dev:session -- --role=admin 2>/dev/null | tail -n1 | tr -d '\r\n'`。`--silent`+`tail -n1` 必須（pnpm のバナーがトークンに混ざり 4dots JWE が壊れる）。`dev:session` は既存ユーザーを SELECT するだけで **INSERT しない**＝prod 安全。`dev:cookie` は `dev-admin@kagetra.local` を **INSERT** するので prod 接続時は使用禁止。
+3. pane を `http://localhost:3000/sw.js` に直接遷移（auth middleware 対象外の静的ファイル＝常に 200・スクリプト可能）。
+4. `javascript_tool` で `document.cookie="authjs.session-token=<TOKEN>; Path=/; Max-Age=604800; SameSite=Lax"` を注入→`fetch('/api/auth/session')` が user を返すこと確認。既存 HttpOnly セッションがあると JS で上書き不可なので session が null であること前提（残っていれば `/api/auth/signout` 等で先に消す）。
+5. pane を目的の 200 ページ（`/dashboard`・`/tournaments`・`/players` 等）に**直接遷移**→描画。下ナビのクリックはクライアント遷移でリダイレクト無し＝pane 内で回遊 OK。
+
+**確実な代替（静止画）**: live pane が不要なら Playwright headless で任意ページをスクショ→画像提示が最速・最堅（`scripts/diagnostics/shot.cjs`、認証は同じ minted cookie を `addCookies`）。
+
+本番データで見るには [[reference_prod_db_tunnel_connect]] を先に実施（`/show-app prod`）。認証の仕組みは [[feedback_auth_js_jwt_strategy_user_id]]。

--- a/.claude/memory/reference_prod_db_tunnel_connect.md
+++ b/.claude/memory/reference_prod_db_tunnel_connect.md
@@ -1,0 +1,18 @@
+---
+name: reference_prod_db_tunnel_connect
+description: ローカル dev web を本番 PostgreSQL に SSH トンネル経由(:5435)で接続する手順
+metadata:
+  type: reference
+---
+
+ローカルの dev web(apps/web) を**本番 DB** に向ける手順（本番データを画面で見る/点検する用）。⚠️ read-write なので**画面操作は本番に反映される**。**セッション限り**：トンネルは切断で消える、`.env.local` は終わったら必ず戻す。
+
+- 本番 postgres は Oracle Cloud VM 内で `127.0.0.1:5432` バインド（外部非公開）。到達は SSH トンネルのみ。
+- ローカル 5432 は他プロセスで埋まっていることがある → **5435** を使う（dev DB は docker で 5433/5434）。
+- トンネル（background）: `ssh -i ~/.ssh/id_ed25519_oracle -o BatchMode=yes -o ExitOnForwardFailure=yes -N -L 127.0.0.1:5435:127.0.0.1:5432 ubuntu@new.hokudaicarta.com`。鍵はパスフレーズ無し・`ubuntu` は NOPASSWD sudo 可。
+- PW 取得（実行時・**ハードコード禁止**）: `ssh -i ~/.ssh/id_ed25519_oracle -o BatchMode=yes ubuntu@new.hokudaicarta.com 'sudo docker exec kagetra-postgres printenv POSTGRES_PASSWORD'`。
+- `apps/web/.env.local` の `DATABASE_URL` を `postgresql://kagetra:<PW>@127.0.0.1:5435/kagetra?sslmode=disable` に切替（gitignore 済み・元値はコメントで残し即 revert）。**host は `127.0.0.1`**（`localhost` は IPv6 解決で docker pg に ECONNRESET）。**PW は git 追跡ファイルや応答に出さない**。
+- 検証: pane を使わず `node`+pg で `select count(*) from players`（本番は約 4.8 万件）や `curl /api/auth/session` で確認。web は起動時に `.env.local` を読むので切替後は preview を再起動。
+- 接続情報の正典 = `c:/tmp/HANDOVER_bulk_load.md`（host `new.hokudaicarta.com`、SSH 鍵、コンテナ名 `kagetra-postgres`、DB/user=`kagetra`）。本番構成は [[project_production_deploy]]。
+
+pane でログイン後画面を見る手順は [[reference_inapp_pane_app_view]]（`/show-app prod`）。

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,8 @@
     "lint": "next lint",
     "test": "vitest run",
     "test:watch": "vitest",
-    "dev:cookie": "tsx scripts/dev-issue-cookie.ts"
+    "dev:cookie": "tsx scripts/dev-issue-cookie.ts",
+    "dev:session": "tsx scripts/dev-session-cookie.ts"
   },
   "dependencies": {
     "@auth/drizzle-adapter": "^1.11.2",

--- a/apps/web/scripts/dev-session-cookie.ts
+++ b/apps/web/scripts/dev-session-cookie.ts
@@ -104,7 +104,7 @@ async function main() {
       },
     })
 
-    process.stderr.write(`[dev-session] minted for role=${u.role} name=${u.name} id=${u.id}\n`)
+    process.stderr.write(`[dev-session] minted for role=${u.role} id=${u.id}\n`)
     process.stdout.write(token + '\n')
   } finally {
     await pool.end()

--- a/apps/web/scripts/dev-session-cookie.ts
+++ b/apps/web/scripts/dev-session-cookie.ts
@@ -1,0 +1,117 @@
+/**
+ * Dev-only helper: mint an Auth.js JWT session cookie for an EXISTING user,
+ * WITHOUT inserting anything. This is the prod-safe companion to
+ * dev-issue-cookie.ts — that script INSERTS a synthetic `dev-*@kagetra.local`
+ * user, which must NEVER hit a prod-connected DB. Use this one whenever
+ * DATABASE_URL might point at production (e.g. via the SSH tunnel; see the
+ * "prod DB connect" memory recipe).
+ *
+ * Reads DATABASE_URL + AUTH_SECRET from apps/web/.env.local, so it targets
+ * whatever that file points at (local dev DB, or prod through the tunnel).
+ * Uses raw SQL selecting only columns that exist in prod (the schema's
+ * line_linked_method column is not present in the prod users table), so it
+ * won't break when pointed at production.
+ *
+ * Usage (from repo root):
+ *   pnpm --filter @kagetra/web dev:session                     # first admin (default)
+ *   pnpm --filter @kagetra/web dev:session -- --role=member
+ *   pnpm --filter @kagetra/web dev:session -- --email=someone@example.com
+ *
+ * Prints ONLY the cookie value to stdout (the chosen user goes to stderr), so
+ * callers can capture it. Then set it as cookie `authjs.session-token`. The
+ * `/show-app` command does this end-to-end for the in-app browser pane.
+ */
+import { config as loadEnv } from 'dotenv'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+// Load apps/web/.env.local before anything reads process.env.
+const here = dirname(fileURLToPath(import.meta.url))
+loadEnv({ path: resolve(here, '..', '.env.local') })
+
+import { Pool } from 'pg'
+import { encode } from 'next-auth/jwt'
+
+type Role = 'admin' | 'vice_admin' | 'member'
+const VALID_ROLES: readonly Role[] = ['admin', 'vice_admin', 'member']
+const AUTHJS_SESSION_COOKIE = 'authjs.session-token'
+const SESSION_MAX_AGE = 60 * 60 * 24 * 7
+
+function parseArgs(): { role: Role; email: string | null } {
+  let role: Role = 'admin'
+  let email: string | null = null
+  for (const arg of process.argv.slice(2)) {
+    const m = /^--([a-z-]+)=(.*)$/.exec(arg)
+    if (!m) continue
+    const [, key, value] = m
+    if (key === 'role') {
+      if (!(VALID_ROLES as readonly string[]).includes(value!)) {
+        throw new Error(`--role must be one of ${VALID_ROLES.join(', ')} (got "${value}")`)
+      }
+      role = value as Role
+    } else if (key === 'email') {
+      email = value!
+    }
+  }
+  return { role, email }
+}
+
+async function main() {
+  const { role, email } = parseArgs()
+  const databaseUrl = process.env.DATABASE_URL
+  const authSecret = process.env.AUTH_SECRET
+  if (!databaseUrl) throw new Error('DATABASE_URL not set (apps/web/.env.local)')
+  if (!authSecret) throw new Error('AUTH_SECRET not set (apps/web/.env.local)')
+
+  const pool = new Pool({ connectionString: databaseUrl })
+  try {
+    const where = email ? 'email = $1' : 'role = $1'
+    const arg = email ?? role
+    // Prefer a LINE-bound user (real member) so middleware treats it as fully bound.
+    const { rows } = await pool.query(
+      `select id, name, role, line_user_id, line_linked_at
+         from users
+        where ${where}
+        order by (line_user_id is not null) desc, id asc
+        limit 1`,
+      [arg],
+    )
+    const u = rows[0]
+    if (!u) {
+      throw new Error(
+        `No existing user matches ${email ? `email=${email}` : `role=${role}`}. ` +
+          'For a fresh local DB with no users, seed one with `pnpm --filter @kagetra/web dev:cookie` ' +
+          '(that INSERTS a dev user — do NOT run it against prod).',
+      )
+    }
+
+    const now = Math.floor(Date.now() / 1000)
+    const token = await encode({
+      salt: AUTHJS_SESSION_COOKIE,
+      secret: authSecret,
+      maxAge: SESSION_MAX_AGE,
+      token: {
+        sub: u.id,
+        id: u.id,
+        name: u.name,
+        role: u.role,
+        lineUserId: u.line_user_id ?? null,
+        lineLinkedAt: u.line_linked_at ? new Date(u.line_linked_at).toISOString() : null,
+        lineLinkedMethod: null,
+        iat: now,
+        exp: now + SESSION_MAX_AGE,
+        jti: crypto.randomUUID(),
+      },
+    })
+
+    process.stderr.write(`[dev-session] minted for role=${u.role} name=${u.name} id=${u.id}\n`)
+    process.stdout.write(token + '\n')
+  } finally {
+    await pool.end()
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`[dev-session] ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`)
+  process.exit(1)
+})


### PR DESCRIPTION
## 何を
- **`.claude/commands/show-app.md`** — `/show-app [local|prod] [route]`。認証済みのアプリ画面を Claude Code の in-app Browser pane にライブ表示するコマンド（手順を全部エンコード）。
- **`apps/web/scripts/dev-session-cookie.ts`** + `dev:session` npm script — 既存ユーザーの Auth.js セッション Cookie を発行。**INSERT しない**ので本番接続時も安全（`dev-issue-cookie.ts` は dev ユーザーを INSERT するため prod 不可、その prod 安全版）。
- **`.claude/memory/`** — reference 2件（in-app pane 表示レシピ / 本番DB SSHトンネル接続レシピ）+ 索引。

## なぜ
in-app Browser pane は**トップレベルの 307 リダイレクトを追従できず** `ERR_TOO_MANY_REDIRECTS` に陥る（サーバー・cookie は正常）。このアプリは `/` でリダイレクトするため、`/` を踏ませず **`/sw.js`（middleware 対象外の 200 静的ファイル）経由で Cookie 注入 → 200 ページに直接遷移**する手順を、毎回探索し直さず 1 コマンドで回せるようにする。

## テスト方法
- `pnpm --filter @kagetra/web dev:session -- --role=admin` → 有効な JWE を発行、`/api/auth/session` が当該ユーザー(admin)を返すことを確認。
- `pnpm --filter @kagetra/web check-types` green。
- `/show-app` がスラッシュコマンドとして登録されることを確認。

## 注意
- `apps/web/**`（package.json 追加）を含むため、**merge 時に本番 web が再ビルド+再起動される**（`auto-deploy.sh` の `WEB=1` 判定）。helper は **dev 専用でランタイムには含まれない**ので機能的影響は無し。都合の良いタイミングで merge してください。