### PR TITLE
feat(events): 大会申込一覧のリデザイン（締切済の非表示・参加者表示の刷新・参加可否の色帯）

### DIFF
--- a/apps/web/src/app/(app)/events/EventListClient.test.tsx
+++ b/apps/web/src/app/(app)/events/EventListClient.test.tsx
@@ -14,7 +14,8 @@ const item = (
   status: 'published',
   canApply: true,
   attendCount: 0,
-  chipSurnames: [],
+  attendeeSurnames: [],
+  viewerAttending: false,
   ...over,
 })
 
@@ -24,10 +25,27 @@ const renderedOrder = (container: HTMLElement): string[] =>
     (a) => a.getAttribute('href')?.replace('/events/', '') ?? '',
   )
 
+/** The row `<li>` whose link text contains `title` (each row is one `<li><a>...`). */
+const rowByTitle = (container: HTMLElement, title: string): HTMLElement =>
+  (screen.getByText(title).closest('li') as HTMLElement) ?? container
+
+/** The 3px color bar is the first DOM child of the row's `<a>`. */
+const barOf = (row: HTMLElement): HTMLElement =>
+  row.querySelector('a > span:first-child') as HTMLElement
+
 const BASE: EventListItem[] = [
   item({ id: 1, title: 'アルファ', eventDate: '2026-08-01', internalDeadline: '2026-07-20' }),
   item({ id: 2, title: 'ブラボー', eventDate: '2026-07-15', internalDeadline: null, canApply: false }),
-  item({ id: 3, title: 'チャーリー', eventDate: '2026-07-10', internalDeadline: '2026-07-05', status: 'cancelled' }),
+  item({
+    id: 3,
+    title: 'チャーリー',
+    eventDate: '2026-07-10',
+    internalDeadline: '2026-07-05',
+    status: 'cancelled',
+    // 締切超過（07-05 < TODAY 07-10）だが自分が attend=true なので可視のまま
+    // （AC-2）。ソート回帰テストの並び順を維持するために必要。
+    viewerAttending: true,
+  }),
   item({ id: 4, title: 'デルタ', eventDate: '2026-07-25', internalDeadline: '2026-07-11' }),
 ]
 
@@ -67,32 +85,115 @@ describe('EventListClient — 申込可能フィルタ', () => {
   })
 })
 
+describe('EventListClient — 可視フィルタ（締切超過の非表示・AC-1/AC-2/AC-13）', () => {
+  it('締切超過（viewerAttending=false）の行は表示されない', () => {
+    const rows = [
+      item({ id: 1, title: '通常', internalDeadline: '2026-07-20' }),
+      item({ id: 2, title: '超過・未回答', internalDeadline: '2026-07-05' }),
+    ]
+    const { container } = render(<EventListClient items={rows} todayStr={TODAY} />)
+    expect(renderedOrder(container)).toEqual(['1'])
+    expect(screen.queryByText('超過・未回答')).toBeNull()
+  })
+
+  it('締切超過でも viewerAttending=true の行は表示され、「締切済」・帯は砂になる', () => {
+    const rows = [
+      item({
+        id: 1,
+        title: '超過・回答済',
+        internalDeadline: '2026-07-05',
+        canApply: true,
+        viewerAttending: true,
+      }),
+    ]
+    const { container } = render(<EventListClient items={rows} todayStr={TODAY} />)
+    expect(renderedOrder(container)).toEqual(['1'])
+    const row = rowByTitle(container, '超過・回答済')
+    expect(within(row).getByText('締切済')).toBeTruthy()
+    expect(barOf(row).className).toContain('bg-border')
+    expect(barOf(row).className).not.toContain('bg-brand')
+  })
+
+  it('items は非空でも全行が締切超過なら「現在のイベントはありません」（フィルタ0件文言とは別）', () => {
+    const rows = [item({ id: 1, title: '超過のみ', internalDeadline: '2026-07-05' })]
+    render(<EventListClient items={rows} todayStr={TODAY} />)
+    expect(screen.getByText('現在のイベントはありません')).toBeTruthy()
+    expect(screen.queryByText('申込可能な大会はありません')).toBeNull()
+    expect(screen.queryByRole('tab')).toBeNull()
+    expect(screen.queryByRole('switch')).toBeNull()
+  })
+})
+
+describe('EventListClient — 色帯（AC-8/AC-9）', () => {
+  it('canApply かつ 中止でない かつ 締切超過でない行だけ藍、それ以外は砂', () => {
+    const rows = [
+      item({ id: 1, title: '開放', internalDeadline: '2026-07-20', canApply: true }),
+      item({ id: 2, title: '級対象外', internalDeadline: '2026-07-20', canApply: false }),
+      // タイトルは「中止」以外にする（中止ピルのラベルと getByText が衝突する）。
+      item({
+        id: 3,
+        title: '中止イベント',
+        internalDeadline: '2026-07-20',
+        canApply: true,
+        status: 'cancelled',
+      }),
+      item({
+        id: 4,
+        title: '締切超過(回答済)',
+        internalDeadline: '2026-07-05',
+        canApply: true,
+        viewerAttending: true,
+      }),
+    ]
+    const { container } = render(<EventListClient items={rows} todayStr={TODAY} />)
+
+    const open = barOf(rowByTitle(container, '開放'))
+    expect(open.className).toContain('bg-brand')
+    expect(open.className).not.toContain('bg-border')
+
+    for (const title of ['級対象外', '中止イベント', '締切超過(回答済)']) {
+      const bar = barOf(rowByTitle(container, title))
+      expect(bar.className).toContain('bg-border')
+      expect(bar.className).not.toContain('bg-brand')
+    }
+  })
+})
+
 describe('EventListClient — 締切 tone', () => {
   const tones: EventListItem[] = [
     item({ id: 1, title: '本日締切', internalDeadline: '2026-07-10' }), // today
     item({ id: 2, title: '間近', internalDeadline: '2026-07-11' }), // soon (1日)
     item({ id: 3, title: '通常', internalDeadline: '2026-07-20' }), // normal (10日)
-    item({ id: 4, title: '超過', internalDeadline: '2026-07-05' }), // past
+    // past（超過）は viewerAttending=true で可視のまま残す（AC-2）
+    item({ id: 4, title: '超過', internalDeadline: '2026-07-05', viewerAttending: true }),
     item({ id: 5, title: 'なし', internalDeadline: null }), // none
   ]
 
-  it('本日＝朱・太字', () => {
-    render(<EventListClient items={tones} todayStr={TODAY} />)
-    const el = screen.getByText('本日')
-    expect(el.className).toContain('text-accent-fg')
-    expect(el.className).toContain('font-bold')
+  it('本日＝朱の塗りピル・白字（数字なし）', () => {
+    const { container } = render(<EventListClient items={tones} todayStr={TODAY} />)
+    const row = rowByTitle(container, '本日締切')
+    const val = within(row).getByText('本日')
+    expect(val.className).toContain('bg-accent')
+    expect(val.className).toContain('text-ink-on-brand')
+    // 「締切」ラベルも当日だけ accent-fg になる
+    const lab = within(row).getByText('締切')
+    expect(lab.className).toContain('text-accent-fg')
   })
 
-  it('1〜3日＝あとN日・太字（soon）', () => {
-    render(<EventListClient items={tones} todayStr={TODAY} />)
-    const el = screen.getByText('あと1日')
-    expect(el.className).toContain('font-bold')
+  it('1〜3日＝数字だけ19pxに拡大・色は墨（朱にしない）', () => {
+    const { container } = render(<EventListClient items={tones} todayStr={TODAY} />)
+    const row = rowByTitle(container, '間近')
+    const digit = within(row).getByText('1')
+    expect(digit.className).toContain('text-[19px]')
+    expect(digit.className).not.toContain('accent')
   })
 
-  it('4日以上＝あとN日・通常（normal, ink-2）', () => {
-    render(<EventListClient items={tones} todayStr={TODAY} />)
-    const el = screen.getByText('あと10日')
-    expect(el.className).toContain('text-ink-2')
+  it('4日以上＝数字15px・通常色（ink-2）', () => {
+    const { container } = render(<EventListClient items={tones} todayStr={TODAY} />)
+    const row = rowByTitle(container, '通常')
+    const digit = within(row).getByText('10')
+    expect(digit.className).toContain('text-[15px]')
+    expect(digit.className).toContain('text-ink-2')
   })
 
   it('超過＝締切済、締切なし＝ダッシュ', () => {
@@ -104,33 +205,90 @@ describe('EventListClient — 締切 tone', () => {
   })
 })
 
-describe('EventListClient — 参加者チップ / 中止 / 空', () => {
-  it('参加数＋苗字チップ最大5＋他N名', () => {
-    const rich = [
-      item({
-        id: 1,
-        title: '大会',
-        internalDeadline: '2026-07-20',
-        attendCount: 7,
-        chipSurnames: ['山田', '鈴木', '佐藤', '高橋', '田中'],
-      }),
-    ]
-    const { container } = render(<EventListClient items={rich} todayStr={TODAY} />)
-    const row = container.querySelector('li') as HTMLElement
-    expect(within(row).getByText('参加 7名')).toBeTruthy()
-    expect(within(row).getByText('山田')).toBeTruthy()
-    expect(within(row).getByText('田中')).toBeTruthy()
-    // 7 - 5 = 2 名を「他2名」に畳む
-    expect(within(row).getByText('他2名')).toBeTruthy()
+describe('EventListClient — 参加者（AC-5/AC-6）', () => {
+  it('参加者0名は meta 行ごと非表示（「参加」の文字列も出ない）', () => {
+    const { container } = render(
+      <EventListClient
+        items={[item({ id: 1, title: '無人', internalDeadline: '2026-07-20', attendCount: 0, attendeeSurnames: [] })]}
+        todayStr={TODAY}
+      />,
+    )
+    const row = rowByTitle(container, '無人')
+    expect(within(row).queryByText(/^参加/)).toBeNull()
+    expect(within(row).queryByText('名')).toBeNull()
   })
 
-  it('参加0名はチップなしで「参加 0名」のみ（他N名は出さない）', () => {
-    const zero = [item({ id: 1, internalDeadline: '2026-07-20', attendCount: 0, chipSurnames: [] })]
-    render(<EventListClient items={zero} todayStr={TODAY} />)
-    expect(screen.getByText('参加 0名')).toBeTruthy()
-    expect(screen.queryByText(/^他\d+名$/)).toBeNull()
+  it('参加者8名でも全員表示され「他N名」は出ない', () => {
+    const surnames = ['中村', '小林', '加藤', '渡辺', '伊藤', '山本', '中島', '清水']
+    const { container } = render(
+      <EventListClient
+        items={[
+          item({
+            id: 1,
+            title: '大阪CD',
+            internalDeadline: '2026-07-20',
+            attendCount: 8,
+            attendeeSurnames: surnames,
+          }),
+        ]}
+        todayStr={TODAY}
+      />,
+    )
+    const row = rowByTitle(container, '大阪CD')
+    expect(within(row).getByText('8')).toBeTruthy()
+    for (const name of surnames) {
+      expect(within(row).getByText(name)).toBeTruthy()
+    }
+    expect(within(row).queryByText(/^他\d+名$/)).toBeNull()
   })
 
+  it('参加者1名: 人数と苗字が表示される', () => {
+    const { container } = render(
+      <EventListClient
+        items={[
+          item({
+            id: 1,
+            title: '東京吉野会C',
+            internalDeadline: '2026-07-20',
+            attendCount: 1,
+            attendeeSurnames: ['鈴木'],
+          }),
+        ]}
+        todayStr={TODAY}
+      />,
+    )
+    const row = rowByTitle(container, '東京吉野会C')
+    expect(within(row).getByText('1')).toBeTruthy()
+    expect(within(row).getByText('鈴木')).toBeTruthy()
+  })
+})
+
+describe('EventListClient — 上段 DOM 順（AC-10）', () => {
+  it('大会名 → 日付 → …→ 締切 の順に並ぶ', () => {
+    const { container } = render(
+      <EventListClient
+        items={[
+          item({
+            id: 1,
+            title: '広島CDE',
+            eventDate: '2026-09-06',
+            internalDeadline: '2026-07-20',
+          }),
+        ]}
+        todayStr={TODAY}
+      />,
+    )
+    const titleEl = within(container).getByText('広島CDE')
+    const top = titleEl.parentElement as HTMLElement
+    const texts = Array.from(top.children).map((c) => c.textContent ?? '')
+    expect(texts[0]).toBe('広島CDE')
+    expect(texts[1]).toBe('9/6(日)')
+    // 最後の子要素が締切（ラベル+値を含む）
+    expect(texts[texts.length - 1]).toContain('締切')
+  })
+})
+
+describe('EventListClient — 中止 / 空表示 / 遷移（回帰）', () => {
   it('中止行は 中止 ピル＋タイトル淡色', () => {
     const cancelled = [
       item({ id: 1, title: '中止大会', status: 'cancelled', internalDeadline: '2026-07-20' }),

--- a/apps/web/src/app/(app)/events/EventListClient.tsx
+++ b/apps/web/src/app/(app)/events/EventListClient.tsx
@@ -1,14 +1,15 @@
 'use client'
 
-import { useState } from 'react'
+import { Fragment, useState } from 'react'
 import Link from 'next/link'
 import { Card, StatusPill } from '@/components/ui'
 import { cn } from '@/lib/utils'
 import {
   formatDeadlineCountdown,
   formatEventDate,
+  isOpenForEntry,
+  isRowVisible,
   sortEvents,
-  type DeadlineTone,
   type EventListItem,
   type SortAxis,
 } from './event-list-utils'
@@ -31,8 +32,14 @@ export function EventListClient({
   const [sort, setSort] = useState<SortAxis>('deadline')
   const [applicableOnly, setApplicableOnly] = useState(false)
 
-  // 全体 0 件：コントロールを出さず現状文言（＝未来イベント無し）。
-  if (items.length === 0) {
+  // 可視判定（締切超過は自分が attend=true でない限り隠す）→ 申込可能フィルタ
+  // → ソート、の順で適用する（実装手順書 タスク3）。
+  const visible = items.filter((e) => isRowVisible(e, todayStr))
+
+  // 可視 0 件：コントロールを出さず現状文言。締切超過で全行隠れた場合も
+  // ここに含まれる（オフシーズンで普通に起きるため、フィルタ 0 件の文言と
+  // 混同しない）。
+  if (visible.length === 0) {
     return (
       <Card>
         <div className="text-center text-ink-meta py-6">
@@ -42,7 +49,7 @@ export function EventListClient({
     )
   }
 
-  const filtered = applicableOnly ? items.filter((e) => e.canApply) : items
+  const filtered = applicableOnly ? visible.filter((e) => e.canApply) : visible
   const rows = sortEvents(filtered, sort)
 
   return (
@@ -135,13 +142,52 @@ function SortTab({
   )
 }
 
-/** tone → 締切カウントダウンの色/太さ/サイズ（design-spec §5）。 */
-const TONE_CLASS: Record<DeadlineTone, string> = {
-  today: 'text-accent-fg font-bold text-[15px]',
-  soon: 'text-ink font-bold text-[15px]',
-  normal: 'text-ink-2 text-xs',
-  past: 'text-ink-muted text-xs',
-  none: 'text-ink-muted text-xs',
+/**
+ * 締切カウントダウンの表示（design-spec §5 / 忠実度チェックリスト）。
+ * tone ごとに構造が異なる（today=塗りピル・soon/normal=数字だけ拡大・
+ * past/none=無地）ため tone→className の単純な辞書では表現できず、
+ * tone で分岐して組み立てる。日数の数字は `<em>` 相当で分離し、周囲の
+ * 「あと」「日」より大きく描画する。
+ */
+function DeadlineValue({
+  countdown,
+}: {
+  countdown: ReturnType<typeof formatDeadlineCountdown>
+}) {
+  const { tone, daysLeft, text } = countdown
+
+  if (tone === 'today') {
+    return (
+      <span className="inline-block rounded-full bg-accent px-[9px] py-px text-[15px] font-bold text-ink-on-brand">
+        {text}
+      </span>
+    )
+  }
+  if (tone === 'soon') {
+    // 3日以内: 数字だけ 19px に拡大。色は墨のまま（朱にしない）。
+    return (
+      <span className="text-xs text-ink">
+        あと
+        <em className="mx-px font-display text-[19px] font-bold text-ink not-italic">
+          {daysLeft}
+        </em>
+        日
+      </span>
+    )
+  }
+  if (tone === 'normal') {
+    return (
+      <span className="text-xs text-ink-2">
+        あと
+        <em className="mx-px font-display text-[15px] font-bold text-ink-2 not-italic">
+          {daysLeft}
+        </em>
+        日
+      </span>
+    )
+  }
+  // past（締切済）/ none（—）は数字を持たない無地表示。
+  return <span className="text-xs text-ink-muted">{text}</span>
 }
 
 function EventRow({
@@ -153,46 +199,66 @@ function EventRow({
 }) {
   const countdown = formatDeadlineCountdown(event.internalDeadline, todayStr)
   const isCancelled = event.status === 'cancelled'
-  const remaining = event.attendCount - event.chipSurnames.length
+  const openForEntry = isOpenForEntry(event, todayStr)
 
   return (
     <Link
       href={`/events/${event.id}`}
-      className="block px-0.5 py-[13px] transition-colors hover:bg-surface-alt"
+      className="flex items-stretch py-[13px] transition-colors hover:bg-surface-alt"
     >
-      <div className="flex items-baseline gap-2">
-        <span className="shrink-0 font-display font-bold text-ink tabular-nums">
-          {formatEventDate(event.eventDate)}
-        </span>
-        <span
-          className={cn(
-            'min-w-0 flex-1 truncate font-display text-[18px] font-bold',
-            isCancelled ? 'text-ink-meta' : 'text-ink',
-          )}
-        >
-          {event.title}
-        </span>
-        <StatusPill status={event.status} size="sm" />
-        <span className="shrink-0 whitespace-nowrap">
-          <span className="mr-1 text-[10px] text-ink-muted">締切</span>
-          <span className={TONE_CLASS[countdown.tone]}>{countdown.text}</span>
-        </span>
-      </div>
-
-      <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
-        <span className="text-[11px] text-ink-meta">
-          参加 {event.attendCount}名
-        </span>
-        {event.chipSurnames.map((name, i) => (
+      {/* 色帯: 藍=今この行から申し込める / 砂=それ以外（対象外・中止・締切超過） */}
+      <span
+        className={cn(
+          'w-[3px] shrink-0 rounded-[2px]',
+          openForEntry ? 'bg-brand' : 'bg-border',
+        )}
+      />
+      <div className="min-w-0 flex-1 pl-[11px]">
+        <div className="flex items-baseline gap-2">
           <span
-            key={`${event.id}-${i}`}
-            className="inline-flex items-center rounded-full bg-neutral-bg px-2 py-0.5 text-xs text-neutral-fg"
+            className={cn(
+              'min-w-0 truncate font-display text-[18px] font-bold',
+              isCancelled ? 'text-ink-meta' : 'text-ink',
+            )}
           >
-            {name}
+            {event.title}
           </span>
-        ))}
-        {remaining > 0 && (
-          <span className="text-[11px] text-ink-meta">他{remaining}名</span>
+          <span className="shrink-0 font-display text-[13.5px] font-bold text-ink-2 tabular-nums">
+            {formatEventDate(event.eventDate)}
+          </span>
+          <StatusPill status={event.status} size="sm" />
+          <span className="ml-auto shrink-0 pl-2 whitespace-nowrap">
+            <span
+              className={cn(
+                'mr-1 text-[10px]',
+                countdown.tone === 'today' ? 'text-accent-fg' : 'text-ink-muted',
+              )}
+            >
+              締切
+            </span>
+            <DeadlineValue countdown={countdown} />
+          </span>
+        </div>
+
+        {event.attendCount > 0 && (
+          <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+            <span className="flex min-w-0 flex-1 items-baseline gap-2">
+              <span className="shrink-0 font-display text-[19px] leading-none font-bold text-brand">
+                {event.attendCount}
+                <small className="ml-px text-[11px] font-normal text-ink-meta">
+                  名
+                </small>
+              </span>
+              <span className="min-w-0 flex-1 text-xs leading-[1.65] text-neutral-fg">
+                {event.attendeeSurnames.map((name, i) => (
+                  <Fragment key={`${event.id}-${i}`}>
+                    {i > 0 && <span className="mx-1 text-ink-muted">・</span>}
+                    <span className="whitespace-nowrap">{name}</span>
+                  </Fragment>
+                ))}
+              </span>
+            </span>
+          </div>
         )}
       </div>
     </Link>

--- a/apps/web/src/app/(app)/events/event-list-utils.test.ts
+++ b/apps/web/src/app/(app)/events/event-list-utils.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import type { Grade } from '@kagetra/shared/types'
+import type { EventStatus, Grade } from '@kagetra/shared/types'
 import {
   formatEventDate,
   formatDeadlineCountdown,
   isGradeEligible,
+  isOpenForEntry,
+  isPastDeadline,
+  isRowVisible,
   sortEvents,
 } from './event-list-utils'
 
@@ -32,13 +35,18 @@ describe('formatDeadlineCountdown', () => {
   const today = '2026-07-10'
 
   it('null deadline → dash / none', () => {
-    expect(formatDeadlineCountdown(null, today)).toEqual({ text: '—', tone: 'none' })
+    expect(formatDeadlineCountdown(null, today)).toEqual({
+      text: '—',
+      tone: 'none',
+      daysLeft: null,
+    })
   })
 
   it('same day (daysLeft 0) → 本日 / today', () => {
     expect(formatDeadlineCountdown('2026-07-10', today)).toEqual({
       text: '本日',
       tone: 'today',
+      daysLeft: 0,
     })
   })
 
@@ -46,6 +54,7 @@ describe('formatDeadlineCountdown', () => {
     expect(formatDeadlineCountdown('2026-07-11', today)).toEqual({
       text: 'あと1日',
       tone: 'soon',
+      daysLeft: 1,
     })
   })
 
@@ -53,6 +62,7 @@ describe('formatDeadlineCountdown', () => {
     expect(formatDeadlineCountdown('2026-07-13', today)).toEqual({
       text: 'あと3日',
       tone: 'soon',
+      daysLeft: 3,
     })
   })
 
@@ -60,6 +70,7 @@ describe('formatDeadlineCountdown', () => {
     expect(formatDeadlineCountdown('2026-07-14', today)).toEqual({
       text: 'あと4日',
       tone: 'normal',
+      daysLeft: 4,
     })
   })
 
@@ -67,6 +78,7 @@ describe('formatDeadlineCountdown', () => {
     expect(formatDeadlineCountdown('2026-07-09', today)).toEqual({
       text: '締切済',
       tone: 'past',
+      daysLeft: -1,
     })
   })
 
@@ -75,6 +87,7 @@ describe('formatDeadlineCountdown', () => {
     expect(formatDeadlineCountdown('2026-08-02', '2026-07-31')).toEqual({
       text: 'あと2日',
       tone: 'soon',
+      daysLeft: 2,
     })
   })
 
@@ -82,7 +95,106 @@ describe('formatDeadlineCountdown', () => {
     expect(formatDeadlineCountdown('garbage', today)).toEqual({
       text: '—',
       tone: 'none',
+      daysLeft: null,
     })
+  })
+})
+
+// event-list-redesign: 締切超過の判定は formatDeadlineCountdown の past tone を
+// 単一の真実として使う（しきい値ロジックを二重化しない）。
+describe('isPastDeadline', () => {
+  const today = '2026-07-10'
+
+  it('昨日 → true', () => {
+    expect(isPastDeadline('2026-07-09', today)).toBe(true)
+  })
+
+  it('当日 → false（締切当日はまだ超過していない）', () => {
+    expect(isPastDeadline('2026-07-10', today)).toBe(false)
+  })
+
+  it('明日 → false', () => {
+    expect(isPastDeadline('2026-07-11', today)).toBe(false)
+  })
+
+  it('締切未設定（null）→ false', () => {
+    expect(isPastDeadline(null, today)).toBe(false)
+  })
+
+  it('不正な日付 → false（none tone・防御的）', () => {
+    expect(isPastDeadline('garbage', today)).toBe(false)
+  })
+})
+
+describe('isRowVisible', () => {
+  const today = '2026-07-10'
+  const row = (internalDeadline: string | null, viewerAttending = false) => ({
+    internalDeadline,
+    viewerAttending,
+  })
+
+  it('AC-1: 締切が昨日以前の行は表示しない', () => {
+    expect(isRowVisible(row('2026-07-09'), today)).toBe(false)
+  })
+
+  it('AC-2: 締切超過でも自分が attend=true なら表示する', () => {
+    expect(isRowVisible(row('2026-07-09', true), today)).toBe(true)
+  })
+
+  it('AC-3: 締切当日（daysLeft=0）は表示する', () => {
+    expect(isRowVisible(row('2026-07-10'), today)).toBe(true)
+  })
+
+  it('締切が明日以降は表示する', () => {
+    expect(isRowVisible(row('2026-07-11'), today)).toBe(true)
+  })
+
+  it('AC-4: 締切未設定（null）は表示する', () => {
+    expect(isRowVisible(row(null), today)).toBe(true)
+  })
+
+  it('viewerAttending=true は締切に関係なく表示を妨げない', () => {
+    expect(isRowVisible(row('2026-07-20', true), today)).toBe(true)
+  })
+})
+
+describe('isOpenForEntry', () => {
+  const today = '2026-07-10'
+  const row = (
+    over: Partial<{
+      internalDeadline: string | null
+      canApply: boolean
+      status: EventStatus
+    }> = {},
+  ) => ({
+    internalDeadline: '2026-07-20' as string | null,
+    canApply: true,
+    status: 'published' as EventStatus,
+    ...over,
+  })
+
+  it('AC-8: canApply・未中止・締切内をすべて満たす → true（藍帯）', () => {
+    expect(isOpenForEntry(row(), today)).toBe(true)
+  })
+
+  it('AC-8: canApply=false → false（砂帯）', () => {
+    expect(isOpenForEntry(row({ canApply: false }), today)).toBe(false)
+  })
+
+  it('AC-9: 中止イベントは canApply=true でも false（砂帯）', () => {
+    expect(isOpenForEntry(row({ status: 'cancelled' }), today)).toBe(false)
+  })
+
+  it('AC-8: 締切超過は canApply=true でも false（砂帯）', () => {
+    expect(isOpenForEntry(row({ internalDeadline: '2026-07-09' }), today)).toBe(false)
+  })
+
+  it('締切当日は申込可能（true）', () => {
+    expect(isOpenForEntry(row({ internalDeadline: '2026-07-10' }), today)).toBe(true)
+  })
+
+  it('締切未設定（null）は締切を理由に落とさない', () => {
+    expect(isOpenForEntry(row({ internalDeadline: null }), today)).toBe(true)
   })
 })
 

--- a/apps/web/src/app/(app)/events/event-list-utils.ts
+++ b/apps/web/src/app/(app)/events/event-list-utils.ts
@@ -18,9 +18,6 @@ export type DeadlineTone = 'today' | 'soon' | 'normal' | 'past' | 'none'
 /** Days-left threshold below which the countdown is emphasised (soon bucket). */
 export const SOON_THRESHOLD = 3
 
-/** Max surname chips rendered per row before collapsing into "他N名". */
-export const CHIP_LIMIT = 5
-
 /** Minimal serialisable row the client list renders (see requirements §4.3). */
 export interface EventListItem {
   id: number
@@ -32,8 +29,18 @@ export interface EventListItem {
   canApply: boolean
   /** Total `attend=true` count (unchanged "参加 N名" semantics). */
   attendCount: number
-  /** Leading surnames (up to CHIP_LIMIT), grade-ascending. */
-  chipSurnames: string[]
+  /**
+   * Surnames of every `attend=true` participant, grade-ascending (unset last).
+   * event-list-redesign: the CHIP_LIMIT slice was dropped — rows render all of
+   * them, so there is no "他N名" remainder to compute.
+   */
+  attendeeSurnames: string[]
+  /**
+   * Whether the viewing user answered `attend=true` for this event. Only used
+   * to keep past-deadline rows visible for people who already applied
+   * (requirements §2.1) — it is not rendered anywhere.
+   */
+  viewerAttending: boolean
 }
 
 const WEEKDAY_JA = ['日', '月', '火', '水', '木', '金', '土'] as const
@@ -69,21 +76,66 @@ export function formatEventDate(eventDate: string): string {
  *   - 0    → 「本日」      today (accent)
  *   - < 0  → 「締切済」    past (muted)
  *   - null → 「—」         none (row kept, dash)
+ *
+ * `daysLeft` is returned alongside `text` because the redesign renders the
+ * number at a larger size than the surrounding 「あと」「日」 (design-spec
+ * 忠実度チェックリスト). It is `null` whenever there is no countdown to show
+ * (`none`), and 0 on the 「本日」 pill which prints no digits.
  */
 export function formatDeadlineCountdown(
   internalDeadline: string | null,
   todayStr: string,
-): { text: string; tone: DeadlineTone } {
-  if (internalDeadline == null) return { text: '—', tone: 'none' }
+): { text: string; tone: DeadlineTone; daysLeft: number | null } {
+  if (internalDeadline == null) return { text: '—', tone: 'none', daysLeft: null }
   const deadline = toEpochDay(internalDeadline)
   const today = toEpochDay(todayStr)
-  if (deadline == null || today == null) return { text: '—', tone: 'none' }
+  if (deadline == null || today == null) return { text: '—', tone: 'none', daysLeft: null }
 
   const daysLeft = Math.round((deadline - today) / 86_400_000)
-  if (daysLeft < 0) return { text: '締切済', tone: 'past' }
-  if (daysLeft === 0) return { text: '本日', tone: 'today' }
-  if (daysLeft <= SOON_THRESHOLD) return { text: `あと${daysLeft}日`, tone: 'soon' }
-  return { text: `あと${daysLeft}日`, tone: 'normal' }
+  if (daysLeft < 0) return { text: '締切済', tone: 'past', daysLeft }
+  if (daysLeft === 0) return { text: '本日', tone: 'today', daysLeft }
+  if (daysLeft <= SOON_THRESHOLD) return { text: `あと${daysLeft}日`, tone: 'soon', daysLeft }
+  return { text: `あと${daysLeft}日`, tone: 'normal', daysLeft }
+}
+
+/**
+ * 会内締切が過ぎているか。`formatDeadlineCountdown` の `past` tone を**唯一の
+ * 真実**として使う（しきい値ロジックを二重化しない）。締切未設定（null）は
+ * 「超過していない」＝ false。
+ */
+export function isPastDeadline(internalDeadline: string | null, todayStr: string): boolean {
+  return formatDeadlineCountdown(internalDeadline, todayStr).tone === 'past'
+}
+
+/**
+ * 行を一覧に出すか（requirements §2.1）。締切超過の行は原則隠すが、閲覧者
+ * 自身が出欠回答済み（attend=true）の行は「申し込んだかの確認」導線として
+ * 残す。締切当日（daysLeft=0）・締切未設定（null）は past ではないので表示。
+ *
+ * 自分の attend 状態でユーザーごとに行集合が変わるため、サーバー側の母集団
+ * 条件ではなく表示フィルタとして適用する。
+ */
+export function isRowVisible(
+  item: Pick<EventListItem, 'internalDeadline' | 'viewerAttending'>,
+  todayStr: string,
+): boolean {
+  return !isPastDeadline(item.internalDeadline, todayStr) || item.viewerAttending
+}
+
+/**
+ * 行左端の色帯を藍にするか（design-spec Round 5）＝「今この行から申し込める」。
+ * `canApply`（級のみ判定）は不変のまま、中止と締切超過を重ねて判定する。
+ * false の行は砂帯。
+ */
+export function isOpenForEntry(
+  item: Pick<EventListItem, 'internalDeadline' | 'canApply' | 'status'>,
+  todayStr: string,
+): boolean {
+  return (
+    item.canApply &&
+    item.status !== 'cancelled' &&
+    !isPastDeadline(item.internalDeadline, todayStr)
+  )
 }
 
 /**

--- a/apps/web/src/app/(app)/events/page.test.tsx
+++ b/apps/web/src/app/(app)/events/page.test.tsx
@@ -1,7 +1,7 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { closeTestDb, truncateAll } from '@/test-utils/db'
-import { createEvent, createUser } from '@/test-utils/seed'
+import { createEvent, createEventAttendance, createUser } from '@/test-utils/seed'
 import { mockAuthModule, setAuthSession } from '@/test-utils/auth-mock'
 
 // entry-overdue-alert タスク4: /events 一覧は entry_status='not_applying' を
@@ -63,6 +63,69 @@ describe('/events 一覧 — entry_status=not_applying の除外 (AC-14)', () =>
     expect(screen.getByText('未申込大会')).toBeDefined()
     expect(screen.getByText('申込済大会')).toBeDefined()
     expect(screen.queryByText('見送り大会')).toBeNull()
+  })
+})
+
+describe('/events 一覧 — 締切超過行の可視性 (AC-2)', () => {
+  it('自分が attend=true の締切済大会は表示され、他人だけの締切済大会は表示されない', async () => {
+    const viewer = await createUser({ role: 'member', name: '閲覧者太郎' })
+    const other = await createUser({ role: 'member', name: '他人花子' })
+    await setAuthSession({ id: viewer.id, role: 'member' })
+
+    const future = addDays(todayJst(), 10)
+    const yesterday = addDays(todayJst(), -1)
+
+    const myEvent = await createEvent({
+      title: '自分参加済み大会',
+      eventDate: future,
+      internalDeadline: yesterday,
+    })
+    const othersEvent = await createEvent({
+      title: '他人だけ参加大会',
+      eventDate: future,
+      internalDeadline: yesterday,
+    })
+
+    await createEventAttendance({ eventId: myEvent.id, userId: viewer.id, attend: true })
+    await createEventAttendance({ eventId: othersEvent.id, userId: other.id, attend: true })
+
+    const ui = await EventsPage()
+    render(ui)
+
+    expect(screen.getByText('自分参加済み大会')).toBeDefined()
+    expect(screen.queryByText('他人だけ参加大会')).toBeNull()
+  })
+})
+
+describe('/events 一覧 — 参加者の苗字は全員分表示される (AC-6)', () => {
+  it('参加者6名以上でも「他N名」が出ず全員分の苗字が描画される', async () => {
+    const admin = await createUser({ role: 'admin' })
+    await setAuthSession({ id: admin.id, role: 'admin' })
+    const future = addDays(todayJst(), 10)
+
+    const event = await createEvent({
+      title: '大人数参加大会',
+      eventDate: future,
+    })
+
+    const surnames = ['佐藤一', '鈴木二', '高橋三', '田中四', '伊藤五', '渡辺六', '山本七']
+    for (const name of surnames) {
+      const participant = await createUser({ name })
+      await createEventAttendance({ eventId: event.id, userId: participant.id, attend: true })
+    }
+
+    const ui = await EventsPage()
+    // 苗字が個別 span で描画されるか結合文字列になるかは EventListClient
+    // （並行作業で書き換え中）の描画方式次第なので、markup 構造ではなく
+    // 描画結果に含まれるテキスト全体（container.textContent）で判定する。
+    const { container } = render(ui)
+
+    for (const name of surnames) {
+      expect(container.textContent).toContain(name)
+    }
+    // リデザインで「参加 N名」の語は廃止され、人数＋「名」だけになった（AC-5）。
+    expect(container.textContent).toContain('7名')
+    expect(container.textContent).not.toMatch(/他\d+名/)
   })
 })
 

--- a/apps/web/src/app/(app)/events/page.tsx
+++ b/apps/web/src/app/(app)/events/page.tsx
@@ -6,11 +6,7 @@ import { and, asc, eq, gte, inArray, ne } from 'drizzle-orm'
 import { auth } from '@/auth'
 import { surname } from '@/lib/surname'
 import { EventListClient } from './EventListClient'
-import {
-  CHIP_LIMIT,
-  isGradeEligible,
-  type EventListItem,
-} from './event-list-utils'
+import { isGradeEligible, type EventListItem } from './event-list-utils'
 
 // Btn primary mirrored as a Link className since wrapping <Link> in <Btn>
 // would nest it inside a <button>.
@@ -48,6 +44,7 @@ export default async function EventsPage() {
       : await db
           .select({
             eventId: eventAttendances.eventId,
+            userId: eventAttendances.userId,
             name: users.name,
             grade: users.grade,
           })
@@ -61,9 +58,10 @@ export default async function EventsPage() {
           )
 
   // イベント別にまとめ、級昇順（未設定は末尾）で並べる（詳細画面の参加者表示に合わせる）。
+  // userId も保持しておき、後段で「自分が attend=true か」を追加クエリなしで判定する。
   const participantsByEvent = new Map<
     number,
-    Array<{ name: string | null; grade: Grade | null }>
+    Array<{ userId: string; name: string | null; grade: Grade | null }>
   >()
   for (const row of participantRows) {
     const list = participantsByEvent.get(row.eventId)
@@ -85,7 +83,9 @@ export default async function EventsPage() {
   }
 
   // クライアントへ渡す最小データ。location/official/eligibleGrades/grade はカードに
-  // 渡さず、①⑤は表示から落とし、⑦は canApply に畳む。
+  // 渡さず、①⑤は表示から落とし、⑦は canApply に畳む。userId はサーバー内の
+  // viewerAttending 判定にのみ使い、items には含めない（個人情報は苗字のみ渡す）。
+  const viewerId = session?.user.id
   const items: EventListItem[] = eventList.map((e) => {
     const parts = participantsByEvent.get(e.id) ?? []
     return {
@@ -96,12 +96,13 @@ export default async function EventsPage() {
       status: e.status,
       canApply: isGradeEligible(e.eligibleGrades, myGrade),
       attendCount: parts.length,
-      chipSurnames: parts.slice(0, CHIP_LIMIT).map((p) => surname(p.name)),
+      attendeeSurnames: parts.map((p) => surname(p.name)),
+      viewerAttending: viewerId != null && parts.some((p) => p.userId === viewerId),
     }
   })
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-4 p-4">
       <div className="flex items-center justify-between">
         <h1 className="font-display text-xl font-bold text-ink">大会申込</h1>
         <div className="flex items-center gap-3">

--- a/apps/web/src/components/layout/mobile-shell.test.tsx
+++ b/apps/web/src/components/layout/mobile-shell.test.tsx
@@ -72,6 +72,21 @@ describe('MobileShell', () => {
     expect(screen.getByTestId('child').textContent).toBe('child-content')
   })
 
+  // event-list-redesign AC-14: /events はページ余白 16px を自前で持つ
+  // （`page.tsx` の `p-4`）。同じ余白を共通シェルの <main> に足すと、すでに
+  // `p-4` を自前で持つ /tournaments・/players/[id] 等が二重余白になる。
+  // 余白はページ側で完結させる、というこの境界を機械的に固定する。
+  it('<main> は padding を持たない（余白は各ページ側で完結させる）', () => {
+    render(
+      <MobileShell user="山田さん" isAdmin signOutAction={noopSignOut}>
+        <div>child</div>
+      </MobileShell>,
+    )
+    const main = screen.getByRole('main')
+    // p-4 / px-4 / py-4 / pt-4 ... いずれの padding utility も入れない。
+    expect(main.className).not.toMatch(/\bp[xytrbl]?-/)
+  })
+
   it('AppBarMain に user prop が透過される', () => {
     render(
       <MobileShell user="山田さん" isAdmin={false} signOutAction={noopSignOut}>

--- a/docs/features/event-list-redesign/implementation-plan.md
+++ b/docs/features/event-list-redesign/implementation-plan.md
@@ -21,7 +21,7 @@ status: completed
 ## 実装タスク
 
 ### タスク1: 純関数・型の拡張（event-list-utils）
-- [ ] 完了
+- [x] 完了
 - **目的:** 表示判定ロジックを純関数として確定させ、後続2タスクが同じ契約に乗れるようにする
 - **対応AC:** AC-1, AC-2, AC-3, AC-4, AC-8, AC-9
 - **主な変更領域:** `apps/web/src/app/(app)/events/event-list-utils.ts` および `event-list-utils.test.ts`

--- a/docs/features/event-list-redesign/implementation-plan.md
+++ b/docs/features/event-list-redesign/implementation-plan.md
@@ -36,7 +36,7 @@ status: completed
 - **対応Issue:** #341
 
 ### タスク2: サーバー側データ供給と余白（events/page.tsx）
-- [ ] 完了
+- [x] 完了
 - **目的:** 自分の参加有無を渡し、苗字を全員分渡し、ページ余白を入れる
 - **対応AC:** AC-2, AC-6, AC-7, AC-14
 - **主な変更領域:** `apps/web/src/app/(app)/events/page.tsx`（`participantRows` の select と items 組立、ページコンテナの className）
@@ -51,7 +51,7 @@ status: completed
 - **対応Issue:** #342
 
 ### タスク3: 一覧 UI の移植（EventListClient）
-- [ ] 完了
+- [x] 完了
 - **目的:** 確定デザインを実コンポーネントへ移植する
 - **対応AC:** AC-1, AC-5, AC-6, AC-8, AC-9, AC-10, AC-11, AC-12, AC-13
 - **主な変更領域:** `apps/web/src/app/(app)/events/EventListClient.tsx` および `EventListClient.test.tsx`
@@ -68,7 +68,7 @@ status: completed
 - **対応Issue:** #343
 
 ### タスク4: 忠実度の確認と余白の回帰ガード
-- [ ] 完了
+- [x] 完了
 - **目的:** 確定デザインが劣化していないことと、余白変更が他画面に波及していないことを機械的に固定する
 - **対応AC:** AC-14, AC-15, AC-16
 - **主な変更領域:** `apps/web/src/components/layout/mobile-shell.test.tsx`（padding 不在の assertion 追加のみ・本体は変更しない）

--- a/docs/spec/events-attendance.md
+++ b/docs/spec/events-attendance.md
@@ -36,9 +36,13 @@
 
 ### 一覧の表示・並び替え・フィルタ
 
-`/events` はサーバー（`page.tsx`）が最小データ（`EventListItem`: id / title / eventDate / internalDeadline / status / canApply / attendCount / chipSurnames）に畳んでクライアント（`EventListClient`）へ渡す。並び替え軸は「開催日順」「締切日順」の 2 種（既定は締切日順、`sortEvents`）。「申込可能のみ」トグルは `canApply`（サーバーで `isGradeEligible(eligibleGrades, myGrade)` により算出済み。管理者バイパスなし、`grade=null` は対象級ありの大会で不可）でクライアント側フィルタする。ソート/フィルタ状態は画面内のみで永続化しない。
+`/events` はサーバー（`page.tsx`）が最小データ（`EventListItem`: id / title / eventDate / internalDeadline / status / canApply / attendCount / attendeeSurnames / viewerAttending）に畳んでクライアント（`EventListClient`）へ渡す。`attendeeSurnames` は `attend=true` 参加者**全員**の姓（`surname()`）を級昇順（未設定は末尾）で並べたもの、`viewerAttending` は閲覧者自身が `attend=true` かどうか。`viewerAttending` は参加者取得の 1 クエリに `event_attendances.user_id` を足して判定し、追加クエリを発生させない（クライアントへ渡すのは苗字のみで、`user_id` は境界を越えない）。
 
-締切カウントダウン（`formatDeadlineCountdown`）は `internalDeadline − todayStr` の日数差で 5 段階に分類する: `null` → `—`（none）、負 → 「締切済」（past）、`0` → 「本日」（today、強調）、`1〜3` → 「あとN日」（soon、強調。しきい値は `SOON_THRESHOLD=3`）、それ以上 → 「あとN日」（normal）。参加者チップは `attendCount` のうち先頭 `CHIP_LIMIT=5` 名の姓（`surname()`）を級昇順で表示し、残りは「他N名」に畳む。
+クライアントは **可視判定 → 「申込可能のみ」フィルタ → ソート** の順に適用する。可視判定（`isRowVisible`）は会内締切を過ぎた行（`isPastDeadline`＝`formatDeadlineCountdown` の `past` tone を単一の真実として判定）を一覧から外すが、**閲覧者自身が `attend=true` の行だけは残す** — 締切後に「自分が申し込んだか」を確認する導線を一覧に維持するため。締切当日（`daysLeft=0`）と締切未設定（`null`）は `past` ではないので表示される。この除外をサーバーの母集団条件にしないのは、自分の出欠状態で行集合がユーザーごとに変わるため（件数・ソートの母集団は可視判定後で揃える）。空表示の母集団も可視判定後で、可視 0 件なら「現在のイベントはありません」（コントロール非表示）、「申込可能のみ」で 0 件になったときだけ「申込可能な大会はありません」を出す。並び替え軸は「開催日順」「締切日順」の 2 種（既定は締切日順、`sortEvents`）。「申込可能のみ」トグルは `canApply`（サーバーで `isGradeEligible(eligibleGrades, myGrade)` により算出済み。管理者バイパスなし、`grade=null` は対象級ありの大会で不可）でクライアント側フィルタする。ソート/フィルタ状態は画面内のみで永続化しない。
+
+締切カウントダウン（`formatDeadlineCountdown`）は `internalDeadline − todayStr` の日数差で 5 段階に分類する: `null` → `—`（none）、負 → 「締切済」（past）、`0` → 「本日」（today、強調）、`1〜3` → 「あとN日」（soon、強調。しきい値は `SOON_THRESHOLD=3`）、それ以上 → 「あとN日」（normal）。表示は日数の**数字だけ**を周囲の「あと」「日」より大きく描画し（normal 15px / soon 19px）、soon は色を落とさず墨のまま、朱（accent）の塗りピルは **today だけ**に使う（朱＝本当に急ぐ行、というシグナルを薄めないため）。
+
+各行の左端には 3px の縦帯があり、`isOpenForEntry`（`canApply && 中止でない && 締切超過でない`＝「今この行から申し込める」）が真なら藍（brand）、それ以外は砂（border）。`canApply` 自体の判定（級のみ）は変えず、中止と締切超過を帯の表示側で重ねている。参加者は `attendCount ≥ 1` の行だけ meta 行を描画し（0 名の行は行ごと出さない）、人数を藍で大きく、苗字を「・」区切りで全員表示する（上限・「他N名」の畳み込みは廃止）。ページ余白 16px は `/events` の `page.tsx` 側で持ち、共通シェル（`mobile-shell.tsx` の `<main>`）には入れない — 自前で `p-4` を持つ既存ページが二重余白になるため。
 
 過去イベント一覧（`/events-archive`）は並び替え/フィルタ UI を持たず、開催日降順の単純なカードリストで、タイトル・公認バッジ（`official`）・開催日・会場（設定時）・ステータスピル・参加人数（`attend=true` の集計）を表示する。
 


### PR DESCRIPTION
## Summary

`/events`（大会申込一覧）を「自分が出られる大会を締切順に流し見できる」画面にするリデザイン。本番実測（2026-07-26）で 15行中6行が「締切済」として先頭を占有し、全行「参加 0名」の同値ノイズが下段を埋めていた問題への対応。

**★ロジック変更**
- **締切済の大会を一覧から除外**（`internalDeadline < 今日(JST)`）。ただし**自分が出欠回答済み（attend=true）の行は表示を継続**する（「申し込んだか」の確認導線を一覧に残すため）。締切当日・締切未設定は従来どおり表示
- 除外はサーバーの母集団条件ではなく**クライアント側の表示フィルタ**（自分の attend 状態で行集合がユーザーごとに変わるため）。適用順は 可視判定 → 申込可能フィルタ → ソート
- **参加者表示の刷新**: 0名の行は meta 行ごと非表示。1名以上は人数（藍）＋苗字を「・」区切りで**全員**表示。サーバー側の `slice(0, CHIP_LIMIT)` も撤廃（`chipSurnames` → `attendeeSurnames` へリネーム）
- **参加可否の色帯（新規・表示のみ）**: 行左端に 3px の縦帯。藍＝`canApply && 中止でない && 締切超過でない`、それ以外は砂。`canApply`（級のみ判定）のロジック自体は不変

**見た目のみ**
- 上段の DOM 順を 日付→大会名 から **大会名 → 日付 → 締切** へ入替え（日付は 13.5px・`text-ink-2` に従属化）
- 締切カウントダウンは**数字だけ拡大**（通常15px／3日以内19px）。3日以内は色を落とさず墨のまま、**朱の塗りピルは当日のみ**（朱の用途を当日に限定）
- ページ余白 16px を導入。**`mobile-shell.tsx` は変更せず** `/events` の `page.tsx` 側で完結させる（自前で `p-4` を持つ既存ページの二重余白を避けるため）

**ユーザーに見える文言の変化**: 参加者行から「参加」の語がなくなり、人数＋「名」だけになります（0名の行はそもそも出ません）。

**ドキュメント**: `docs/spec/events-attendance.md` の一覧セクションを実装に合わせて同PR内で更新済み。

## Related Issues

Closes #340
Closes #341
Closes #342
Closes #343
Closes #344

Requirements: docs/features/event-list-redesign/requirements.md
Design spec（視覚の正・locked）: docs/features/event-list-redesign/design-spec.md ＋ design-mock/redesign.html

## Test plan

- [x] `pnpm --filter=@kagetra/web test --no-file-parallelism` — 119 files / 1616 passed / 1 skipped
- [x] `pnpm check-types` — 全4パッケージ green
- [x] `pnpm lint` — green
- [x] 忠実度チェックリスト 10項目中 9項目をコードと1項目ずつ照合してクリア
- [ ] **AC-15 の残り1項目**: 「375px で横スクロールが発生しない・長い大会名が省略記号で切れる」は確定モックに長いタイトルを注入して実測（`.main`/`.row` とも `scrollWidth === clientWidth`、タイトルは省略済み）。**React ツリーでの実測は未実施** — worktree から dev サーバーを起動すると worktree 削除が Device busy になるため、出荷後に本番で確認する
- [ ] 本番での実機確認（出荷後）

### レビュー時の申し送り

- 締切ラベル「締切」は当日のみ `text-accent-fg` になる。design-spec の散文「朱は当日の塗りピルのみ」より1箇所多いが、モックの `.ddl.today .lab` に準拠した意図的なもの
- 色帯の角丸は `rounded-[2px]`（生値）。本プロジェクトの `rounded-sm` は 5px でモックの 2px と一致しないため
- `page.test.tsx` の締切系テストは `todayJst()` をテスト側と `EventsPage()` 側で二重に算出する。JST 日付境界をまたぐと理論上ずれうるが、既存の `not_applying` テストと同じ形で安定している既知パターン

🤖 Generated with [Claude Code](https://claude.com/claude-code)