### PR TITLE
test: テスト DB を worktree ごとに自動分離する

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -132,7 +132,7 @@
 - [drizzle raw SQLのint[]はANY(ARRAY[...])](feedback_drizzle_sql_int_array_binding.md) — 要素展開かinArray。空配列early-return
 - [公開添付routeはblocklist+attachment固定](feedback_attachment_mime_blocklist.md)
 - [vitestは--no-file-parallelism](feedback_vitest_no_file_parallelism.md) — 時刻境界テストのflaky回避
-- [並行worktreeの共有test DB push衝突](feedback_shared_test_db_worktree_push_race.md) — TEST_DATABASE_URLで隔離
+- [並行worktreeのtest DB衝突は自動隔離で解決済み](feedback_shared_test_db_worktree_push_race.md) — worktreeごとにDB自動導出・手動createdb不要
 - [module-level stateはglobalThis pin必須](feedback_nextjs_module_state_globalthis_pin.md) — chunk splittingで別instance化
 - [git textconvが.doc入りdiffを非UTF-8化](feedback_git_textconv_doc_no_utf8_diff.md) — --no-textconvで生成
 - [iOS PWAはattachment dispositionで白画面死](feedback_ios_pwa_attachment_disposition.md) — inline fail-closed allowlist

--- a/.claude/memory/feedback_shared_test_db_worktree_push_race.md
+++ b/.claude/memory/feedback_shared_test_db_worktree_push_race.md
@@ -1,11 +1,13 @@
 ---
 name: feedback_shared_test_db_worktree_push_race
-description: 並行 worktree が共有 test DB(5434) に push し合うとスキーマが衝突しテストが 42P01 で落ちる。隔離 DB を使う
+description: 並行 worktree の test DB 衝突は自動隔離で解決済み（vitest が worktree ごとに DB を導出・自動作成）。手動 createdb は不要
 metadata: 
   node_type: memory
   type: feedback
   originSessionId: c9cb1b98-a35e-454a-97c5-8ccec1f015d5
 ---
+
+**【解決済み 2026-07-26】** vitest は `@kagetra/shared/test-db`（`packages/shared/src/test-db.ts`）で **worktree パスから DB 名を自動導出し、postgres-test(5434) 上に自動作成**するようになった。`TEST_DATABASE_URL` 未設定なら worktree ごとに別 DB になるため、以下の衝突は通常発生しない。手動の `createdb`・`TEST_DATABASE_URL` 設定は不要（明示すれば上書き可能。CI は明示している）。同一 worktree 内での vitest 並行起動だけは今も競合する（`## parallel` の worker_verify: none を維持）。以下は経緯の記録:
 
 vitest の global-setup は `drizzle-kit push --force` で **共有 test DB（`localhost:5434/kagetra_test`）** にスキーマを焼く。**2 つの worktree が同時にテストを走らせると、互いの push がスキーマを上書きし合う**（片方が新表を足し、もう片方が旧 schema を push して消す）→ truncateAll や query が存在しない表を引いて `42P01 (relation does not exist)` で大量 fail。
 

--- a/.claude/project-profile.md
+++ b/.claude/project-profile.md
@@ -22,7 +22,7 @@ DEVFLOW_CI_COVERS=("test" "lint" "typecheck")
 ## run
 
 - Web 起動: `pnpm dev:web`（Next.js。ローカル DB は `docker/docker-compose.yml` の postgres）
-- テスト DB: `pnpm test:db:up`（127.0.0.1:5434）→ `pnpm test:db:push`
+- テスト DB: `pnpm test:db:up`（127.0.0.1:5434）。DB の作成と schema push は vitest の global-setup が **worktree ごとに自動実行**する（`@kagetra/shared/test-db`。`pnpm test:db:push` の手動実行は E2E 用の固定 DB `kagetra_test` にのみ必要）
 - 詳細な /verify 用起動レシピは未整備 — 初回の /verify 時に `/run-skill-generator` で整備すること
 
 ## worktree
@@ -36,11 +36,9 @@ max_workers: 3
 worker_verify: none
 ```
 
-**`worker_verify: none` の理由（テストは並行実行できない）**: `apps/web/vitest.global-setup.ts` は vitest 起動のたびに `drizzle-kit push --force` を共有テスト DB（`127.0.0.1:5434` / `kagetra_test`）へ**無条件に**実行する。DB を使わない純関数・jsdom テストでも走る。`vitest.config.mts` の `fileParallelism: false` はプロセス内の直列化しかしないため、複数ワーカーが同時に vitest を起動すると push 同士・push と `truncateAll` が競合する（entry-management 実装中に実際に `deadlock detected` (40P01) を踏んだ）。
+**`worker_verify: none` の理由（テストは並行実行できない）**: `apps/web/vitest.global-setup.ts` は vitest 起動のたびに `drizzle-kit push --force` をテスト DB へ**無条件に**実行する。DB を使わない純関数・jsdom テストでも走る。テスト DB は worktree ごとに自動導出されるため（`@kagetra/shared/test-db`）**別 worktree・別セッションとは隔離済み**だが、Wave のワーカーは**同一 worktree を共有する**ため DB も1つで、複数ワーカーが同時に vitest を起動すると push 同士・push と `truncateAll` が競合する（`vitest.config.mts` の `fileParallelism: false` はプロセス内の直列化しかしない。entry-management 実装中に実際に `deadlock detected` (40P01) を踏んだ）。
 
 したがって Wave 中のワーカーには**検証コマンドを渡さない**。ワーカーは実装とテストを**書くだけ**で、テスト実行はバリア後に main が直列で行う。ワーカー自身の判断でテストコマンドを実行することも禁止する。
-
-なお `## database` の `TEST_DATABASE_URL` による隔離はここでは効かない — Wave のワーカーは**同一 worktree を共有する**ため DB URL も1つで、隔離できるのは worktree 単位（並行機能開発）だけである。
 
 **ワーカーに渡してよい唯一の検証コマンド**: ファイルスコープの eslint — `pnpm --filter=@kagetra/web exec eslint <file>`。DB に触れないためワーカー同士で競合せず、並行実行してよい。
 
@@ -53,7 +51,7 @@ worker_verify: none
 ## database
 
 - ローカル開発 DB: `docker exec kagetra-db psql`（Docker Compose）
-- テスト DB: `127.0.0.1:5434`（`localhost` は IPv6 で ECONNRESET になるため IP 直指定）。並行 worktree は `TEST_DATABASE_URL` で隔離
+- テスト DB: `127.0.0.1:5434`（`localhost` は IPv6 で ECONNRESET になるため IP 直指定）。並行 worktree は**自動隔離** — vitest が worktree パスから DB 名を導出し `postgres-test` 上に自動作成する（`packages/shared/src/test-db.ts`。`TEST_DATABASE_URL` 明示で上書き可。手動での `createdb` は不要）
 - スキーマ管理: Drizzle ORM（`pnpm db:generate` / `db:migrate`）。**本番 DB への直接操作・db:push はユーザー確認必須**
 - 実装ワーカーの DB 書き込みは**テスト DB 限定**
 

--- a/apps/mail-worker/vitest.global-setup.ts
+++ b/apps/mail-worker/vitest.global-setup.ts
@@ -1,18 +1,18 @@
 import { execSync } from 'node:child_process'
+import { ensureTestDatabase, resolveTestDatabaseUrl } from '@kagetra/shared/test-db'
 
 /**
- * Vitest global setup. Pushes the current Drizzle schema to the test DB once
- * before any test file. Mirrors apps/web/vitest.global-setup.ts so we can
- * rely on `mail_messages` existing without needing an explicit migration step
- * in CI.
+ * Vitest global setup. Pushes the current Drizzle schema to the (per-worktree)
+ * test DB once before any test file. Mirrors apps/web/vitest.global-setup.ts so
+ * we can rely on `mail_messages` existing without needing an explicit migration
+ * step in CI.
  */
 export default async function setup() {
-  const dbUrl =
-    process.env.TEST_DATABASE_URL ??
-    'postgresql://kagetra:kagetra_dev@localhost:5434/kagetra_test'
+  const dbUrl = resolveTestDatabaseUrl()
 
-  // eslint-disable-next-line no-console
   console.log('[mail-worker test-setup] Applying schema to', dbUrl)
+
+  await ensureTestDatabase(dbUrl)
 
   execSync(
     'pnpm --filter @kagetra/shared exec drizzle-kit push --force --config=drizzle.config.ts',

--- a/apps/mail-worker/vitest.setup.ts
+++ b/apps/mail-worker/vitest.setup.ts
@@ -1,9 +1,12 @@
+import { resolveTestDatabaseUrl } from '@kagetra/shared/test-db'
+
 /**
- * Vitest per-file setup. Force DATABASE_URL to the test DB so that any
- * pipeline import (which reaches for `loadConfig()` / `getDb()`) connects to
- * `postgres-test` rather than the developer's dev DB. Tests can still
- * override via vi.stubEnv.
+ * Vitest per-file setup. Force DATABASE_URL to the (per-worktree) test DB so
+ * that any pipeline import (which reaches for `loadConfig()` / `getDb()`)
+ * connects to `postgres-test` rather than the developer's dev DB. Tests can
+ * still override via vi.stubEnv. TEST_DATABASE_URL is pinned too so nested
+ * resolvers land on the same database.
  */
-process.env.DATABASE_URL =
-  process.env.TEST_DATABASE_URL ??
-  'postgresql://kagetra:kagetra_dev@localhost:5434/kagetra_test'
+const testDbUrl = resolveTestDatabaseUrl()
+process.env.TEST_DATABASE_URL = testDbUrl
+process.env.DATABASE_URL = testDbUrl

--- a/apps/web/src/test-utils/db.ts
+++ b/apps/web/src/test-utils/db.ts
@@ -2,12 +2,11 @@ import { drizzle } from 'drizzle-orm/node-postgres'
 import { sql } from 'drizzle-orm'
 import { Pool } from 'pg'
 import * as schema from '@kagetra/shared/schema'
+import { resolveTestDatabaseUrl } from '@kagetra/shared/test-db'
 
-const TEST_DATABASE_URL =
-  process.env.TEST_DATABASE_URL ??
-  'postgresql://kagetra:kagetra_dev@localhost:5434/kagetra_test'
-
-const testPool = new Pool({ connectionString: TEST_DATABASE_URL })
+// vitest.setup.ts pins TEST_DATABASE_URL, so this resolves to the same
+// per-worktree DB the global setup pushed schema to.
+const testPool = new Pool({ connectionString: resolveTestDatabaseUrl() })
 export const testDb = drizzle(testPool, { schema })
 
 // TRUNCATE all tables (CASCADE to handle FK). Call in beforeEach.

--- a/apps/web/vitest.global-setup.ts
+++ b/apps/web/vitest.global-setup.ts
@@ -1,22 +1,24 @@
 import { execSync } from 'node:child_process'
+import { ensureTestDatabase, resolveTestDatabaseUrl } from '@kagetra/shared/test-db'
 
 /**
  * Vitest global setup. Runs once before any test file.
  *
- * Applies the current Drizzle schema to the test database via `drizzle-kit push --force`.
- * `--force` auto-approves data-loss statements so the push is non-interactive. This is safe
- * because the test DB is ephemeral (see docker-compose `postgres-test` tmpfs).
+ * Resolves the per-worktree test database (see @kagetra/shared/test-db), creates
+ * it on the postgres-test container if missing, then applies the current Drizzle
+ * schema via `drizzle-kit push --force`. `--force` auto-approves data-loss
+ * statements so the push is non-interactive. This is safe because the test DB is
+ * ephemeral (see docker-compose `postgres-test` tmpfs).
  *
- * TEST_DATABASE_URL may be set explicitly; otherwise falls back to the docker-compose
- * `postgres-test` service URL (port 5434).
+ * TEST_DATABASE_URL may be set explicitly to override the derivation (CI does
+ * this; so can a developer who wants a specific DB).
  */
 export default async function setup() {
-  const dbUrl =
-    process.env.TEST_DATABASE_URL ??
-    'postgresql://kagetra:kagetra_dev@localhost:5434/kagetra_test'
+  const dbUrl = resolveTestDatabaseUrl()
 
-  // eslint-disable-next-line no-console
   console.log('[test-setup] Applying schema to', dbUrl)
+
+  await ensureTestDatabase(dbUrl)
 
   execSync(
     'pnpm --filter @kagetra/shared exec drizzle-kit push --force --config=drizzle.config.ts',

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -1,9 +1,13 @@
-// Force DATABASE_URL to the test DB so that @/lib/db (top-level Pool) connects
-// to postgres-test container. Tests are destructive (TRUNCATE) so this must
-// never point at a dev/prod DB.
-process.env.DATABASE_URL =
-  process.env.TEST_DATABASE_URL ??
-  'postgresql://kagetra:kagetra_dev@localhost:5434/kagetra_test'
+import { resolveTestDatabaseUrl } from '@kagetra/shared/test-db'
+
+// Force DATABASE_URL to the (per-worktree) test DB so that @/lib/db (top-level
+// Pool) connects to the postgres-test container. Tests are destructive
+// (TRUNCATE) so this must never point at a dev/prod DB. TEST_DATABASE_URL is
+// pinned too so anything re-resolving inside this process (test-utils/db,
+// spawned helpers) lands on the same database.
+const testDbUrl = resolveTestDatabaseUrl()
+process.env.TEST_DATABASE_URL = testDbUrl
+process.env.DATABASE_URL = testDbUrl
 
 // LINE link state cookie signing uses AUTH_SECRET. Provide a fixture value
 // so `buildLineLinkStateCookie` / `verifyLineLinkStateCookie` work under

--- a/packages/shared/__tests__/test-db.test.ts
+++ b/packages/shared/__tests__/test-db.test.ts
@@ -8,10 +8,17 @@ describe('testDatabaseNameForRoot', () => {
     )
   })
 
-  it('normalizes Windows path separators and case to the same name', () => {
-    // path.resolve は実行 OS の区切りに正規化するため、同一パスの表記揺れは同名に落ちる
-    expect(testDatabaseNameForRoot('C:\\tmp\\impl-entry-management')).toBe(
-      testDatabaseNameForRoot('C:/tmp/IMPL-Entry-Management'),
+  it('normalizes separators and case on win32 to the same name', () => {
+    expect(testDatabaseNameForRoot('C:\\tmp\\impl-entry-management', 'win32')).toBe(
+      testDatabaseNameForRoot('C:/tmp/IMPL-Entry-Management', 'win32'),
+    )
+  })
+
+  it('keeps case-sensitive POSIX worktrees distinct', () => {
+    // Linux では /tmp/Feature と /tmp/feature は別ディレクトリ。同名に潰すと
+    // 分離したはずの worktree 同士が再衝突するため、hash は case を保持する
+    expect(testDatabaseNameForRoot('/tmp/Feature', 'linux')).not.toBe(
+      testDatabaseNameForRoot('/tmp/feature', 'linux'),
     )
   })
 

--- a/packages/shared/__tests__/test-db.test.ts
+++ b/packages/shared/__tests__/test-db.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { testDatabaseNameForRoot } from '../src/test-db'
+
+describe('testDatabaseNameForRoot', () => {
+  it('is deterministic for the same root', () => {
+    expect(testDatabaseNameForRoot('C:/tmp/impl-entry-management')).toBe(
+      testDatabaseNameForRoot('C:/tmp/impl-entry-management'),
+    )
+  })
+
+  it('normalizes Windows path separators and case to the same name', () => {
+    // path.resolve は実行 OS の区切りに正規化するため、同一パスの表記揺れは同名に落ちる
+    expect(testDatabaseNameForRoot('C:\\tmp\\impl-entry-management')).toBe(
+      testDatabaseNameForRoot('C:/tmp/IMPL-Entry-Management'),
+    )
+  })
+
+  it('produces distinct names for distinct worktrees', () => {
+    expect(testDatabaseNameForRoot('C:/tmp/worktree-a')).not.toBe(
+      testDatabaseNameForRoot('C:/tmp/worktree-b'),
+    )
+  })
+
+  it('produces distinct names even when basenames collide', () => {
+    expect(testDatabaseNameForRoot('C:/tmp/a/kagetra_new')).not.toBe(
+      testDatabaseNameForRoot('C:/tmp/b/kagetra_new'),
+    )
+  })
+
+  it('yields a safe Postgres identifier within the 63-char limit', () => {
+    const name = testDatabaseNameForRoot(
+      'C:/Users/popon/some very-long directory (with spaces & symbols)/日本語パス',
+    )
+    expect(name).toMatch(/^kagetra_test_[a-z0-9_]+_[0-9a-f]{6}$/)
+    expect(name.length).toBeLessThanOrEqual(63)
+  })
+})

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -6,7 +6,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./types": "./src/types/index.ts",
-    "./schema": "./src/schema/index.ts"
+    "./schema": "./src/schema/index.ts",
+    "./test-db": "./src/test-db.ts"
   },
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/shared/src/test-db.ts
+++ b/packages/shared/src/test-db.ts
@@ -47,12 +47,24 @@ export function deriveTestDatabaseName(startDir: string): string {
 /**
  * Pure derivation from a worktree root path: stable per worktree, distinct
  * across worktrees, valid as an unquoted-safe Postgres identifier, ≤63 chars.
+ *
+ * Case handling is platform-dependent: Windows paths are case-insensitive, so
+ * they are lowercased before hashing (`C:\Tmp\X` ≡ `c:/tmp/x`). POSIX paths
+ * are case-SENSITIVE — `/tmp/Feature` and `/tmp/feature` are different
+ * worktrees and must not collide, so case is preserved in the hash there.
+ * The slug is always lowercased (identifier cosmetics only; the hash carries
+ * the distinction).
  */
-export function testDatabaseNameForRoot(root: string): string {
-  const normalized = path.resolve(root).replace(/\\/g, '/').toLowerCase()
+export function testDatabaseNameForRoot(
+  root: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  let normalized = path.resolve(root).replace(/\\/g, '/')
+  if (platform === 'win32') normalized = normalized.toLowerCase()
   const hash = createHash('sha1').update(normalized).digest('hex').slice(0, 6)
   const slug = normalized
     .slice(normalized.lastIndexOf('/') + 1)
+    .toLowerCase()
     .replace(/[^a-z0-9_]/g, '_')
     .slice(0, 24)
   return `kagetra_test_${slug}_${hash}`
@@ -72,8 +84,24 @@ function findRepoRoot(startDir: string): string {
 /**
  * Creates the database if it does not exist yet (idempotent; tolerates a
  * concurrent creator). Call from vitest globalSetup before `drizzle-kit push`.
+ *
+ * Probes the target DB first: if it is reachable, no admin connection is made
+ * at all — an explicitly provided TEST_DATABASE_URL keeps working even for
+ * restricted users who may only CONNECT to that one database. Only a missing
+ * database (3D000 invalid_catalog_name) falls through to creation via the
+ * `postgres` maintenance DB.
  */
 export async function ensureTestDatabase(dbUrl: string): Promise<void> {
+  const probe = new Client({ connectionString: dbUrl })
+  try {
+    await probe.connect()
+    return
+  } catch (err) {
+    if ((err as { code?: string }).code !== '3D000') throw err
+  } finally {
+    await probe.end().catch(() => {})
+  }
+
   const url = new URL(dbUrl)
   const dbName = decodeURIComponent(url.pathname.replace(/^\//, ''))
   const adminUrl = new URL(dbUrl)
@@ -81,11 +109,8 @@ export async function ensureTestDatabase(dbUrl: string): Promise<void> {
   const client = new Client({ connectionString: adminUrl.toString() })
   await client.connect()
   try {
-    const exists = await client.query('SELECT 1 FROM pg_database WHERE datname = $1', [dbName])
-    if (exists.rowCount === 0) {
-      await client.query(`CREATE DATABASE "${dbName.replace(/"/g, '""')}"`)
-      console.log('[test-db] Created database', dbName)
-    }
+    await client.query(`CREATE DATABASE "${dbName.replace(/"/g, '""')}"`)
+    console.log('[test-db] Created database', dbName)
   } catch (err) {
     // 42P04 duplicate_database: 並行プロセスが同時に作成した場合は成功扱い
     if ((err as { code?: string }).code !== '42P04') throw err

--- a/packages/shared/src/test-db.ts
+++ b/packages/shared/src/test-db.ts
@@ -1,0 +1,95 @@
+import { createHash } from 'node:crypto'
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+import { Client } from 'pg'
+
+/**
+ * Per-worktree test database isolation.
+ *
+ * The vitest suites TRUNCATE tables and push schema (`drizzle-kit push --force`)
+ * on every run. With a single shared `kagetra_test` DB, two sessions running
+ * tests from different worktrees corrupt each other (deadlocks, FK violations,
+ * 42P01 after a cross-worktree schema push — see
+ * .claude/memory/feedback_shared_test_db_worktree_push_race.md).
+ *
+ * Unless TEST_DATABASE_URL is set explicitly (CI does this; manual isolation
+ * still works), each git worktree gets its own database on the same
+ * `postgres-test` container, derived deterministically from the worktree root
+ * path. Databases are cheap: the container is tmpfs, so they vanish on restart,
+ * and `ensureTestDatabase` recreates them on demand.
+ *
+ * Limitation: two vitest processes in the SAME worktree still share a DB.
+ * That case is covered by policy (`## parallel` in .claude/project-profile.md:
+ * Wave workers do not run tests), not by this module.
+ */
+
+// 127.0.0.1 固定: Windows では localhost が IPv6 (::1) に解決され、Docker の
+// port publish がコネクションをリセットして ECONNRESET になる
+// (.claude/memory/feedback_windows_localhost_econnreset_docker_pg.md)。
+const TEST_DB_BASE = 'postgresql://kagetra:kagetra_dev@127.0.0.1:5434'
+
+/**
+ * Explicit TEST_DATABASE_URL wins; otherwise derive a per-worktree DB URL.
+ * Safe to call from any cwd inside the repo: it walks up to the worktree root,
+ * so apps/web and apps/mail-worker in the same worktree resolve the same DB.
+ */
+export function resolveTestDatabaseUrl(): string {
+  const explicit = process.env.TEST_DATABASE_URL
+  if (explicit) return explicit
+  return `${TEST_DB_BASE}/${deriveTestDatabaseName(process.cwd())}`
+}
+
+/** Derives the DB name from the enclosing git worktree root of `startDir`. */
+export function deriveTestDatabaseName(startDir: string): string {
+  return testDatabaseNameForRoot(findRepoRoot(startDir))
+}
+
+/**
+ * Pure derivation from a worktree root path: stable per worktree, distinct
+ * across worktrees, valid as an unquoted-safe Postgres identifier, ≤63 chars.
+ */
+export function testDatabaseNameForRoot(root: string): string {
+  const normalized = path.resolve(root).replace(/\\/g, '/').toLowerCase()
+  const hash = createHash('sha1').update(normalized).digest('hex').slice(0, 6)
+  const slug = normalized
+    .slice(normalized.lastIndexOf('/') + 1)
+    .replace(/[^a-z0-9_]/g, '_')
+    .slice(0, 24)
+  return `kagetra_test_${slug}_${hash}`
+}
+
+function findRepoRoot(startDir: string): string {
+  // worktree では .git はディレクトリではなくファイルなので existsSync で見る
+  let dir = path.resolve(startDir)
+  for (;;) {
+    if (existsSync(path.join(dir, '.git'))) return dir
+    const parent = path.dirname(dir)
+    if (parent === dir) return path.resolve(startDir)
+    dir = parent
+  }
+}
+
+/**
+ * Creates the database if it does not exist yet (idempotent; tolerates a
+ * concurrent creator). Call from vitest globalSetup before `drizzle-kit push`.
+ */
+export async function ensureTestDatabase(dbUrl: string): Promise<void> {
+  const url = new URL(dbUrl)
+  const dbName = decodeURIComponent(url.pathname.replace(/^\//, ''))
+  const adminUrl = new URL(dbUrl)
+  adminUrl.pathname = '/postgres'
+  const client = new Client({ connectionString: adminUrl.toString() })
+  await client.connect()
+  try {
+    const exists = await client.query('SELECT 1 FROM pg_database WHERE datname = $1', [dbName])
+    if (exists.rowCount === 0) {
+      await client.query(`CREATE DATABASE "${dbName.replace(/"/g, '""')}"`)
+      console.log('[test-db] Created database', dbName)
+    }
+  } catch (err) {
+    // 42P04 duplicate_database: 並行プロセスが同時に作成した場合は成功扱い
+    if ((err as { code?: string }).code !== '42P04') throw err
+  } finally {
+    await client.end()
+  }
+}


### PR DESCRIPTION
## Summary
- vitest のテスト DB を worktree パスから決定論的に導出（`kagetra_test_<slug>_<hash>`）し、`postgres-test` 上に自動作成する `@kagetra/shared/test-db` を新設
- 共有 `kagetra_test` への同時アクセスによる deadlock・FK 違反・42P01 の偽陽性（PR #334 出荷時に2度発生）の恒久対応。手動 `createdb` + `TEST_DATABASE_URL` の運用を廃止
- `TEST_DATABASE_URL` 明示時は従来どおりそれを優先（**CI は明示しているため挙動不変**）
- 既定ホストを `localhost` → `127.0.0.1` に変更（Windows の IPv6 解決による ECONNRESET 回避）
- E2E（Playwright）は対象外: webServer のポート 3001 占有により元々直列化される
- project-profile / memory の手動隔離手順を「自動化済み」に更新

## 検証
- `packages/shared` 28 tests green（新規 test-db 派生ロジック 5 件含む）
- `apps/web` の DB 使用テスト1ファイルを worktree から実行し、`kagetra_test_test_db_isolation_91ba95` が自動作成 → schema push → 15 tests green を確認
- shared / web / mail-worker の `tsc --noEmit` green、変更ファイルの eslint clean
- フルスイートは CI に委譲

Docs: no-change-needed（テスト基盤のみの変更で、仕様・画面・DB スキーマに影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)