### PR TITLE
fix: 申込管理ボードの大会表示名で級が重複する（多摩AA・鳳玉CDCD）

### DIFF
--- a/apps/web/src/app/(app)/admin/entries/entry-board-utils.test.ts
+++ b/apps/web/src/app/(app)/admin/entries/entry-board-utils.test.ts
@@ -561,9 +561,16 @@ describe('displayName', () => {
     expect(displayName(item)).toBe('札幌AB')
   })
 
-  it('通称が NULL なら title にフォールバック', () => {
-    const item = makeItem({ title: '正式名称大会', shortName: null, eligibleGrades: ['A'] })
-    expect(displayName(item)).toBe('正式名称大会A')
+  // Issue #335 回帰: title は運用上すでに級込み（「多摩A」等）なので、
+  // フォールバック時に級を連結すると「多摩AA」と二重になる。title はそのまま出す。
+  it('通称が NULL なら title にフォールバックし、級を追記しない（AC-1）', () => {
+    const item = makeItem({ title: '多摩A', shortName: null, eligibleGrades: ['A'] })
+    expect(displayName(item)).toBe('多摩A')
+  })
+
+  it('通称が NULL・複数級でも title のまま（AC-1: 鳳玉CDCD にならない）', () => {
+    const item = makeItem({ title: '鳳玉CD', shortName: null, eligibleGrades: ['C', 'D'] })
+    expect(displayName(item)).toBe('鳳玉CD')
   })
 
   it('級が NULL なら級なし', () => {

--- a/apps/web/src/app/(app)/admin/entries/entry-board-utils.ts
+++ b/apps/web/src/app/(app)/admin/entries/entry-board-utils.ts
@@ -138,12 +138,14 @@ function isHiddenArea(area: AreaId): area is Exclude<AreaId, VisibleAreaId> {
 
 /**
  * 一覧に出す表示名 = 通称 + 級（例「札幌AB」）。正式名称は使わない。
- * 通称が引けない大会（edition 未紐付け）は正式名称にフォールバックする。
+ * 通称が引けない大会（edition 未紐付け）は title にフォールバックするが、
+ * title は運用上すでに級込みの命名（「多摩A」等。メール承認の unit 分割が
+ * 級込みの名前で events を作る）なので、級は連結せずそのまま出す（Issue #335）。
  */
 export function displayName(item: EntryBoardItem): string {
-  const base = item.shortName ?? item.title
+  if (item.shortName == null) return item.title
   const grades = item.eligibleGrades?.join('') ?? ''
-  return `${base}${grades}`
+  return `${item.shortName}${grades}`
 }
 
 /** 基準締切 = 会内締切、未入力なら大会申込締切で代替（要件 §3.2.2）。 */

--- a/apps/web/src/app/(app)/admin/entries/page.test.tsx
+++ b/apps/web/src/app/(app)/admin/entries/page.test.tsx
@@ -263,8 +263,8 @@ describe('/admin/entries（申込管理ボード）', () => {
 
       await renderPage()
 
-      // 表示名は「通称（なければ title）+ 対象級」なので A 級が連結される
-      const row = screen.getByText('人数集計大会A').closest('a')
+      // 通称が引けない大会は title をそのまま表示（級は連結しない。Issue #335）
+      const row = screen.getByText('人数集計大会').closest('a')
       expect(row?.textContent).toContain('（3名）')
     })
 

--- a/docs/bugs/335-entry-board-grade-duplicate/requirements.md
+++ b/docs/bugs/335-entry-board-grade-duplicate/requirements.md
@@ -1,0 +1,53 @@
+---
+status: approved
+issue: 335
+---
+# バグ改修要件: 申込管理ボードの大会表示名で級が重複する（多摩AA・鳳玉CDCD）
+
+## 再現手順
+1. 管理者で `/admin/entries`（申込管理ボード）を開く
+2. edition 未紐付け（通称が引けない）かつ title に級文字が含まれる大会（例: title「多摩A」対象級 `{A}`、title「鳳玉CD」対象級 `{C,D}`）の行を見る
+3. 「多摩AA」「鳳玉CDCD」のように級が二重表示される
+
+## 根本原因
+[apps/web/src/app/(app)/admin/entries/entry-board-utils.ts:143-147](../../../apps/web/src/app/(app)/admin/entries/entry-board-utils.ts) の `displayName`:
+
+```ts
+const base = item.shortName ?? item.title
+const grades = item.eligibleGrades?.join('') ?? ''
+return `${base}${grades}`
+```
+
+- 表示名は「通称 + 級」の想定で、通称（`tournament_series.short_name`）が引けない大会は title にフォールバックする
+- ところが大会イベントの title は運用上すでに「通称+級」形式（メール承認の unit 分割承認が級込みの名前で events を作る。本番実データ: 「多摩A」「鳳玉CD」「益田BD」等）
+- title フォールバック時にも級を連結するため二重になる
+- 本番の申込管理ボード母集団 29 件中 26 件が edition 未紐付けで、この経路に該当（edition 紐付け済みの「宇都宮」「大阪」「椿」は通称に級が含まれず正常表示）
+
+## 修正方針
+`displayName` を「級の連結は通称が引けたときだけ」に変更する:
+
+```ts
+if (item.shortName == null) return item.title  // title は運用上すでに級込み。そのまま出す
+return `${item.shortName}${item.eligibleGrades?.join('') ?? ''}`
+```
+
+- title は管理者が入力・承認した表示名そのものなので、加工せずそのまま出すのが安全（title に級が含まれない大会でも「入力どおり」に表示されるだけで実害なし）
+- title から級文字を剥がすヒューリスティックは採らない（「椿杯ABC」のような固有名との衝突リスク）
+- 既存テスト 1 件（`displayName > 通称が引けない大会は正式名称にフォールバック` — title フォールバック時にも級を連結する期待値 `'正式名称大会A'`）は今回のバグ仕様そのものなので、期待値を title そのまま（級なし）へ変更する
+
+## Acceptance Criteria
+| ID | 条件 | 検証手段 |
+|----|------|------|
+| AC-1 | 通称が引けない大会は title をそのまま表示し、級を追記しない（title「多摩A」`{A}` →「多摩A」、title「鳳玉CD」`{C,D}` →「鳳玉CD」） | auto-test（回帰テスト） |
+| AC-2 | 通称が引ける大会は従来どおり「通称+級」（例「札幌AB」）、対象級なしなら通称のみ | auto-test（既存テスト） |
+| AC-3 | 既存テスト・lint・typecheck がすべて成功する（デグレードなし） | auto-test |
+
+## Non-goals
+- 本番 events の edition 紐付けデータ整備（別課題。紐付ければ通称表示に自然に戻る）
+- title から級文字列を剥がすパース処理の導入
+- /events 一覧など他画面の表示変更（/events は title のみ表示で本バグの影響なし）
+
+## 影響範囲
+- `apps/web/src/app/(app)/admin/entries/entry-board-utils.ts` — `displayName` のみ（利用箇所は `EntryBoardClient.tsx` の 1 箇所）
+- `apps/web/src/app/(app)/admin/entries/entry-board-utils.test.ts` — 既存期待値 1 件変更 + 回帰テスト追加
+- 修正規模: **軽微**（実装 1 ファイル + テスト 1 ファイル）


### PR DESCRIPTION
## Summary
- 申込管理ボード（/admin/entries）の大会表示名で、通称が引けない大会（edition 未紐付け）が「多摩AA」「鳳玉CDCD」のように級を二重表示する問題を修正
- 原因: `displayName` が title フォールバック時にも対象級を連結していたが、title は運用上すでに級込みの命名（メール承認の unit 分割承認が級込みの名前で events を作る）
- 修正: 級の連結は通称（`tournament_series.short_name`）が引けたときだけに変更し、title フォールバックはそのまま表示する
- 回帰テスト 2 件を追加（修正前に fail し「鳳玉CDCD」を再現することを確認済み）。バグ仕様そのものだった既存期待値 2 件（entry-board-utils.test.ts / page.test.tsx）を修正

## Related Issues
Closes #335

Requirements: docs/bugs/335-entry-board-grade-duplicate/requirements.md

## Test plan
- [x] 回帰テスト: title「多摩A」`{A}` →「多摩A」／title「鳳玉CD」`{C,D}` →「鳳玉CD」（AC-1）
- [x] 既存テスト: 通称あり大会は従来どおり「通称+級」（札幌AB）（AC-2）
- [x] web 全体スイート 1508 件 green + typecheck + lint（AC-3）

🤖 Generated with [Claude Code](https://claude.com/claude-code)