### PR TITLE
Use shared Codex cloud devflow

### DIFF
--- a/.codex/cloud-maintenance.sh
+++ b/.codex/cloud-maintenance.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Codex cloud maintenance entrypoint: refresh the centrally managed devflow.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec bash "$repo_root/.codex/cloud-setup.sh"

--- a/.codex/cloud-setup.sh
+++ b/.codex/cloud-setup.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Refresh the shared devflow checkout and install its Codex adapters.
+set -euo pipefail
+
+devflow_repo="${DEVFLOW_REPO:-poponta2020/claude-devflow}"
+devflow_ref="${DEVFLOW_REF:-main}"
+codex_root="${CODEX_HOME:-${HOME}/.codex}"
+devflow_dir="${DEVFLOW_DIR:-${codex_root}/shared/claude-devflow}"
+
+if [ -n "${DEVFLOW_GITHUB_TOKEN:-}" ]; then
+  export GH_TOKEN="${DEVFLOW_GITHUB_TOKEN}"
+fi
+
+mkdir -p "$(dirname "$devflow_dir")"
+
+if [ -d "$devflow_dir/.git" ]; then
+  git -C "$devflow_dir" fetch --depth 1 origin "$devflow_ref"
+  git -C "$devflow_dir" checkout --detach FETCH_HEAD
+elif command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  gh repo clone "$devflow_repo" "$devflow_dir" -- --depth 1 --branch "$devflow_ref"
+else
+  git clone --depth 1 --branch "$devflow_ref" "https://github.com/${devflow_repo}.git" "$devflow_dir"
+fi
+
+bash "$devflow_dir/scripts/setup-codex.sh"

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,0 +1,16 @@
+name: Devflow Codex review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  review:
+    if: ${{ !github.event.pull_request.draft && vars.CODEX_REVIEW_ENABLED == 'true' }}
+    uses: poponta2020/claude-devflow/.github/workflows/codex-review.yml@main
+    secrets:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Codex repository instructions
+
+- Read `CLAUDE.md` completely before planning or editing; it is the repository's canonical engineering instruction file.
+- Read `.claude/project-profile.md` for commands, risk paths, documentation ownership, Definition of Done, and review policy.
+- The shared devflow is installed by `.codex/cloud-setup.sh`; its canonical workflows live in `poponta2020/claude-devflow`, not in this repository.
+- Use the shared devflow skills when the request maps to define-feature, implement, quickfix, review/fix, DoD, ship, or the other documented workflows.
+- Treat CI pending as mergeable under the accepted project policy. A confirmed failing check still blocks shipping.
+- Preserve unrelated user changes and untracked files. Do not introduce a second copy of shared skills into this repository.
+- After implementation, update the canonical documentation selected by `.claude/project-profile.md` and run the documented verification commands.

--- a/docs/dev/local-dev-setup.md
+++ b/docs/dev/local-dev-setup.md
@@ -13,6 +13,15 @@ PR #21 (Phase P3-A メール大会取り込み 最終 PR) のマージ後、ま�
 - Node.js 22.13+ / pnpm 9.15+
 - リポジトリ clone 済み
 
+### Codex cloud から開発する場合
+
+- Codex cloud の Environment で Setup script に `bash .codex/cloud-setup.sh`、Maintenance script に `bash .codex/cloud-maintenance.sh` を設定する。
+- Environment secret `DEVFLOW_GITHUB_TOKEN` には private リポジトリ `poponta2020/claude-devflow` を read できる fine-grained GitHub token を設定する。
+- 初期化時に共通 devflow の `main` を `$CODEX_HOME/shared/claude-devflow` へ取得し、Codex アダプタースキルをユーザースコープへリンクする。ワークフロー本体は共通リポジトリだけで更新し、このリポジトリには複製しない。
+- Codex cloud はクラウド上の checkout で動くためローカルPCは不要。DB、LINE、メール、AIなど外部サービスを必要とするタスクだけ、対応する secret とネットワーク許可を Environment に追加する。
+- PR 出荷時は既定方針どおり CI pending を PASS とする。失敗が確定した check はマージを止める。
+- GitHub Actions の自動レビューは repository secret `OPENAI_API_KEY` と variable `CODEX_REVIEW_ENABLED=true` を設定した時だけ有効になる。中央 private リポジトリの reusable workflow access も許可する。レビューが `pass` なら即マージし、`needs_changes` はCodex cloudの `auto-review-loop` が引き継ぐ。
+
 ---
 
 ## 1. 初回セットアップ


### PR DESCRIPTION
## What changed

- Added Codex cloud setup and maintenance entrypoints that fetch the centrally managed devflow.
- Added the thin caller for the shared Codex Action review workflow.
- Added `AGENTS.md` so Codex reads the canonical repository and project-profile instructions.
- Documented cloud environment secrets, review enablement, and the accepted CI-pending merge policy.

## Why

kagetra_new should be maintainable from Codex cloud and a phone without keeping a local PC online, using the same centrally managed workflow as Match Tracker.

## Dependency

- Merge poponta2020/claude-devflow#5 first so the shared skills and reusable workflow exist on `main`.

## Impact

Codex cloud installs skills from `poponta2020/claude-devflow`. Existing application behavior is unchanged. Confirmed failing checks still block shipping; pending checks remain mergeable by project policy.

## Validation

- Cloud shell scripts passed `bash -n`.
- Caller workflow YAML and `AGENTS.md` structure were inspected successfully.
- The project profile parsed successfully with the shared safe parser.
- `git diff --check` passed.
- Application tests were not run because no application code changed.
