### PR TITLE
fix: 配色をデザイントークンに一元化（素の Tailwind パレット・ベタ書き hex を撤去）

### DIFF
--- a/apps/web/src/app/(app)/admin/line-channels/page.tsx
+++ b/apps/web/src/app/(app)/admin/line-channels/page.tsx
@@ -179,7 +179,7 @@ export default async function LineChannelsAdminPage({ searchParams }: PageProps)
               href={href}
               className={
                 active
-                  ? 'px-3 py-1 rounded-full bg-brand text-white'
+                  ? 'px-3 py-1 rounded-full bg-brand text-ink-on-brand'
                   : 'px-3 py-1 rounded-full border border-border text-ink-2 hover:bg-surface-alt'
               }
             >

--- a/apps/web/src/app/(app)/admin/mail-inbox/[id]/page.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/[id]/page.tsx
@@ -499,7 +499,7 @@ export default async function MailDraftDetailPage({
               </select>
               <button
                 type="submit"
-                className="inline-flex h-10 items-center justify-center rounded-lg bg-brand px-4 text-sm font-semibold text-white hover:bg-brand-hover"
+                className="inline-flex h-10 items-center justify-center rounded-lg bg-brand px-4 text-sm font-semibold text-ink-on-brand hover:bg-brand-hover"
               >
                 紐付ける
               </button>

--- a/apps/web/src/app/(app)/admin/mail-inbox/attachments/[id]/page.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/attachments/[id]/page.tsx
@@ -141,6 +141,8 @@ export default async function AttachmentViewerPage({
     body = (
       // 認証つき動的ルートの生バイト表示。next/image の optimizer は
       // Cookie なしでサーバー側 fetch するため 401 になり使えない。
+      // 背景は意図的に純白（和紙トークンにしない）。透過 PNG や紙面より
+      // 小さい画像で、白い紙面の周囲だけ和紙色が覗くのを避けるため。
       // eslint-disable-next-line @next/next/no-img-element
       <img
         src={binaryUrl}
@@ -166,7 +168,7 @@ export default async function AttachmentViewerPage({
     body = (
       <div className="flex flex-col gap-2">
         {Array.from({ length: docMeta.pageCount }, (_, i) => (
-          // 認証つき動的ルートの生バイト表示 (上の image kind と同じ理由)。
+          // 認証つき動的ルートの生バイト表示・純白背景とも上の image kind と同じ理由。
           // eslint-disable-next-line @next/next/no-img-element
           <img
             key={i + 1}

--- a/apps/web/src/app/(app)/admin/mail-inbox/components/ApprovalForm.tsx
+++ b/apps/web/src/app/(app)/admin/mail-inbox/components/ApprovalForm.tsx
@@ -530,7 +530,7 @@ export function ApprovalForm({
         <div className="flex justify-end pt-1">
           <button
             type="submit"
-            className="inline-flex h-10 items-center justify-center rounded-lg bg-brand px-4 text-sm font-semibold text-white hover:bg-brand-hover"
+            className="inline-flex h-10 items-center justify-center rounded-lg bg-brand px-4 text-sm font-semibold text-ink-on-brand hover:bg-brand-hover"
           >
             選択したイベントを登録
           </button>

--- a/apps/web/src/app/(app)/admin/members/[id]/edit/delete-member-section.tsx
+++ b/apps/web/src/app/(app)/admin/members/[id]/edit/delete-member-section.tsx
@@ -44,10 +44,14 @@ export function DeleteMemberSection({
         className="mt-3"
       >
         <input type="hidden" name="userId" value={userId} />
+        {/* hover は opacity ではなく brightness で当てる。disabled:opacity-60 と
+            同じ property を奪い合うと、どちらが勝つかが Tailwind の出力順依存に
+            なり className の順では制御できない（globals.css の .mobile-shell-h
+            と同じ罠）。property を分けておけば衝突しようがない。 */}
         <button
           type="submit"
           disabled={pending}
-          className="rounded-md bg-accent px-4 py-2 text-sm text-ink-on-brand hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+          className="rounded-md bg-accent px-4 py-2 text-sm text-ink-on-brand hover:brightness-95 disabled:cursor-not-allowed disabled:opacity-60"
         >
           {pending ? '削除中…' : 'この会員を削除する'}
         </button>

--- a/apps/web/src/app/(app)/admin/members/[id]/edit/delete-member-section.tsx
+++ b/apps/web/src/app/(app)/admin/members/[id]/edit/delete-member-section.tsx
@@ -23,14 +23,14 @@ export function DeleteMemberSection({
   )
 
   return (
-    <section className="rounded-lg bg-white p-4 shadow-sm">
+    <section className="rounded-lg bg-surface p-4 shadow-sm">
       <h3 className="text-sm font-semibold">会員の削除</h3>
-      <p className="mt-1 text-xs text-gray-600">
+      <p className="mt-1 text-xs text-ink-2">
         誤登録の取り消し用です。LINE
         紐付け前で関連データがない場合のみ削除できます（元に戻せません）。それ以外は退会処理を使ってください。
       </p>
       {state.error && (
-        <p role="alert" className="mt-2 text-sm text-red-600">
+        <p role="alert" className="mt-2 text-sm text-danger">
           {state.error}
         </p>
       )}
@@ -47,7 +47,7 @@ export function DeleteMemberSection({
         <button
           type="submit"
           disabled={pending}
-          className="rounded-md bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-60"
+          className="rounded-md bg-accent px-4 py-2 text-sm text-ink-on-brand hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
         >
           {pending ? '削除中…' : 'この会員を削除する'}
         </button>

--- a/apps/web/src/app/(app)/admin/members/[id]/edit/edit-member-form.tsx
+++ b/apps/web/src/app/(app)/admin/members/[id]/edit/edit-member-form.tsx
@@ -142,7 +142,7 @@ export function EditMemberForm({
               type="text"
               value={name}
               readOnly
-              className="mt-1 w-full rounded-md border border-border-soft bg-surface-alt px-3 py-2 text-sm text-ink-meta"
+              className="mt-1 w-full rounded-md border border-border-soft bg-surface-alt px-3 py-2 text-sm text-neutral-fg"
             />
             <p className="mt-1 text-xs text-ink-meta">
               ユーザー名はログインに使われるため、この画面からは変更できません。

--- a/apps/web/src/app/(app)/admin/members/[id]/edit/edit-member-form.tsx
+++ b/apps/web/src/app/(app)/admin/members/[id]/edit/edit-member-form.tsx
@@ -33,13 +33,13 @@ function NameEditForm({ userId, name }: { userId: string; name: string }) {
   return (
     <form
       action={formAction}
-      className="space-y-3 rounded-lg bg-white p-4 shadow-sm"
+      className="space-y-3 rounded-lg bg-surface p-4 shadow-sm"
     >
       <input type="hidden" name="userId" value={userId} />
       <div>
         <label
           htmlFor="member-name"
-          className="block text-sm font-medium text-gray-700"
+          className="block text-sm font-medium text-ink-2"
         >
           名前
         </label>
@@ -51,20 +51,20 @@ function NameEditForm({ userId, name }: { userId: string; name: string }) {
           maxLength={50}
           value={value}
           onChange={(e) => setValue(e.target.value)}
-          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+          className="mt-1 w-full rounded-md border border-border px-3 py-2 text-sm"
         />
-        <p className="mt-1 text-xs text-gray-500">
+        <p className="mt-1 text-xs text-ink-meta">
           LINE 紐付け前のため修正できます。
         </p>
       </div>
 
       {state.error && (
-        <p role="alert" className="text-sm text-red-600">
+        <p role="alert" className="text-sm text-danger">
           {state.error}
         </p>
       )}
       {state.success && (
-        <p role="status" className="text-sm text-green-600">
+        <p role="status" className="text-sm text-success">
           名前を変更しました。
         </p>
       )}
@@ -72,7 +72,7 @@ function NameEditForm({ userId, name }: { userId: string; name: string }) {
       <button
         type="submit"
         disabled={pending}
-        className="rounded-md bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand/90 disabled:cursor-not-allowed disabled:opacity-60"
+        className="rounded-md bg-brand px-4 py-2 text-sm font-medium text-ink-on-brand hover:bg-brand-hover disabled:cursor-not-allowed disabled:opacity-60"
       >
         {pending ? '保存中…' : '名前を保存'}
       </button>
@@ -132,30 +132,30 @@ export function EditMemberForm({
   return (
     <>
       {nameEditable && <NameEditForm userId={userId} name={name} />}
-      <form action={formAction} className="space-y-4 rounded-lg bg-white p-4 shadow-sm">
+      <form action={formAction} className="space-y-4 rounded-lg bg-surface p-4 shadow-sm">
         <input type="hidden" name="userId" value={userId} />
 
         {!nameEditable && (
           <div>
-            <label className="block text-sm font-medium text-gray-700">名前</label>
+            <label className="block text-sm font-medium text-ink-2">名前</label>
             <input
               type="text"
               value={name}
               readOnly
-              className="mt-1 w-full rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-500"
+              className="mt-1 w-full rounded-md border border-border-soft bg-surface-alt px-3 py-2 text-sm text-ink-meta"
             />
-            <p className="mt-1 text-xs text-gray-500">
+            <p className="mt-1 text-xs text-ink-meta">
               ユーザー名はログインに使われるため、この画面からは変更できません。
             </p>
           </div>
         )}
 
         <fieldset className="grid grid-cols-2 gap-3">
-          <legend className="mb-1 text-sm font-medium text-gray-700">
+          <legend className="mb-1 text-sm font-medium text-ink-2">
             氏名・ふりがな（任意）
           </legend>
           <div>
-            <label htmlFor="familyName" className="block text-xs text-gray-600">
+            <label htmlFor="familyName" className="block text-xs text-ink-2">
               姓（漢字）
             </label>
             <input
@@ -164,11 +164,11 @@ export function EditMemberForm({
               type="text"
               maxLength={20}
               defaultValue={familyName}
-              className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+              className="mt-1 w-full rounded-md border border-border px-3 py-2 text-sm"
             />
           </div>
           <div>
-            <label htmlFor="givenName" className="block text-xs text-gray-600">
+            <label htmlFor="givenName" className="block text-xs text-ink-2">
               名（漢字）
             </label>
             <input
@@ -177,11 +177,11 @@ export function EditMemberForm({
               type="text"
               maxLength={20}
               defaultValue={givenName}
-              className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+              className="mt-1 w-full rounded-md border border-border px-3 py-2 text-sm"
             />
           </div>
           <div>
-            <label htmlFor="familyKana" className="block text-xs text-gray-600">
+            <label htmlFor="familyKana" className="block text-xs text-ink-2">
               せい（ふりがな）
             </label>
             <input
@@ -190,11 +190,11 @@ export function EditMemberForm({
               type="text"
               maxLength={30}
               defaultValue={familyKana}
-              className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+              className="mt-1 w-full rounded-md border border-border px-3 py-2 text-sm"
             />
           </div>
           <div>
-            <label htmlFor="givenKana" className="block text-xs text-gray-600">
+            <label htmlFor="givenKana" className="block text-xs text-ink-2">
               めい（ふりがな）
             </label>
             <input
@@ -203,10 +203,10 @@ export function EditMemberForm({
               type="text"
               maxLength={30}
               defaultValue={givenKana}
-              className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+              className="mt-1 w-full rounded-md border border-border px-3 py-2 text-sm"
             />
           </div>
-          <p className="col-span-2 text-xs text-gray-500">
+          <p className="col-span-2 text-xs text-ink-meta">
             表示名（ログイン名）は上の「名前」が正典で、ここでは変更されません。
           </p>
         </fieldset>
@@ -214,7 +214,7 @@ export function EditMemberForm({
         <div>
           <label
             htmlFor="grade"
-            className="block text-sm font-medium text-gray-700"
+            className="block text-sm font-medium text-ink-2"
           >
             級
           </label>
@@ -222,7 +222,7 @@ export function EditMemberForm({
             id="grade"
             name="grade"
             defaultValue={grade ?? ''}
-            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+            className="mt-1 w-full rounded-md border border-border px-3 py-2 text-sm"
           >
             <option value="">未設定</option>
             {grades.map((g) => (
@@ -236,7 +236,7 @@ export function EditMemberForm({
         <div>
           <label
             htmlFor="gender"
-            className="block text-sm font-medium text-gray-700"
+            className="block text-sm font-medium text-ink-2"
           >
             性別
           </label>
@@ -244,7 +244,7 @@ export function EditMemberForm({
             id="gender"
             name="gender"
             defaultValue={gender ?? ''}
-            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+            className="mt-1 w-full rounded-md border border-border px-3 py-2 text-sm"
           >
             <option value="">未設定</option>
             {genders.map((g) => (
@@ -258,7 +258,7 @@ export function EditMemberForm({
         <div>
           <label
             htmlFor="affiliation"
-            className="block text-sm font-medium text-gray-700"
+            className="block text-sm font-medium text-ink-2"
           >
             所属（学校名 / 社会人 など）
           </label>
@@ -267,14 +267,14 @@ export function EditMemberForm({
             name="affiliation"
             type="text"
             defaultValue={affiliation}
-            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+            className="mt-1 w-full rounded-md border border-border px-3 py-2 text-sm"
           />
         </div>
 
         <div>
           <label
             htmlFor="dan"
-            className="block text-sm font-medium text-gray-700"
+            className="block text-sm font-medium text-ink-2"
           >
             段位（0〜9）
           </label>
@@ -285,7 +285,7 @@ export function EditMemberForm({
             min={0}
             max={9}
             defaultValue={dan ?? ''}
-            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+            className="mt-1 w-full rounded-md border border-border px-3 py-2 text-sm"
           />
         </div>
 
@@ -297,17 +297,17 @@ export function EditMemberForm({
             defaultChecked={zenNichikyo}
             className="h-4 w-4"
           />
-          <label htmlFor="zenNichikyo" className="text-sm font-medium text-gray-700">
+          <label htmlFor="zenNichikyo" className="text-sm font-medium text-ink-2">
             全日協会員
           </label>
         </div>
 
-        <fieldset className="space-y-3 border-t border-gray-200 pt-4">
-          <legend className="text-sm font-medium text-gray-700">
+        <fieldset className="space-y-3 border-t border-border-soft pt-4">
+          <legend className="text-sm font-medium text-ink-2">
             全日協登録情報（任意・管理者のみ閲覧）
           </legend>
           <div>
-            <label htmlFor="birthDate" className="block text-xs text-gray-600">
+            <label htmlFor="birthDate" className="block text-xs text-ink-2">
               生年月日
             </label>
             <input
@@ -315,11 +315,11 @@ export function EditMemberForm({
               name="birthDate"
               type="date"
               defaultValue={birthDate}
-              className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+              className="mt-1 w-full rounded-md border border-border px-3 py-2 text-sm"
             />
           </div>
           <div>
-            <label htmlFor="phone" className="block text-xs text-gray-600">
+            <label htmlFor="phone" className="block text-xs text-ink-2">
               電話番号
             </label>
             <input
@@ -328,11 +328,11 @@ export function EditMemberForm({
               type="tel"
               inputMode="tel"
               defaultValue={phone}
-              className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+              className="mt-1 w-full rounded-md border border-border px-3 py-2 text-sm"
             />
           </div>
           <div>
-            <label htmlFor="postalCode" className="block text-xs text-gray-600">
+            <label htmlFor="postalCode" className="block text-xs text-ink-2">
               郵便番号
             </label>
             <input
@@ -340,11 +340,11 @@ export function EditMemberForm({
               name="postalCode"
               inputMode="numeric"
               defaultValue={postalCode}
-              className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+              className="mt-1 w-full rounded-md border border-border px-3 py-2 text-sm"
             />
           </div>
           <div>
-            <label htmlFor="address1" className="block text-xs text-gray-600">
+            <label htmlFor="address1" className="block text-xs text-ink-2">
               住所1（丁目・番地まで）
             </label>
             <input
@@ -353,11 +353,11 @@ export function EditMemberForm({
               type="text"
               maxLength={100}
               defaultValue={address1}
-              className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+              className="mt-1 w-full rounded-md border border-border px-3 py-2 text-sm"
             />
           </div>
           <div>
-            <label htmlFor="address2" className="block text-xs text-gray-600">
+            <label htmlFor="address2" className="block text-xs text-ink-2">
               住所2（建物名・部屋番号）
             </label>
             <input
@@ -366,18 +366,18 @@ export function EditMemberForm({
               type="text"
               maxLength={100}
               defaultValue={address2}
-              className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+              className="mt-1 w-full rounded-md border border-border px-3 py-2 text-sm"
             />
           </div>
         </fieldset>
 
         {state.error && (
-          <p role="alert" className="text-sm text-red-600">
+          <p role="alert" className="text-sm text-danger">
             {state.error}
           </p>
         )}
         {state.success && (
-          <p role="status" className="text-sm text-green-600">
+          <p role="status" className="text-sm text-success">
             更新しました。
           </p>
         )}
@@ -385,7 +385,7 @@ export function EditMemberForm({
         <button
           type="submit"
           disabled={pending}
-          className="rounded-md bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand/90 disabled:cursor-not-allowed disabled:opacity-60"
+          className="rounded-md bg-brand px-4 py-2 text-sm font-medium text-ink-on-brand hover:bg-brand-hover disabled:cursor-not-allowed disabled:opacity-60"
         >
           {pending ? '更新中…' : '保存'}
         </button>

--- a/apps/web/src/app/(app)/admin/members/[id]/edit/page.tsx
+++ b/apps/web/src/app/(app)/admin/members/[id]/edit/page.tsx
@@ -61,7 +61,7 @@ export default async function EditMemberPage({
       <div>
         <Link
           href="/admin/members"
-          className="text-sm text-gray-500 hover:text-gray-700"
+          className="text-sm text-ink-meta hover:text-ink-2"
         >
           ← 会員一覧へ戻る
         </Link>
@@ -69,7 +69,7 @@ export default async function EditMemberPage({
           会員編集: {member.name ?? '未設定'}
         </h2>
         {member.deactivatedAt && (
-          <p className="mt-1 inline-block rounded bg-gray-200 px-2 py-0.5 text-xs font-medium text-gray-700">
+          <p className="mt-1 inline-block rounded bg-neutral-bg px-2 py-0.5 text-xs font-medium text-neutral-fg">
             退会済み（{member.deactivatedAt.toLocaleDateString('ja-JP')}）
           </p>
         )}
@@ -98,9 +98,9 @@ export default async function EditMemberPage({
       />
 
       {member.lineUserId && (
-        <section className="rounded-lg bg-white p-4 shadow-sm">
+        <section className="rounded-lg bg-surface p-4 shadow-sm">
           <h3 className="text-sm font-semibold">LINE 紐付け</h3>
-          <dl className="mt-2 space-y-1 text-sm text-gray-600">
+          <dl className="mt-2 space-y-1 text-sm text-ink-2">
             <div>
               <dt className="inline font-medium">紐付け日時: </dt>
               <dd className="inline">
@@ -117,21 +117,21 @@ export default async function EditMemberPage({
               <input type="hidden" name="userId" value={member.id} />
               <button
                 type="submit"
-                className="rounded-md bg-red-50 px-3 py-1.5 text-sm text-red-700 hover:bg-red-100"
+                className="rounded-md bg-danger-bg px-3 py-1.5 text-sm text-danger-fg hover:opacity-90"
               >
                 LINE 紐付けを解除
               </button>
             </form>
           )}
-          <p className="mt-2 text-xs text-gray-500">
+          <p className="mt-2 text-xs text-ink-meta">
             解除すると本人の次回 LINE ログインで /self-identify から再選択できます。
           </p>
         </section>
       )}
 
-      <section className="rounded-lg bg-white p-4 shadow-sm">
+      <section className="rounded-lg bg-surface p-4 shadow-sm">
         <h3 className="text-sm font-semibold">退会処理</h3>
-        <p className="mt-1 text-xs text-gray-600">
+        <p className="mt-1 text-xs text-ink-2">
           退会処理するとログインできなくなります。取り消しで復帰できます。
         </p>
         <form action={toggleMemberDeactivation} className="mt-3">
@@ -140,8 +140,8 @@ export default async function EditMemberPage({
             type="submit"
             className={
               member.deactivatedAt
-                ? 'rounded-md bg-green-600 px-4 py-2 text-sm text-white hover:bg-green-700'
-                : 'rounded-md bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700'
+                ? 'rounded-md bg-brand px-4 py-2 text-sm text-ink-on-brand hover:bg-brand-hover'
+                : 'rounded-md bg-accent px-4 py-2 text-sm text-ink-on-brand hover:opacity-90'
             }
           >
             {member.deactivatedAt ? '退会を取り消す' : '退会処理する'}

--- a/apps/web/src/app/(app)/admin/members/new-member-form.tsx
+++ b/apps/web/src/app/(app)/admin/members/new-member-form.tsx
@@ -36,7 +36,7 @@ export function NewMemberForm() {
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="rounded-md bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand/90"
+        className="rounded-md bg-brand px-4 py-2 text-sm font-medium text-ink-on-brand hover:bg-brand-hover"
       >
         新規会員追加
       </button>
@@ -46,14 +46,14 @@ export function NewMemberForm() {
   return (
     <form
       action={formAction}
-      className="space-y-3 rounded-lg bg-white p-4 shadow-sm"
+      className="space-y-3 rounded-lg bg-surface p-4 shadow-sm"
     >
-      <h3 className="text-sm font-semibold text-gray-900">新規会員追加</h3>
+      <h3 className="text-sm font-semibold text-ink">新規会員追加</h3>
 
       <div>
         <label
           htmlFor="new-member-name"
-          className="block text-sm font-medium text-gray-700"
+          className="block text-sm font-medium text-ink-2"
         >
           名前（必須）
         </label>
@@ -65,14 +65,14 @@ export function NewMemberForm() {
           maxLength={50}
           value={name}
           onChange={(e) => setName(e.target.value)}
-          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+          className="mt-1 w-full rounded-md border border-border px-3 py-2 text-sm"
         />
       </div>
 
       <div>
         <label
           htmlFor="new-member-grade"
-          className="block text-sm font-medium text-gray-700"
+          className="block text-sm font-medium text-ink-2"
         >
           級
         </label>
@@ -81,7 +81,7 @@ export function NewMemberForm() {
           name="grade"
           value={grade}
           onChange={(e) => setGrade(e.target.value)}
-          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+          className="mt-1 w-full rounded-md border border-border px-3 py-2 text-sm"
         >
           <option value="">未設定</option>
           {GRADES.map((g) => (
@@ -92,18 +92,18 @@ export function NewMemberForm() {
         </select>
       </div>
 
-      <p className="text-xs text-gray-500">
+      <p className="text-xs text-ink-meta">
         登録した会員は LINE
         ログイン後の「自分の名前を選択」候補にすぐ表示されます。性別・所属などは登録後に編集画面で入力できます。
       </p>
 
       {state.error && (
-        <p role="alert" className="text-sm text-red-600">
+        <p role="alert" className="text-sm text-danger">
           {state.error}
         </p>
       )}
       {state.success && (
-        <p role="status" className="text-sm text-green-600">
+        <p role="status" className="text-sm text-success">
           登録しました。
         </p>
       )}
@@ -112,14 +112,14 @@ export function NewMemberForm() {
         <button
           type="submit"
           disabled={pending}
-          className="rounded-md bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand/90 disabled:cursor-not-allowed disabled:opacity-60"
+          className="rounded-md bg-brand px-4 py-2 text-sm font-medium text-ink-on-brand hover:bg-brand-hover disabled:cursor-not-allowed disabled:opacity-60"
         >
           {pending ? '登録中…' : '登録'}
         </button>
         <button
           type="button"
           onClick={() => setOpen(false)}
-          className="rounded-md bg-gray-100 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200"
+          className="rounded-md bg-surface-alt px-4 py-2 text-sm font-medium text-ink-2 hover:bg-border-soft"
         >
           閉じる
         </button>

--- a/apps/web/src/app/(app)/admin/members/page.tsx
+++ b/apps/web/src/app/(app)/admin/members/page.tsx
@@ -74,32 +74,32 @@ export default async function MembersPage() {
       <h2 className="text-xl font-bold">会員管理</h2>
       <NewMemberForm />
       <RegistrationInviteSection activeInvites={activeInvites} />
-      <div className="overflow-x-auto rounded-lg bg-white shadow-sm">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
+      <div className="overflow-x-auto rounded-lg bg-surface shadow-sm">
+        <table className="min-w-full divide-y divide-border-soft">
+          <thead className="bg-surface-alt">
             <tr>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500">名前</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500">ロール</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500">級</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500">招待状態</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500">登録日</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500">LINE 紐付け日時</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500">方法</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500">操作</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-ink-meta">名前</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-ink-meta">ロール</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-ink-meta">級</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-ink-meta">招待状態</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-ink-meta">登録日</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-ink-meta">LINE 紐付け日時</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-ink-meta">方法</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-ink-meta">操作</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-200">
+          <tbody className="divide-y divide-border-soft">
             {memberList.map((member) => {
               const deactivated = member.deactivatedAt != null
               const rowClass = deactivated
-                ? 'text-gray-400'
-                : 'text-gray-900'
+                ? 'text-ink-muted'
+                : 'text-ink'
               return (
                 <tr key={member.id} className={rowClass}>
                   <td className="whitespace-nowrap px-4 py-3 text-sm">
                     {member.name ?? '未設定'}
                     {deactivated && (
-                      <span className="ml-2 inline-block rounded bg-gray-200 px-1.5 py-0.5 text-[10px] font-medium text-gray-700">
+                      <span className="ml-2 inline-block rounded bg-neutral-bg px-1.5 py-0.5 text-[10px] font-medium text-neutral-fg">
                         退会
                       </span>
                     )}
@@ -111,7 +111,7 @@ export default async function MembersPage() {
                       <select
                         name="grade"
                         defaultValue={member.grade ?? ''}
-                        className="rounded-md border border-gray-300 px-2 py-1 text-sm"
+                        className="rounded-md border border-border px-2 py-1 text-sm"
                         aria-label={`${member.name ?? member.id} の級`}
                       >
                         <option value="">未設定</option>
@@ -121,7 +121,7 @@ export default async function MembersPage() {
                       </select>
                       <button
                         type="submit"
-                        className="rounded-md bg-gray-100 px-3 py-1 text-xs hover:bg-gray-200"
+                        className="rounded-md bg-surface-alt px-3 py-1 text-xs hover:bg-border-soft"
                       >
                         保存
                       </button>

--- a/apps/web/src/app/(app)/admin/members/page.tsx
+++ b/apps/web/src/app/(app)/admin/members/page.tsx
@@ -78,14 +78,14 @@ export default async function MembersPage() {
         <table className="min-w-full divide-y divide-border-soft">
           <thead className="bg-surface-alt">
             <tr>
-              <th className="px-4 py-3 text-left text-xs font-medium text-ink-meta">名前</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-ink-meta">ロール</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-ink-meta">級</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-ink-meta">招待状態</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-ink-meta">登録日</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-ink-meta">LINE 紐付け日時</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-ink-meta">方法</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-ink-meta">操作</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-neutral-fg">名前</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-neutral-fg">ロール</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-neutral-fg">級</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-neutral-fg">招待状態</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-neutral-fg">登録日</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-neutral-fg">LINE 紐付け日時</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-neutral-fg">方法</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-neutral-fg">操作</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-border-soft">

--- a/apps/web/src/app/(app)/admin/members/registration-invite-section.tsx
+++ b/apps/web/src/app/(app)/admin/members/registration-invite-section.tsx
@@ -70,21 +70,21 @@ export function RegistrationInviteSection({
   }
 
   return (
-    <section className="space-y-3 rounded-lg bg-white p-4 shadow-sm">
+    <section className="space-y-3 rounded-lg bg-surface p-4 shadow-sm">
       <div>
-        <h3 className="text-sm font-semibold text-gray-900">招待リンク</h3>
-        <p className="mt-1 text-xs text-gray-500">
+        <h3 className="text-sm font-semibold text-ink">招待リンク</h3>
+        <p className="mt-1 text-xs text-ink-meta">
           URLを渡すだけで本人が会員登録できます。期限内なら複数の人が利用できます。
         </p>
       </div>
 
       <div className="flex flex-wrap items-end gap-2">
-        <label className="text-sm text-gray-700">
+        <label className="text-sm text-ink-2">
           有効期限
           <select
             value={preset}
             onChange={(e) => setPreset(e.target.value as RegistrationInviteExpiryPreset)}
-            className="ml-2 rounded-md border border-gray-300 px-2 py-1 text-sm"
+            className="ml-2 rounded-md border border-border px-2 py-1 text-sm"
             aria-label="招待リンクの有効期限"
           >
             {EXPIRY_PRESET_OPTIONS.map((p) => (
@@ -98,35 +98,35 @@ export function RegistrationInviteSection({
           type="button"
           onClick={handleIssue}
           disabled={issuing}
-          className="rounded-md bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand/90 disabled:cursor-not-allowed disabled:opacity-60"
+          className="rounded-md bg-brand px-4 py-2 text-sm font-medium text-ink-on-brand hover:bg-brand-hover disabled:cursor-not-allowed disabled:opacity-60"
         >
           {issuing ? '発行中…' : '招待リンクを発行'}
         </button>
       </div>
 
       {error && (
-        <p role="alert" className="text-sm text-red-600">
+        <p role="alert" className="text-sm text-danger">
           {error}
         </p>
       )}
 
       {activeInvites.length > 0 && (
         <div className="space-y-2">
-          <h4 className="text-xs font-semibold text-gray-700">現在有効な招待リンク</h4>
-          <ul className="divide-y divide-gray-200 rounded-md border border-gray-200">
+          <h4 className="text-xs font-semibold text-ink-2">現在有効な招待リンク</h4>
+          <ul className="divide-y divide-border-soft rounded-md border border-border-soft">
             {activeInvites.map((inv) => (
               <li
                 key={inv.id}
                 className="flex flex-wrap items-center justify-between gap-2 px-3 py-2 text-xs"
               >
-                <span className="text-gray-600">
+                <span className="text-ink-2">
                   発行 {formatDateTime(inv.createdAt)} ／ 失効 {formatDateTime(inv.expiresAt)}
                 </span>
                 <button
                   type="button"
                   onClick={() => handleRevoke(inv.id)}
                   disabled={revokingId === inv.id}
-                  className="rounded-md bg-gray-100 px-3 py-1 text-xs text-gray-700 hover:bg-gray-200 disabled:opacity-60"
+                  className="rounded-md bg-surface-alt px-3 py-1 text-xs text-ink-2 hover:bg-border-soft disabled:opacity-60"
                 >
                   {revokingId === inv.id ? '無効化中…' : '無効化'}
                 </button>

--- a/apps/web/src/app/(app)/events/EventListClient.tsx
+++ b/apps/web/src/app/(app)/events/EventListClient.tsx
@@ -78,6 +78,9 @@ export function EventListClient({
               applicableOnly ? 'bg-brand' : 'bg-neutral-bg',
             )}
           >
+            {/* つまみは意図的に純白のまま。OFF 時のトラックが bg-neutral-bg
+                (#ebe3ce) なので、bg-surface (#fbf7ed) だとコントラストが
+                足りずつまみの位置が読み取れない。 */}
             <span
               className={cn(
                 'inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform',
@@ -124,7 +127,7 @@ function SortTab({
       onClick={onClick}
       className={cn(
         'flex-1 rounded-full px-3 py-1.5 font-medium whitespace-nowrap transition-colors',
-        active ? 'bg-brand text-white' : 'text-ink-meta hover:bg-surface-alt',
+        active ? 'bg-brand text-ink-on-brand' : 'text-ink-meta hover:bg-surface-alt',
       )}
     >
       {label}

--- a/apps/web/src/app/(app)/events/page.tsx
+++ b/apps/web/src/app/(app)/events/page.tsx
@@ -15,7 +15,7 @@ import {
 // Btn primary mirrored as a Link className since wrapping <Link> in <Btn>
 // would nest it inside a <button>.
 const NEW_LINK_CLASS =
-  'inline-flex items-center justify-center gap-1.5 rounded-lg font-semibold transition-colors h-8 px-3 text-xs bg-brand text-white hover:bg-brand-hover'
+  'inline-flex items-center justify-center gap-1.5 rounded-lg font-semibold transition-colors h-8 px-3 text-xs bg-brand text-ink-on-brand hover:bg-brand-hover'
 
 export default async function EventsPage() {
   const session = await auth()

--- a/apps/web/src/app/(app)/players/ranking/RankingFilterBar.tsx
+++ b/apps/web/src/app/(app)/players/ranking/RankingFilterBar.tsx
@@ -209,7 +209,7 @@ export function RankingFilterBar({
                       className={cn(
                         'flex-1 rounded-lg border py-2 text-sm font-medium transition-colors',
                         on
-                          ? 'border-brand bg-brand text-white'
+                          ? 'border-brand bg-brand text-ink-on-brand'
                           : 'border-border bg-surface text-ink-meta hover:bg-surface-alt',
                       )}
                     >
@@ -255,7 +255,7 @@ export function RankingFilterBar({
                         className={cn(
                           'flex-1 rounded-lg border py-2 text-sm font-medium transition-colors',
                           on
-                            ? 'border-brand bg-brand text-white'
+                            ? 'border-brand bg-brand text-ink-on-brand'
                             : 'border-border bg-surface text-ink-meta hover:bg-surface-alt',
                         )}
                       >
@@ -278,7 +278,7 @@ export function RankingFilterBar({
               <button
                 type="button"
                 onClick={apply}
-                className="ml-auto rounded-lg bg-brand px-5 py-2 text-sm font-semibold text-white hover:bg-brand-hover"
+                className="ml-auto rounded-lg bg-brand px-5 py-2 text-sm font-semibold text-ink-on-brand hover:bg-brand-hover"
               >
                 適用
               </button>

--- a/apps/web/src/app/(app)/players/ranking/RankingMetricChips.tsx
+++ b/apps/web/src/app/(app)/players/ranking/RankingMetricChips.tsx
@@ -36,7 +36,7 @@ export function RankingMetricChips({
             className={cn(
               'shrink-0 rounded-full border px-3 py-1 text-[13px] font-medium whitespace-nowrap transition-colors',
               active
-                ? 'border-brand bg-brand text-white'
+                ? 'border-brand bg-brand text-ink-on-brand'
                 : 'border-border bg-surface text-ink-meta hover:bg-surface-alt',
             )}
           >

--- a/apps/web/src/app/(app)/tournaments/TournamentsHeader.tsx
+++ b/apps/web/src/app/(app)/tournaments/TournamentsHeader.tsx
@@ -80,7 +80,7 @@ function ToggleLink({ href, active, label }: { href: string; active: boolean; la
       aria-selected={active}
       className={cn(
         'flex flex-1 items-center justify-center rounded-full py-1.5 font-medium transition-colors',
-        active ? 'bg-brand text-white' : 'text-ink-meta hover:bg-surface-alt',
+        active ? 'bg-brand text-ink-on-brand' : 'text-ink-meta hover:bg-surface-alt',
       )}
     >
       {label}

--- a/apps/web/src/app/(app)/tournaments/[id]/TournamentDetailTabs.tsx
+++ b/apps/web/src/app/(app)/tournaments/[id]/TournamentDetailTabs.tsx
@@ -62,7 +62,7 @@ function TabPill({
       onClick={onClick}
       className={cn(
         'shrink-0 whitespace-nowrap rounded-full px-3.5 py-1.5 text-[13px] font-medium transition-colors',
-        active ? 'bg-brand text-white' : 'border border-border bg-surface text-ink-meta hover:bg-surface-alt',
+        active ? 'bg-brand text-ink-on-brand' : 'border border-border bg-surface text-ink-meta hover:bg-surface-alt',
       )}
     >
       {label}
@@ -78,7 +78,7 @@ function blockBadge(b: ClassBlock): string {
 
 /** 順位ピルの藍濃淡（design-spec §3.5：p1=藍/p2=藍薄/p3=砂寄り中立/p4=面）。朱は不使用。 */
 const PLACE_PILL: Record<1 | 2 | 3 | 4, string> = {
-  1: 'bg-brand text-white',
+  1: 'bg-brand text-ink-on-brand',
   2: 'bg-brand-bg text-brand-fg',
   3: 'bg-neutral-bg text-neutral-fg',
   4: 'border border-border bg-surface text-ink-meta',

--- a/apps/web/src/app/auth/signin/page.tsx
+++ b/apps/web/src/app/auth/signin/page.tsx
@@ -18,11 +18,11 @@ export default async function SignInPage({
     : null
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
-      <div className="w-full max-w-md space-y-6 rounded-lg bg-white p-8 shadow-lg">
+    <div className="flex min-h-screen items-center justify-center bg-canvas px-4">
+      <div className="w-full max-w-md space-y-6 rounded-lg bg-surface p-8 shadow-lg">
         <div>
           <h1 className="text-xl font-bold">かげとら ログイン</h1>
-          <p className="mt-2 text-sm text-gray-600">
+          <p className="mt-2 text-sm text-ink-2">
             LINE アカウントでログインします。
           </p>
         </div>
@@ -30,7 +30,7 @@ export default async function SignInPage({
         {errorMessage && (
           <p
             role="alert"
-            className="rounded-md bg-red-50 p-3 text-sm text-red-700"
+            className="rounded-md bg-danger-bg p-3 text-sm text-danger-fg"
           >
             {errorMessage}
           </p>
@@ -44,7 +44,7 @@ export default async function SignInPage({
         >
           <button
             type="submit"
-            className="w-full rounded-md bg-[#06c755] px-4 py-3 text-sm font-semibold text-white hover:bg-[#05a648]"
+            className="w-full rounded-md bg-line px-4 py-3 text-sm font-semibold text-white hover:bg-line-hover"
           >
             LINE でログイン
           </button>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -38,7 +38,13 @@
   --color-border: #d8cdb3;
   --color-border-strong: #b8aa8a;
 
-  /* Ink 墨 */
+  /* Ink 墨
+     コントラスト上の制約（本文サイズ = WCAG AA 4.5:1 基準）:
+       ink-meta on surface     4.67:1  OK
+       ink-meta on surface-alt 4.16:1  NG → surface-alt の上では neutral-fg (6.71:1) を使う
+       ink-meta on canvas      4.35:1  NG → 同上
+       ink-muted は本文には使わない（surface 上で 2.53:1）。退会行など
+       「読めなくてよい」装飾的に落とす用途に限る。 */
   --color-ink: #1e1b13;
   --color-ink-2: #3a342a;
   --color-ink-meta: #7a6e5a;

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -133,6 +133,12 @@
   --kg-neutral-bg: #ebe3ce;
   --kg-neutral-fg: #5b4f33;
 
+  /* Attendance bar — 不参加セグメント。danger 系より淡い専用の朱で、
+     細い積み上げバーの中でも 参加(藍) と潰れずに読み分けられる。
+     Tailwind ユーティリティは不要（inline style から var() で参照）。
+     消費元: components/ui/attendance-counts.tsx (variant="bar") */
+  --kg-nonattend: #f3b4b4;
+
   /* Status pill pairs */
   --kg-pill-success-bg: var(--kg-success-bg);
   --kg-pill-success-fg: var(--kg-success-fg);

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -37,7 +37,9 @@ export const metadata: Metadata = {
 }
 
 export const viewport: Viewport = {
-  themeColor: '#ffffff',
+  // globals.css の --kg-bg (canvas 和紙) と同値。<meta> に出力されるため
+  // CSS 変数は使えず、リテラルで持つしかない。canvas を変えたらここも直す。
+  themeColor: '#f4efe3',
   // Suppress pinch-to-zoom in browser tabs so the app feels native, matching
   // the sister app match-tracker (which uses maximum-scale=1.0). width and
   // initialScale are inherited from Next.js' default viewport. userScalable is

--- a/apps/web/src/app/register/[token]/register-form.tsx
+++ b/apps/web/src/app/register/[token]/register-form.tsx
@@ -235,7 +235,7 @@ export function RegisterForm({ token }: { token: string }) {
       <button
         type="submit"
         disabled={pending}
-        className="w-full rounded-[4px] bg-brand px-4 py-3 text-sm font-semibold text-white hover:bg-brand-hover disabled:cursor-not-allowed disabled:opacity-60"
+        className="w-full rounded-[4px] bg-brand px-4 py-3 text-sm font-semibold text-ink-on-brand hover:bg-brand-hover disabled:cursor-not-allowed disabled:opacity-60"
       >
         {pending ? '登録中…' : '登録する'}
       </button>

--- a/apps/web/src/app/self-identify/candidate-list.tsx
+++ b/apps/web/src/app/self-identify/candidate-list.tsx
@@ -32,19 +32,19 @@ export function CandidateList({ candidates }: { candidates: Candidate[] }) {
           onChange={(e) => setQuery(e.target.value)}
           placeholder="お名前で検索"
           autoComplete="off"
-          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand"
+          className="w-full rounded-md border border-border px-3 py-2 text-sm focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand"
         />
       </div>
 
       {filtered.length === 0 ? (
-        <p className="rounded-md bg-gray-50 p-3 text-sm text-gray-600">
+        <p className="rounded-md bg-surface-alt p-3 text-sm text-ink-2">
           一致する会員が見つかりません。
         </p>
       ) : (
-        <ul className="max-h-80 divide-y divide-gray-100 overflow-y-auto rounded-md border border-gray-200">
+        <ul className="max-h-80 divide-y divide-border-soft overflow-y-auto rounded-md border border-border-soft">
           {filtered.map((c) => (
             <li key={c.id}>
-              <label className="flex cursor-pointer items-center gap-3 px-4 py-3 hover:bg-gray-50">
+              <label className="flex cursor-pointer items-center gap-3 px-4 py-3 hover:bg-surface-alt">
                 <input
                   type="radio"
                   name="userId"
@@ -52,7 +52,7 @@ export function CandidateList({ candidates }: { candidates: Candidate[] }) {
                   required
                   className="h-4 w-4"
                 />
-                <span className="text-sm text-gray-900">
+                <span className="text-sm text-ink">
                   {c.name ?? '(名前未設定)'}
                 </span>
               </label>
@@ -63,7 +63,7 @@ export function CandidateList({ candidates }: { candidates: Candidate[] }) {
 
       <button
         type="submit"
-        className="w-full rounded-md bg-brand px-4 py-3 text-sm font-semibold text-white hover:bg-brand/90"
+        className="w-full rounded-md bg-brand px-4 py-3 text-sm font-semibold text-ink-on-brand hover:bg-brand-hover"
       >
         このメンバーとして続ける
       </button>

--- a/apps/web/src/app/self-identify/page.tsx
+++ b/apps/web/src/app/self-identify/page.tsx
@@ -44,11 +44,11 @@ export default async function SelfIdentifyPage({
     : null
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-8">
-      <div className="w-full max-w-md space-y-6 rounded-lg bg-white p-6 shadow-lg">
+    <div className="flex min-h-screen items-center justify-center bg-canvas px-4 py-8">
+      <div className="w-full max-w-md space-y-6 rounded-lg bg-surface p-6 shadow-lg">
         <div>
           <h1 className="text-xl font-bold">あなたは誰ですか？</h1>
-          <p className="mt-2 text-sm text-gray-600">
+          <p className="mt-2 text-sm text-ink-2">
             会員一覧から、ご自身のお名前を選んでください。一度選ぶと、この
             LINE アカウントと紐付きます。
           </p>
@@ -57,21 +57,21 @@ export default async function SelfIdentifyPage({
         {errorMessage && (
           <p
             role="alert"
-            className="rounded-md bg-red-50 p-3 text-sm text-red-700"
+            className="rounded-md bg-danger-bg p-3 text-sm text-danger-fg"
           >
             {errorMessage}
           </p>
         )}
 
         {candidates.length === 0 ? (
-          <p className="rounded-md bg-amber-50 p-3 text-sm text-amber-800">
+          <p className="rounded-md bg-warn-bg p-3 text-sm text-warn-fg">
             選択可能な会員がいません。管理者にご連絡ください。
           </p>
         ) : (
           <CandidateList candidates={candidates} />
         )}
 
-        <p className="text-xs text-gray-500">
+        <p className="text-xs text-ink-meta">
           一覧にお名前がない場合は管理者にご連絡ください。
         </p>
       </div>

--- a/apps/web/src/app/settings/line-link/page.tsx
+++ b/apps/web/src/app/settings/line-link/page.tsx
@@ -63,7 +63,7 @@ export default async function LineLinkPage({
         )}
 
         <div className="space-y-1 rounded-md bg-surface-alt p-4 text-sm">
-          <p className="text-ink-meta">現在連携中の LINE アカウント</p>
+          <p className="text-neutral-fg">現在連携中の LINE アカウント</p>
           <p className="font-mono text-ink">{maskLineUserId(user.lineUserId)}</p>
         </div>
 

--- a/apps/web/src/app/settings/line-link/page.tsx
+++ b/apps/web/src/app/settings/line-link/page.tsx
@@ -46,38 +46,38 @@ export default async function LineLinkPage({
     : null
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
-      <div className="w-full max-w-md space-y-6 rounded-lg bg-white p-8 shadow-lg">
+    <div className="flex min-h-screen items-center justify-center bg-canvas px-4">
+      <div className="w-full max-w-md space-y-6 rounded-lg bg-surface p-8 shadow-lg">
         <div>
           <h1 className="text-xl font-bold">LINE アカウント切替</h1>
-          <p className="mt-2 text-sm text-gray-600">
+          <p className="mt-2 text-sm text-ink-2">
             通知を受け取る LINE アカウントを変更できます。機種変更などで
             LINE アカウントが変わった場合にご利用ください。
           </p>
         </div>
 
         {errorMessage && (
-          <p role="alert" className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+          <p role="alert" className="rounded-md bg-danger-bg p-3 text-sm text-danger-fg">
             {errorMessage}
           </p>
         )}
 
-        <div className="space-y-1 rounded-md bg-gray-50 p-4 text-sm">
-          <p className="text-gray-500">現在連携中の LINE アカウント</p>
-          <p className="font-mono text-gray-900">{maskLineUserId(user.lineUserId)}</p>
+        <div className="space-y-1 rounded-md bg-surface-alt p-4 text-sm">
+          <p className="text-ink-meta">現在連携中の LINE アカウント</p>
+          <p className="font-mono text-ink">{maskLineUserId(user.lineUserId)}</p>
         </div>
 
         <div className="flex gap-3">
           <Link
             href="/"
-            className="rounded-md bg-gray-100 px-4 py-2 text-sm text-gray-700 hover:bg-gray-200"
+            className="rounded-md bg-surface-alt px-4 py-2 text-sm text-ink-2 hover:bg-border-soft"
           >
             ダッシュボードへ戻る
           </Link>
           <form action={startLineLink}>
             <button
               type="submit"
-              className="rounded-md bg-[#06c755] px-4 py-2 text-sm font-semibold text-white hover:bg-[#05a648]"
+              className="rounded-md bg-line px-4 py-2 text-sm font-semibold text-white hover:bg-line-hover"
             >
               別の LINE に切り替える
             </button>

--- a/apps/web/src/components/stats/StatsPeriodFilter.tsx
+++ b/apps/web/src/components/stats/StatsPeriodFilter.tsx
@@ -160,7 +160,7 @@ export function StatsPeriodFilter({
               <button
                 type="button"
                 onClick={apply}
-                className="ml-auto rounded-lg bg-brand px-5 py-2 text-sm font-semibold text-white hover:bg-brand-hover"
+                className="ml-auto rounded-lg bg-brand px-5 py-2 text-sm font-semibold text-ink-on-brand hover:bg-brand-hover"
               >
                 適用
               </button>

--- a/apps/web/src/components/ui/attendance-counts.tsx
+++ b/apps/web/src/components/ui/attendance-counts.tsx
@@ -23,7 +23,7 @@ export interface AttendanceCountsProps {
 interface SegmentSpec {
   key: 'attend' | 'nonAttending'
   value: number
-  /** Inline `background` value — CSS variable for brand, literal hex for others. */
+  /** Inline `background` value — always a design-token CSS variable. */
   background: string
 }
 
@@ -57,7 +57,7 @@ export function AttendanceCounts({
       {
         key: 'nonAttending',
         value: ev.nonAttendingCount,
-        background: '#F3B4B4',
+        background: 'var(--kg-nonattend)',
       },
     ]
     return (

--- a/apps/web/src/components/ui/btn.tsx
+++ b/apps/web/src/components/ui/btn.tsx
@@ -12,7 +12,7 @@ export interface BtnProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const KIND_CLASS: Record<BtnKind, string> = {
-  primary: 'bg-brand text-white hover:bg-brand-hover',
+  primary: 'bg-brand text-ink-on-brand hover:bg-brand-hover',
   secondary:
     'bg-surface text-ink-2 border border-border hover:bg-surface-alt',
   ghost: 'bg-transparent text-brand hover:bg-brand-bg',


### PR DESCRIPTION
## Summary

`apps/web/src/app/globals.css` の `@theme` / `:root(--kg-*)` を配色の唯一のソースとし、画面側に残っていたハードコード配色をトークン参照へ置換した。会員向けのメイン画面群は既にトークンで統一されていたが、**管理画面と認証まわりだけデザインシステム導入前の素パレットのまま**残っており、色味が揃っていなかった。

### 何を変えたか

- **素の Tailwind パレット 106箇所 / 10ファイル**をトークンへ置換
  - `gray-*` → `ink` / `ink-2` / `ink-meta` / `ink-muted` / `border` / `border-soft` / `surface` / `surface-alt` / `canvas`
  - `red-50/700` → `danger-bg` / `danger-fg`、`amber-50/800` → `warn-bg` / `warn-fg`
  - `gray-200` の退会バッジ → `neutral-bg` / `neutral-fg`
  - リポジトリ全体で該当クラスがゼロになったことを確認
- **ベタ書きの LINE 緑** `#06c755` / `#05a648` → `bg-line` / `hover:bg-line-hover`（同一 hex のトークンが定義済みかつ未使用だった。**視覚変化なし**）
- `bg-white` → `bg-surface`、`bg-brand` 上の `text-white` → `text-ink-on-brand`（和紙白 `#fbf7ed`）
- `hover:bg-brand/90` → `hover:bg-brand-hover`（トークンあり）
- `attendance-counts` の不参加バー `#F3B4B4` → 新規トークン `--kg-nonattend`（**同一 hex**）
- PWA `themeColor` `#ffffff` → `#f4efe3`（canvas と同値）

### 意図的に残した箇所（コードにコメントで理由を明記）

| 箇所 | 理由 |
|---|---|
| LINE ログインボタンの `text-white` 3箇所 | LINE 緑の上は純白が正。和紙白は off-brand |
| イベント一覧トグルのつまみ `bg-white` | OFF 時トラック `#ebe3ce` とのコントラスト確保。`bg-surface` では位置が読めない |
| 添付プレビューの文書背景 `bg-white` | 白い紙面の周囲に和紙色が覗くのを避ける |
| モーダル背景 `bg-black/40`（12ファイル） | 既に全箇所で完全に統一済み・対応トークンなし。`bg-ink/40` 化は全オーバーレイの色味変更になるため見送り |

### 設計メモ

`--kg-nonattend` は `:root` 側のみに追加し `@theme` 側には対を作っていない。inline `style` から `var()` で参照するだけで Tailwind ユーティリティが不要なため（globals.css の `:root` ブロックは「ユーティリティを必要としないセマンティック名」用途としてコメントで定義されている）。**意図的な非対称であり漏れではない。**

### 見た目が変わる点（すべてユーザー承認済み）

- 成功メッセージ `text-green-600` → `text-success`（藍 `#2b4e8c`。「参加=藍」の設計方針に沿う）
- 退会 / 削除のベタ赤ボタン → `bg-accent`（朱 `#b33c2d`）+ `text-ink-on-brand`
- 純白 → 和紙白への移行（カード背景・primary ボタン文字。`btn.tsx` 経由でアプリ全域に及ぶ）
- PWA themeColor（iPhone のステータスバー周りの色）

### 2つめのコミットについて

`bg-accent` 化で付けた `hover:opacity-90` が、同一要素の `disabled:opacity-60` と同じ property を奪い合っていた。どちらが勝つかは Tailwind の**出力順依存**で className の順では制御できず（`.mobile-shell-h` で一度踏んでいる罠）、「pending 中の削除ボタンにホバーすると暗転が解ける」になり得た。実測では disabled 側が後に出力され意図通り勝っていたが、出力順への依存を残さないため `hover:brightness-95`（別 property）へ変更した。

## Test plan

- [x] `pnpm lint` — クリーン
- [x] `pnpm check-types` — クリーン
- [x] `pnpm --filter=@kagetra/web test` — 113ファイル / 1402件 全パス
- [x] **生成 CSS による end-to-end 検証**（下記）
- [ ] 実機での見え方確認（出荷後）

### 生成 CSS 検証について

Tailwind v4 は**未定義トークンを参照するクラスに対して CSS を一切出力せず、エラーも出さない**。つまり `text-ink-meta` を `text-ink-metal` とタイポしても、ビルドもテストも green のまま該当要素だけ無色になる。この失敗モードは lint / typecheck / vitest のいずれも検出できない。

そのため postcss + `@tailwindcss/postcss` でアプリの実スタイルシートを実際にコンパイルし、以下を機械的に確認した:

1. 導入した色ユーティリティ **27種すべて**が CSS を出力している（未出力＝ゼロ）
2. 各ユーティリティが期待どおり `var(--color-<token>)` を参照している
3. 参照先の `--color-*` **23種**が期待どおりの hex 値で出力されている
4. 撤去したパレットクラス（`bg-gray-50` / `text-red-600` / `text-green-600` 等）が生成 CSS から消えている

🤖 Generated with [Claude Code](https://claude.com/claude-code)